### PR TITLE
Remove tether constraints on popover [fixes FF bug]

### DIFF
--- a/src/popover.jsx
+++ b/src/popover.jsx
@@ -38,14 +38,7 @@ var Popover = React.createClass({
       targetOffset: '10px 0',
       optimizations: {
         moveElement: false // always moves to <body> anyway!
-      },
-      constraints: [
-        {
-          to: 'scrollParent',
-          attachment: 'together',
-          pin: true
-        }
-      ]
+      }
     };
   },
 


### PR DESCRIPTION
In Firefox, I was seeing behavior like this:
![screen shot 2015-03-16 at 4 11 50 pm](https://cloud.githubusercontent.com/assets/2406167/6678457/40f635c0-cbf8-11e4-8357-082703e67c9b.png)

I also noticed that on pages that scrolled, the datepicker would fix to the top of the page, due to the pin constraint. I don't think that this component needs to have scroll constraints - we really just want it to appear next to the input.

Also, has the build process changed? If so, can someone update the docs? I have no idea how to update the stuff in /example.