### PR TITLE
Moved react to peerDependencies, and reactify to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,13 +29,16 @@
     "grunt-jsxhint": "0.4.0",
     "grunt-scss-lint": "^0.3.4",
     "jest-cli": "0.1.18",
-    "react-tools": "0.11.1"
+    "react-tools": "0.11.1",
+    "reactify": "^1.0",
+    "react": "^0.12"
+  },
+  "peerDependencies" : {
+    "react": "^0.12"
   },
   "dependencies": {
-    "react": "^0.12",
     "moment": "^2.8",
     "tether": "^0.6",
-    "reactify": "^1.0",
     "react-onclickoutside": "0.2.1"
   },
   "scripts": {


### PR DESCRIPTION
React I believe should be a `peerDependencies` item since I believe this qualifies as a plugin component. This will help reduce this chance of duplicates in the bundle. Also, I believe `reactify` is only for dev.