### PR TITLE
Remove disabled-look from days in previous/next month

### DIFF
--- a/react-datepicker.css
+++ b/react-datepicker.css
@@ -95,7 +95,7 @@
 }
 
 .datepicker__day {
-  color: #ccc;
+  color: #000;
   display: inline-block;
   width: 24px;
   line-height: 24px;
@@ -106,9 +106,6 @@
 .datepicker__day:hover {
   border-radius: 4px;
   background-color: #f0f0f0;
-}
-.datepicker__day--this-month {
-  color: #000;
 }
 .datepicker__day--today {
   font-weight: bold;

--- a/src/day.js
+++ b/src/day.js
@@ -12,7 +12,6 @@ var Day = React.createClass({
       'datepicker__day': true,
       'datepicker__day--disabled': this.props.disabled,
       'datepicker__day--selected': this.props.day.sameDay(this.props.selected),
-      'datepicker__day--this-month': this.props.day.sameMonth(this.props.date),
       'datepicker__day--today': this.props.day.sameDay(moment())
     });
 

--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -82,7 +82,7 @@
 }
 
 .datepicker__day {
-  color: $muted-color;
+  color: $text-color;
   display: inline-block;
   width: $item-size;
   line-height: $item-size;
@@ -94,11 +94,7 @@
     border-radius: $border-radius;
     background-color: $background-color;
   }
-
-  &--this-month {
-    color: $text-color;
-  }
-
+  
   &--today {
     font-weight: bold;
   }


### PR DESCRIPTION
While working with the react-datepicker I discovered that days in the
previous and/or next months look like they're disabled, but they're
not.

We should make it more clear dates in the previous and/or next month
are selectable. In order to achieve this, I propose to remove this
`this-month` state and make the day's color default to black.

Screenshot:

![screen shot 2015-02-10 at 17 27 32](https://cloud.githubusercontent.com/assets/997034/6131138/2801e92e-b14a-11e4-99b6-5583ac6ff43f.png)
