### PR TITLE
Custom week starts

### DIFF
--- a/example.html
+++ b/example.html
@@ -36,7 +36,8 @@
             start_date: moment(),
             end_date: moment(),
             new_date: null,
-            bound_date: null
+            bound_date: null,
+            sunday_start_date: null
           };
         },
 
@@ -61,6 +62,12 @@
         handleBoundDateChange: function(date) {
           this.setState({
             bound_date: date
+          });
+        },
+
+        handleSundayStartDateChange: function(date) {
+          this.setState({
+            sunday_start_date: date
           });
         },
 
@@ -90,6 +97,13 @@
               minDate: moment(),
               maxDate: moment().add(5, 'days'),
               placeholderText: 'Select a date between today and 5 days in the future'
+            }),
+            DatePickerFactory({
+              key: 'example5',
+              selected: this.state.sunday_start_date,
+              onChange: this.handleSundayStartDateChange,
+              placeholderText: 'I start on Sunday!',
+              weekStart: 0
             })
           ]);
         }

--- a/react-datepicker.js
+++ b/react-datepicker.js
@@ -98,6 +98,16 @@ var Calendar = React.createClass({displayName: "Calendar",
     };
   },
 
+  getDefaultProps: function() {
+    return {
+      weekStart: 1
+    };
+  },
+
+  componentWillMount: function() {
+    this.initializeMomentLocale();
+  },
+
   componentWillReceiveProps: function(nextProps) {
     // When the selected date changed
     if (nextProps.selected !== this.props.selected) {
@@ -105,6 +115,18 @@ var Calendar = React.createClass({displayName: "Calendar",
         date: new DateUtil(nextProps.selected).clone()
       });
     }
+  },
+
+  initializeMomentLocale: function() {
+    var weekdays = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
+    weekdays = weekdays.concat(weekdays.splice(0, this.props.weekStart));
+
+    moment.locale('en', {
+      week: {
+        dow: this.props.weekStart
+      },
+      weekdaysMin : weekdays
+    });
   },
 
   increaseMonth: function() {
@@ -159,6 +181,12 @@ var Calendar = React.createClass({displayName: "Calendar",
     return weekStart.mapDaysInWeek(this.renderDay);
   },
 
+  header: function() {
+    return moment.weekdaysMin().map(function(day, key) {
+      return React.createElement("div", {className: "datepicker__day", key: key}, day);
+    });
+  },
+
   render: function() {
     return (
       React.createElement("div", {className: "datepicker"}, 
@@ -174,13 +202,7 @@ var Calendar = React.createClass({displayName: "Calendar",
               onClick: this.increaseMonth}
           ), 
           React.createElement("div", null, 
-            React.createElement("div", {className: "datepicker__day"}, "Mo"), 
-            React.createElement("div", {className: "datepicker__day"}, "Tu"), 
-            React.createElement("div", {className: "datepicker__day"}, "We"), 
-            React.createElement("div", {className: "datepicker__day"}, "Th"), 
-            React.createElement("div", {className: "datepicker__day"}, "Fr"), 
-            React.createElement("div", {className: "datepicker__day"}, "Sa"), 
-            React.createElement("div", {className: "datepicker__day"}, "Su")
+            this.header()
           )
         ), 
         React.createElement("div", {className: "datepicker__month"}, 
@@ -343,7 +365,8 @@ var DatePicker = React.createClass({displayName: "DatePicker",
             onSelect: this.handleSelect, 
             hideCalendar: this.hideCalendar, 
             minDate: this.props.minDate, 
-            maxDate: this.props.maxDate})
+            maxDate: this.props.maxDate, 
+            weekStart: this.props.weekStart})
         )
       );
     }
