### PR TITLE
Adds ability to use a custom date format

### DIFF
--- a/example.html
+++ b/example.html
@@ -40,11 +40,13 @@
             DatePicker({
               key: 'example1',
               selected: this.state.start_date,
+              dateFormat: 'MM-DD-YYYY',
               onChange: this.handleStartDateChange
             }),
             DatePicker({
               key: 'example2',
               selected: this.state.end_date,
+              dateFormat: 'MM-DD-YYYY',
               onChange: this.handleEndDateChange
             })
           ]);

--- a/react-datepicker.js
+++ b/react-datepicker.js
@@ -109,7 +109,8 @@ var DateUtil = require('./util/date');
 var DateInput = React.createClass({displayName: 'DateInput',
   getInitialState: function() {
     return {
-      value: this.props.date.format("YYYY-MM-DD")
+      dateFormat: this.props.dateFormat,
+      value: this.props.date.format(this.props.dateFormat)
     };
   },
 
@@ -121,7 +122,7 @@ var DateInput = React.createClass({displayName: 'DateInput',
     this.toggleFocus(newProps.focus);
 
     this.setState({
-      value: newProps.date.format("YYYY-MM-DD")
+      value: newProps.date.format(this.state.dateFormat)
     });
   },
 
@@ -146,7 +147,7 @@ var DateInput = React.createClass({displayName: 'DateInput',
   },
 
   handleChange: function(event) {
-    var date = moment(event.target.value, "YYYY-MM-DD", true);
+    var date = moment(event.target.value, this.state.dateFormat, true);
 
     this.setState({
       value: event.target.value
@@ -158,7 +159,7 @@ var DateInput = React.createClass({displayName: 'DateInput',
   },
 
   isValueAValidDate: function() {
-    var date = moment(event.target.value, "YYYY-MM-DD", true);
+    var date = moment(event.target.value, this.state.dateFormat, true);
 
     return date.isValid();
   },
@@ -324,6 +325,7 @@ var DatePicker = React.createClass({displayName: 'DatePicker',
       React.DOM.div(null, 
         DateInput({
           date: this.props.selected, 
+          dateFormat: this.props.dateFormat || 'YYYY-MM-DD', 
           focus: this.state.focus, 
           onBlur: this.handleBlur, 
           onFocus: this.handleFocus, 

--- a/react-datepicker.js
+++ b/react-datepicker.js
@@ -109,7 +109,6 @@ var DateUtil = require('./util/date');
 var DateInput = React.createClass({displayName: 'DateInput',
   getInitialState: function() {
     return {
-      dateFormat: this.props.dateFormat,
       value: this.props.date.format(this.props.dateFormat)
     };
   },
@@ -122,7 +121,7 @@ var DateInput = React.createClass({displayName: 'DateInput',
     this.toggleFocus(newProps.focus);
 
     this.setState({
-      value: newProps.date.format(this.state.dateFormat)
+      value: newProps.date.format(this.props.dateFormat)
     });
   },
 
@@ -147,7 +146,7 @@ var DateInput = React.createClass({displayName: 'DateInput',
   },
 
   handleChange: function(event) {
-    var date = moment(event.target.value, this.state.dateFormat, true);
+    var date = moment(event.target.value, this.props.dateFormat, true);
 
     this.setState({
       value: event.target.value
@@ -159,7 +158,7 @@ var DateInput = React.createClass({displayName: 'DateInput',
   },
 
   isValueAValidDate: function() {
-    var date = moment(event.target.value, this.state.dateFormat, true);
+    var date = moment(event.target.value, this.props.dateFormat, true);
 
     return date.isValid();
   },
@@ -255,6 +254,12 @@ var DatePicker = React.createClass({displayName: 'DatePicker',
     };
   },
 
+  getDefaultProps: function() {
+      return {
+        dateFormat: 'YYYY-MM-DD'
+      };
+  },
+
   handleFocus: function() {
     this.setState({
       focus: true
@@ -325,7 +330,7 @@ var DatePicker = React.createClass({displayName: 'DatePicker',
       React.DOM.div(null, 
         DateInput({
           date: this.props.selected, 
-          dateFormat: this.props.dateFormat || 'YYYY-MM-DD', 
+          dateFormat: this.props.dateFormat,
           focus: this.state.focus, 
           onBlur: this.handleBlur, 
           onFocus: this.handleFocus, 

--- a/src/date_input.js
+++ b/src/date_input.js
@@ -5,7 +5,6 @@ var DateUtil = require('./util/date');
 var DateInput = React.createClass({
   getInitialState: function() {
     return {
-      dateFormat: this.props.dateFormat,
       value: this.props.date.format(this.props.dateFormat)
     };
   },
@@ -18,7 +17,7 @@ var DateInput = React.createClass({
     this.toggleFocus(newProps.focus);
 
     this.setState({
-      value: newProps.date.format(this.state.dateFormat)
+      value: newProps.date.format(this.props.dateFormat)
     });
   },
 
@@ -43,7 +42,7 @@ var DateInput = React.createClass({
   },
 
   handleChange: function(event) {
-    var date = moment(event.target.value, this.state.dateFormat, true);
+    var date = moment(event.target.value, this.props.dateFormat, true);
 
     this.setState({
       value: event.target.value
@@ -55,7 +54,7 @@ var DateInput = React.createClass({
   },
 
   isValueAValidDate: function() {
-    var date = moment(event.target.value, this.state.dateFormat, true);
+    var date = moment(event.target.value, this.props.dateFormat, true);
 
     return date.isValid();
   },

--- a/src/date_input.js
+++ b/src/date_input.js
@@ -5,7 +5,8 @@ var DateUtil = require('./util/date');
 var DateInput = React.createClass({
   getInitialState: function() {
     return {
-      value: this.props.date.format("YYYY-MM-DD")
+      dateFormat: this.props.dateFormat,
+      value: this.props.date.format(this.props.dateFormat)
     };
   },
 
@@ -17,7 +18,7 @@ var DateInput = React.createClass({
     this.toggleFocus(newProps.focus);
 
     this.setState({
-      value: newProps.date.format("YYYY-MM-DD")
+      value: newProps.date.format(this.state.dateFormat)
     });
   },
 
@@ -42,7 +43,7 @@ var DateInput = React.createClass({
   },
 
   handleChange: function(event) {
-    var date = moment(event.target.value, "YYYY-MM-DD", true);
+    var date = moment(event.target.value, this.state.dateFormat, true);
 
     this.setState({
       value: event.target.value
@@ -54,7 +55,7 @@ var DateInput = React.createClass({
   },
 
   isValueAValidDate: function() {
-    var date = moment(event.target.value, "YYYY-MM-DD", true);
+    var date = moment(event.target.value, this.state.dateFormat, true);
 
     return date.isValid();
   },

--- a/src/datepicker.js
+++ b/src/datepicker.js
@@ -82,6 +82,7 @@ var DatePicker = React.createClass({
       <div>
         <DateInput
           date={this.props.selected}
+          dateFormat={this.props.dateFormat || 'YYYY-MM-DD'}
           focus={this.state.focus}
           onBlur={this.handleBlur}
           onFocus={this.handleFocus}

--- a/src/datepicker.js
+++ b/src/datepicker.js
@@ -12,6 +12,12 @@ var DatePicker = React.createClass({
     };
   },
 
+  getDefaultProps: function() {
+      return {
+        dateFormat: 'YYYY-MM-DD'
+      };
+  },
+
   handleFocus: function() {
     this.setState({
       focus: true
@@ -82,7 +88,7 @@ var DatePicker = React.createClass({
       <div>
         <DateInput
           date={this.props.selected}
-          dateFormat={this.props.dateFormat || 'YYYY-MM-DD'}
+          dateFormat={this.props.dateFormat}
           focus={this.state.focus}
           onBlur={this.handleBlur}
           onFocus={this.handleFocus}


### PR DESCRIPTION
A date format string can be entered as the prop `dateFormat` to the `DatePicker` element. If you do not enter this prop, it will default to `YYYY-MM-DD`, which was previously the only valid format allowed. The requirements of one of my current projects was that I needed a different format, so I put in the issue https://github.com/Hacker0x01/react-datepicker/issues/45. Please let me know if you have any questions. Thanks!