### PR TITLE
Update state.date when props.selected changes

### DIFF
--- a/react-datepicker.js
+++ b/react-datepicker.js
@@ -10,6 +10,12 @@ var Calendar = React.createClass({displayName: 'Calendar',
     };
   },
 
+  componentWillReceiveProps: function(nextProps) {
+    this.setState({
+      date: nextProps.selected.clone()
+    });
+  },
+
   increaseMonth: function() {
     this.setState({
       date: this.state.date.addMonth()

--- a/src/calendar.js
+++ b/src/calendar.js
@@ -9,6 +9,12 @@ var Calendar = React.createClass({
     };
   },
 
+  componentWillReceiveProps: function(nextProps) {
+    this.setState({
+      date: nextProps.selected.clone()
+    });
+  },
+
   increaseMonth: function() {
     this.setState({
       date: this.state.date.addMonth()


### PR DESCRIPTION
This solves an issue where the calendar wouldn't immediately switch to the correct view when a user types in another date in the input.
