### PR TITLE
Remove unneeded old JSX pragma

### DIFF
--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -1,5 +1,3 @@
-/** @jsx React.DOM */
-
 var React = require('react/addons');
 var Day = require('./day');
 var DateUtil = require('./util/date');

--- a/src/date_input.jsx
+++ b/src/date_input.jsx
@@ -1,5 +1,3 @@
-/** @jsx React.DOM */
-
 var React = require('react/addons');
 var DateUtil = require('./util/date');
 var moment = require('moment');

--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -1,5 +1,3 @@
-/** @jsx React.DOM */
-
 var React = require('react/addons');
 var Popover = require('./popover');
 var DateUtil = require('./util/date');

--- a/src/day.jsx
+++ b/src/day.jsx
@@ -1,5 +1,3 @@
-/** @jsx React.DOM */
-
 var React = require('react/addons');
 var moment = require('moment');
 

--- a/src/popover.jsx
+++ b/src/popover.jsx
@@ -1,5 +1,3 @@
-/** @jsx React.DOM */
-
 var React = require('react/addons');
 
 var Popover = React.createClass({

--- a/test/date_input_test.js
+++ b/test/date_input_test.js
@@ -1,5 +1,3 @@
-/** @jsx React.DOM */
-
 jest.dontMock('../src/date_input.jsx');
 
 describe('DateInput', function() {


### PR DESCRIPTION
The peer dependencies in package.json show "react": "^0.12" as a peer dependency, which means that the JSX pragma is no longer needed for valid consumer modules.

This also fixes some deprecation error messages with tools like babel-loader.