### PR TITLE
Allow parent to pass updates to selected

### DIFF
--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -31,6 +31,12 @@ var DatePicker = React.createClass({
     };
   },
 
+  componentWillReceiveProps: function (nextProps) {
+      this.setState({
+        selected: nextProps.selected
+      });
+  },
+
   getValue: function() {
     return this.state.selected;
   },


### PR DESCRIPTION
This change will allow a parent component to control the selected value of the date picker.  Use case is:

1. Initialize component with null value
2. User selects a date
3. A separate "Clear" button clears out the field by setting the selected prop to null

Fixes #133 