### PR TITLE
Add className as prop

### DIFF
--- a/src/date_input.jsx
+++ b/src/date_input.jsx
@@ -7,7 +7,7 @@ var DateInput = React.createClass({
   getDefaultProps: function() {
     return {
       dateFormat: 'YYYY-MM-DD',
-      className: "datepicker__input"
+      className: 'datepicker__input'
     };
   },
 

--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -96,8 +96,7 @@ var DatePicker = React.createClass({
             minDate={this.props.minDate}
             maxDate={this.props.maxDate}
             excludeDates={this.props.excludeDates}
-            weekStart={this.props.weekStart} 
-            className={this.props.className}/>
+            weekStart={this.props.weekStart} />
         </Popover>
       );
     }
@@ -119,7 +118,8 @@ var DatePicker = React.createClass({
           clearSelected={this.clearSelected}
           hideCalendar={this.hideCalendar}
           placeholderText={this.props.placeholderText}
-          disabled={this.props.disabled} />
+          disabled={this.props.disabled}  
+          className={this.props.className} />
         {this.props.disabled ? null : this.calendar()}
       </div>
     );

--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -96,7 +96,8 @@ var DatePicker = React.createClass({
             minDate={this.props.minDate}
             maxDate={this.props.maxDate}
             excludeDates={this.props.excludeDates}
-            weekStart={this.props.weekStart} />
+            weekStart={this.props.weekStart} 
+            className={this.props.className}/>
         </Popover>
       );
     }


### PR DESCRIPTION
With default of "datepicker__input". I know there is a pull request, but it wasn't merged yet. Its an absolute showstopper that there is currently no way to define a class name. This seems like the most unobtrusive, non-breaking way.