### PR TITLE
Added option to give a start_date as props

### DIFF
--- a/react-datepicker.js
+++ b/react-datepicker.js
@@ -102,7 +102,8 @@ var Calendar = _dereq_('./calendar');
 
 var DatePicker = React.createClass({displayName: 'DatePicker',
   getInitialState: function() {
-    var selected = new DateUtil(moment());
+    var date_start = this.props.date_start;
+    var selected = new DateUtil(moment(date_start)); // If date_start is undefined moment defaults to today
 
     return {
       focus: false,

--- a/src/datepicker.js
+++ b/src/datepicker.js
@@ -6,7 +6,8 @@ var Calendar = require('./calendar');
 
 var DatePicker = React.createClass({
   getInitialState: function() {
-    var selected = new DateUtil(moment());
+    var date_start = this.props.date_start;
+    var selected = new DateUtil(moment(date_start)); // If date_start is undefined moment defaults to today
 
     return {
       focus: false,


### PR DESCRIPTION
Passing props through the initialState is an anti patern (http://facebook.github.io/react/tips/props-in-getInitialState-as-anti-pattern.html), but I would suggest to fix this later because we're already doing this.