@@ -509,7 +532,7 @@ DateUtil.prototype.day = function() {
 
 DateUtil.prototype.mapDaysInWeek = function(callback) {
   var week = [];
-  var firstDay = this._date.clone().startOf('isoWeek');
+  var firstDay = this._date.clone();
 
   for(var i = 0; i < 7; i++) {
     var day = new DateUtil(firstDay.clone().add(i, 'days'));
@@ -522,7 +545,7 @@ DateUtil.prototype.mapDaysInWeek = function(callback) {
 
 DateUtil.prototype.mapWeeksInMonth = function(callback) {
   var month = [];
-  var firstDay = this._date.clone().startOf('month').startOf('isoWeek');
+  var firstDay = this._date.clone().startOf('month').startOf('week');
 
   for(var i = 0; i < 6; i++) {
     var weekStart = new DateUtil(firstDay.clone().add(i, 'weeks'));
@@ -535,7 +558,7 @@ DateUtil.prototype.mapWeeksInMonth = function(callback) {
 
 DateUtil.prototype.weekInMonth = function(other) {
   var firstDayInWeek = this._date.clone();
-  var lastDayInWeek = this._date.clone().isoWeekday(7);
+  var lastDayInWeek = this._date.clone().weekday(7);
 
   return firstDayInWeek.isSame(other._date, 'month') ||
     lastDayInWeek.isSame(other._date, 'month');

--- a/src/calendar.js
+++ b/src/calendar.js
@@ -16,6 +16,16 @@ var Calendar = React.createClass({
     };
   },
 
+  getDefaultProps: function() {
+    return {
+      weekStart: 1
+    };
+  },
+
+  componentWillMount: function() {
+    this.initializeMomentLocale();
+  },
+
   componentWillReceiveProps: function(nextProps) {
     // When the selected date changed
     if (nextProps.selected !== this.props.selected) {
@@ -23,6 +33,18 @@ var Calendar = React.createClass({
         date: new DateUtil(nextProps.selected).clone()
       });
     }
+  },
+
+  initializeMomentLocale: function() {
+    var weekdays = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
+    weekdays = weekdays.concat(weekdays.splice(0, this.props.weekStart));
+
+    moment.locale('en', {
+      week: {
+        dow: this.props.weekStart
+      },
+      weekdaysMin : weekdays
+    });
   },
 
   increaseMonth: function() {
@@ -77,6 +99,12 @@ var Calendar = React.createClass({
     return weekStart.mapDaysInWeek(this.renderDay);
   },
 
+  header: function() {
+    return moment.weekdaysMin().map(function(day, key) {
+      return <div className="datepicker__day" key={key}>{day}</div>;
+    });
+  },
+
   render: function() {
     return (
       <div className="datepicker">
@@ -92,13 +120,7 @@ var Calendar = React.createClass({
               onClick={this.increaseMonth}>
           </a>
           <div>
-            <div className="datepicker__day">Mo</div>
-            <div className="datepicker__day">Tu</div>
-            <div className="datepicker__day">We</div>
-            <div className="datepicker__day">Th</div>
-            <div className="datepicker__day">Fr</div>
-            <div className="datepicker__day">Sa</div>
-            <div className="datepicker__day">Su</div>
+            {this.header()}
           </div>
         </div>
         <div className="datepicker__month">

--- a/src/datepicker.js
+++ b/src/datepicker.js
@@ -53,7 +53,8 @@ var DatePicker = React.createClass({
             onSelect={this.handleSelect}
             hideCalendar={this.hideCalendar}
             minDate={this.props.minDate}
-            maxDate={this.props.maxDate} />
+            maxDate={this.props.maxDate}
+            weekStart={this.props.weekStart} />
         </Popover>
       );
     }

--- a/src/util/date.js
+++ b/src/util/date.js
@@ -24,7 +24,7 @@ DateUtil.prototype.day = function() {
 
 DateUtil.prototype.mapDaysInWeek = function(callback) {
   var week = [];
-  var firstDay = this._date.clone().startOf('isoWeek');
+  var firstDay = this._date.clone();
 
   for(var i = 0; i < 7; i++) {
     var day = new DateUtil(firstDay.clone().add(i, 'days'));
@@ -37,7 +37,7 @@ DateUtil.prototype.mapDaysInWeek = function(callback) {
 
 DateUtil.prototype.mapWeeksInMonth = function(callback) {
   var month = [];
-  var firstDay = this._date.clone().startOf('month').startOf('isoWeek');
+  var firstDay = this._date.clone().startOf('month').startOf('week');
 
   for(var i = 0; i < 6; i++) {
     var weekStart = new DateUtil(firstDay.clone().add(i, 'weeks'));
@@ -50,7 +50,7 @@ DateUtil.prototype.mapWeeksInMonth = function(callback) {
 
 DateUtil.prototype.weekInMonth = function(other) {
   var firstDayInWeek = this._date.clone();
-  var lastDayInWeek = this._date.clone().isoWeekday(7);
+  var lastDayInWeek = this._date.clone().weekday(7);
 
   return firstDayInWeek.isSame(other._date, 'month') ||
     lastDayInWeek.isSame(other._date, 'month');


### PR DESCRIPTION
Live example [here](http://cdn.rawgit.com/hahahana/react-datepicker/db566c23015bf2487aadb0fe6b9966306bbda59e/example.html).

I've been thinking about the moment + locale feature. The calendar was definitely opinionated before since it used isoWeek, and is technically less opinionated now (since people can just override the 'en' locale in the global scope), but if people wanted to use locales and custom weekStarts they would experience unexpected behavior. I honestly haven't gone over the locales code at all, so I don't really know how to leverage it. I'm guessing it doesn't matter much at this point, maybe just something to keep in mind for the future.

Also, tests, need tests...

----

Change the `weekStart` prop:

0 for Sunday
1 for Monday
2 for Tuesday
3 for Wednesday
4 for Thursday
5 for Friday
6 for Saturday
