### PR TITLE
fix: remove `NameFormat` rule breaking `grunt build`

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -77,7 +77,7 @@ linters:
     force_nesting: true
 
   NameFormat:
-    enabled: true
+    enabled: false
     convention: BEM
 
   NestingDepth:


### PR DESCRIPTION
I couldn't build the application without removing this rule in the `.scss-lint.yml`

![screen shot 2015-05-20 at 11 56 58](https://cloud.githubusercontent.com/assets/893837/7723232/7d2bd758-fee7-11e4-9dda-a22e349433f7.png)
