### PR TITLE
changing npm i to npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A simple and reusable datepicker component for React ([Demo](http://cdn.rawgit.c
 Installing is really simple and can be done in two different ways:
 
 - Install with Bower: `bower install react-date-picker`
-- Install with npm: `npm i react-datepicker --save`
+- Install with npm: `npm install react-datepicker --save`
 - Install with Bundler: `bundle install rails-assets-react-date-picker`
 
 ## Local Development


### PR DESCRIPTION
The discussion about `npm i` or `npm install` isn't worth it's time. At least not in this context.
@RSO prefers `npm install` over  `npm i` so I have changed it to `npm install`.
