### PR TITLE
Add ability to disable dates in the future and/or past

### DIFF
--- a/example.html
+++ b/example.html
@@ -14,6 +14,10 @@
     body {
       min-height: 500px;
     }
+
+    input {
+      width: 350px;
+    }
   </style>
 
   <body>
@@ -31,7 +35,8 @@
           return {
             start_date: moment(),
             end_date: moment(),
-            new_date: null
+            new_date: null,
+            bound_date: null
           };
         },
 
@@ -53,6 +58,12 @@
           });
         },
 
+        handleBoundDateChange: function(date) {
+          this.setState({
+            bound_date: date
+          });
+        },
+
         render: function() {
           return React.DOM.div({}, [
             DatePickerFactory({
@@ -71,6 +82,14 @@
               selected: this.state.new_date,
               onChange: this.handleNewDateChange,
               placeholderText: 'Click to select a date'
+            }),
+            DatePickerFactory({
+              key: 'example4',
+              selected: this.state.bound_date,
+              onChange: this.handleBoundDateChange,
+              minDate: moment(),
+              maxDate: moment().add(5, 'days'),
+              placeholderText: 'Select a date between today and 5 days in the future'
             })
           ]);
         }

--- a/react-datepicker.css
+++ b/react-datepicker.css
@@ -121,6 +121,13 @@
 .datepicker__day--selected:hover {
   background-color: #1d5d90;
 }
+.datepicker__day--disabled {
+  cursor: default;
+  color: #ccc;
+}
+.datepicker__day--disabled:hover {
+  background-color: transparent;
+}
 
 .datepicker__input {
   position: relative;

--- a/react-datepicker.js
+++ b/react-datepicker.js
@@ -140,13 +140,18 @@ var Calendar = React.createClass({displayName: "Calendar",
   },
 
   renderDay: function(day, key) {
+    var minDate = new DateUtil(this.props.minDate).safeClone(),
+        maxDate = new DateUtil(this.props.maxDate).safeClone(),
+        disabled = day.isBefore(minDate) || day.isAfter(maxDate);
+
     return (
       React.createElement(Day, {
         key: key, 
         day: day, 
         date: this.state.date, 
         onClick: this.handleDayClick.bind(this, day), 
-        selected: new DateUtil(this.props.selected)})
+        selected: new DateUtil(this.props.selected), 
+        disabled: disabled})
     );
   },
 
@@ -336,7 +341,9 @@ var DatePicker = React.createClass({displayName: "DatePicker",
           React.createElement(Calendar, {
             selected: this.props.selected, 
             onSelect: this.handleSelect, 
-            hideCalendar: this.hideCalendar})
+            hideCalendar: this.hideCalendar, 
+            minDate: this.props.minDate, 
+            maxDate: this.props.maxDate})
         )
       );
     }
