### PR TITLE
Fix issues with clicking on the calendar, primarily for IE11

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,8 @@
   "dependencies": {
     "react": "0.11.1",
     "moment": "2.8.2",
-    "tether": "0.6.5"
+    "tether": "0.6.5",
+    "react-onclickoutside": "0.2.1"
   },
   "ignore": [
     "**/.*",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "react": "^0.11",
     "moment": "^2.8",
     "tether": "^0.6",
-    "reactify": "^0.14"
+    "reactify": "^0.14",
+    "react-onclickoutside": "0.2.1"
   },
   "scripts": {
     "test": "grunt travis --verbose"

--- a/src/calendar.js
+++ b/src/calendar.js
@@ -4,6 +4,12 @@ var Day = require('./day');
 var DateUtil = require('./util/date');
 
 var Calendar = React.createClass({
+  mixins: [require('react-onclickoutside')],
+
+  handleClickOutside: function() {
+    this.props.hideCalendar();
+  },
+
   getInitialState: function() {
     return {
       date: new DateUtil(this.props.selected).clone()
@@ -68,7 +74,7 @@ var Calendar = React.createClass({
 
   render: function() {
     return (
-      <div className="datepicker" onMouseDown={this.props.onMouseDown}>
+      <div className="datepicker">
         <div className="datepicker__triangle"></div>
         <div className="datepicker__header">
           <a className="datepicker__navigation datepicker__navigation--previous"

--- a/src/date_input.js
+++ b/src/date_input.js
@@ -72,7 +72,6 @@ var DateInput = React.createClass({
       ref="input"
       type="text"
       value={this.state.value}
-      onBlur={this.props.onBlur}
       onClick={this.handleClick}
       onKeyDown={this.handleKeyDown}
       onFocus={this.props.onFocus}

--- a/src/datepicker.js
+++ b/src/datepicker.js
@@ -19,31 +19,11 @@ var DatePicker = React.createClass({
   },
 
   hideCalendar: function() {
-    this.setState({
-      focus: false
-    });
-  },
-
-  handleBlur: function() {
-    this.setState({
-      focus: !! this._shouldBeFocussed
-    });
-
-    if (!! this._shouldBeFocussed) {
-      // Firefox doesn't support immediately focussing inside of blur
-      setTimeout(function() {
-        this.setState({
-          focus: true
-        });
-      }.bind(this), 0);
-    }
-
-    // Reset the value of this._shouldBeFocussed to it's default
-    this._shouldBeFocussed = false;
-  },
-
-  handleCalendarMouseDown: function() {
-    this._shouldBeFocussed = true;
+    setTimeout(function() {
+      this.setState({
+        focus: false
+      });
+    }.bind(this), 0);
   },
 
   handleSelect: function(date) {
@@ -70,8 +50,7 @@ var DatePicker = React.createClass({
         <Popover>
           <Calendar
             selected={this.props.selected}
-            onSelect={this.handleSelect}
-            onMouseDown={this.handleCalendarMouseDown} />
+            onSelect={this.handleSelect} />
         </Popover>
       );
     }
@@ -84,11 +63,11 @@ var DatePicker = React.createClass({
           date={this.props.selected}
           dateFormat={this.props.dateFormat}
           focus={this.state.focus}
-          onBlur={this.handleBlur}
           onFocus={this.handleFocus}
           handleClick={this.onInputClick}
           handleEnter={this.hideCalendar}
-          setSelected={this.setSelected} />
+          setSelected={this.setSelected}
+          hideCalendar = {this.hideCalendar} />
         {this.calendar()}
       </div>
     );


### PR DESCRIPTION
I noticed that I wasn't able to select a date or cycle through the months on IE11. If I tried to increment the month, the calendar would close, same with trying to select a date. I even checked that it wasn't just my codebase by throwing up the example file on BrowserStack.

I believe the bug comes from the blur event firing twice in IE11 (don't ask me for any literature to back this up though!). I put a breakpoint in handleBlur and it was indeed firing one more time than in Chrome, which obviously would then set focus to be false since _shouldBeFocussed was never reset to true since handleCalendarMouseDown was not being fired again, just handleBlur.

The primary purpose of both handleBlur and handleCalendarMouseDown was to detect if the blur came from clicking inside or outside the calendar. The extra blur meant I couldn't use these as a function to determine what was a legitimate intent to close. I had the best luck utilizing [react-onclickoutside](https://github.com/Pomax/react-onclickoutside), which originated from [this discussion](https://github.com/facebook/react/issues/579). It has so far proved very accurate in detecting clicks outside a component and I was able to completely remove the handleBlur and handleCalendarMouseDown.

I'm not really suggesting that this be merged in to the main library, but to offer a patch to those experiencing similar issues in IE11 and to start a larger discussion on this issue that I faced. 

----
FYI, I pushed up the example to my github project page to make it easier to view and test the bug http://hanawang.com/react-datepicker/