### PR TITLE
add grunt-cli to devDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,12 @@ Installing is really simple and can be done in two different ways:
 ## Local Development
 
 - Install Bower `npm install -g bower`
-- Install Grunt CLI `npm install -g grunt-cli`
 - Install Bower Packages `bower install`
 - Install packages `npm install`
 - Start a static webserver `python -m SimpleHTTPServer`
 - And visit `localhost:8000/example.html` to see the example.
 
-To run tests, simply run `grunt jest`.
+To run tests, simply run `npm test`.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "grunt": "0.4.5",
     "grunt-browserify": "3.2.1",
+    "grunt-cli": "0.1.13",
     "grunt-contrib-sass": "0.8.1",
     "grunt-contrib-watch": "0.6.1",
     "grunt-jest": "0.1.1",


### PR DESCRIPTION
since `./node_modules/.bin` is added to your PATH when running npm
scripts, add grunt-cli to deps to cut out `npm install -g grunt` step