@@ -369,16 +376,23 @@ module.exports = DatePicker;
 /** @jsx React.DOM */
 
 var Day = React.createClass({displayName: "Day",
+  handleClick: function(event) {
+    if (this.props.disabled) return;
+
+    this.props.onClick(event);
+  },
+
   render: function() {
     classes = React.addons.classSet({
       'datepicker__day': true,
+      'datepicker__day--disabled': this.props.disabled,
       'datepicker__day--selected': this.props.day.sameDay(this.props.selected),
       'datepicker__day--this-month': this.props.day.sameMonth(this.props.date),
       'datepicker__day--today': this.props.day.sameDay(moment())
     });
 
     return (
-      React.createElement("div", {className: classes, onClick: this.props.onClick}, 
+      React.createElement("div", {className: classes, onClick: this.handleClick}, 
         this.props.day.day()
       )
     );
@@ -472,6 +486,14 @@ module.exports = Popover;
 function DateUtil(date) {
   this._date = date;
 }
+
+DateUtil.prototype.isBefore = function(other) {
+  return this._date.isBefore(other._date, 'day');
+};
+
+DateUtil.prototype.isAfter = function(other) {
+  return this._date.isAfter(other._date, 'day');
+};
 
 DateUtil.prototype.sameDay = function(other) {
   return this._date.isSame(other._date, 'day');

--- a/src/calendar.js
+++ b/src/calendar.js
@@ -58,13 +58,18 @@ var Calendar = React.createClass({
   },
 
   renderDay: function(day, key) {
+    var minDate = new DateUtil(this.props.minDate).safeClone(),
+        maxDate = new DateUtil(this.props.maxDate).safeClone(),
+        disabled = day.isBefore(minDate) || day.isAfter(maxDate);
+
     return (
       <Day
         key={key}
         day={day}
         date={this.state.date}
         onClick={this.handleDayClick.bind(this, day)}
-        selected={new DateUtil(this.props.selected)} />
+        selected={new DateUtil(this.props.selected)}
+        disabled={disabled} />
     );
   },
 

--- a/src/datepicker.js
+++ b/src/datepicker.js
@@ -51,7 +51,9 @@ var DatePicker = React.createClass({
           <Calendar
             selected={this.props.selected}
             onSelect={this.handleSelect}
-            hideCalendar={this.hideCalendar} />
+            hideCalendar={this.hideCalendar}
+            minDate={this.props.minDate}
+            maxDate={this.props.maxDate} />
         </Popover>
       );
     }

--- a/src/day.js
+++ b/src/day.js
@@ -1,16 +1,23 @@
 /** @jsx React.DOM */
 
 var Day = React.createClass({
+  handleClick: function(event) {
+    if (this.props.disabled) return;
+
+    this.props.onClick(event);
+  },
+
   render: function() {
     classes = React.addons.classSet({
       'datepicker__day': true,
+      'datepicker__day--disabled': this.props.disabled,
       'datepicker__day--selected': this.props.day.sameDay(this.props.selected),
       'datepicker__day--this-month': this.props.day.sameMonth(this.props.date),
       'datepicker__day--today': this.props.day.sameDay(moment())
     });
 
     return (
-      <div className={classes} onClick={this.props.onClick}>
+      <div className={classes} onClick={this.handleClick}>
         {this.props.day.day()}
       </div>
     );

--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -112,6 +112,15 @@
       background-color: darken($selected-color, 5%);
     }
   }
+
+  &--disabled {
+    cursor: default;
+    color: $muted-color;
+
+    &:hover {
+      background-color: transparent;
+    }
+  }
 }
 
 .datepicker__input {

--- a/src/util/date.js
+++ b/src/util/date.js
@@ -2,6 +2,14 @@ function DateUtil(date) {
   this._date = date;
 }
 
+DateUtil.prototype.isBefore = function(other) {
+  return this._date.isBefore(other._date, 'day');
+};
+
+DateUtil.prototype.isAfter = function(other) {
+  return this._date.isAfter(other._date, 'day');
+};
+
 DateUtil.prototype.sameDay = function(other) {
   return this._date.isSame(other._date, 'day');
 };

--- a/test/util/date_test.js
+++ b/test/util/date_test.js
@@ -5,6 +5,52 @@ var moment = require('moment');
 var DateUtil = require('../../src/util/date');
 
 describe('DateUtil', function() {
+  describe('#isBefore', function() {
+    it('returns true when the date is before the passed date', function() {
+      var date = new DateUtil(moment('2014-02-08'));
+      var other_date = new DateUtil(moment('2014-02-09'));
+
+      expect(date.isBefore(other_date)).toBe(true);
+    });
+
+    it('returns false when the date is after the passed date', function() {
+      var date = new DateUtil(moment('2014-02-08'));
+      var other_date = new DateUtil(moment('2014-02-05'));
+
+      expect(date.isBefore(other_date)).toBe(false);
+    });
+
+    it('returns false when the passed date is the same day', function() {
+      var date = new DateUtil(moment('2014-02-08'));
+      var other_date = new DateUtil(moment('2014-02-08'));
+
+      expect(date.isBefore(other_date)).toBe(false);
+    });
+  });
+
+  describe('#isAfter', function() {
+    it('returns true when the date is after the passed date', function() {
+      var date = new DateUtil(moment('2014-02-09'));
+      var other_date = new DateUtil(moment('2014-02-08'));
+
+      expect(date.isAfter(other_date)).toBe(true);
+    });
+
+    it('returns false when the date is before the passed date', function() {
+      var date = new DateUtil(moment('2014-02-05'));
+      var other_date = new DateUtil(moment('2014-02-08'));
+
+      expect(date.isAfter(other_date)).toBe(false);
+    });
+
+    it('returns false when the passed date is the same day', function() {
+      var date = new DateUtil(moment('2014-02-08'));
+      var other_date = new DateUtil(moment('2014-02-08'));
+
+      expect(date.isAfter(other_date)).toBe(false);
+    });
+  });
+
   describe('#sameDay', function() {
     it('returns true when the passed date is the same date', function() {
       var date = new DateUtil(moment('2014-02-08'));


### PR DESCRIPTION
Live example [here](http://cdn.rawgit.com/hahahana/react-datepicker/23f3362c1e3b7be530d2891fe4238be13a1c5469/example.html).

The example is getting a bit gnarly, what do you guys think? Maybe separate pages for different functionality with some documentation on the page too?

---
Should close https://github.com/Hacker0x01/react-datepicker/issues/69