### PR TITLE
Use strict date parsing when the input changes value

### DIFF
--- a/react-datepicker.js
+++ b/react-datepicker.js
@@ -179,7 +179,7 @@ var DatePicker = React.createClass({displayName: 'DatePicker',
   },
 
   handleInputChange: function(event) {
-    var date = moment(event.target.value, "YYYY-MM-DD");
+    var date = moment(event.target.value, "YYYY-MM-DD", true);
 
     this.setState({
       value: event.target.value

--- a/src/datepicker.js
+++ b/src/datepicker.js
@@ -79,7 +79,7 @@ var DatePicker = React.createClass({
   },
 
   handleInputChange: function(event) {
-    var date = moment(event.target.value, "YYYY-MM-DD");
+    var date = moment(event.target.value, "YYYY-MM-DD", true);
 
     this.setState({
       value: event.target.value


### PR DESCRIPTION
Found a bug where `2014--01` would convert to `2014-01-01` which made the input pretty much unusable, so I decided to turn on strict parsing. The date is now only selected if the date strictly matches `YYYY-MM-DD`
