### PR TITLE
Change 'lodash' from a devDependency to a regular dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "grunt-scss-lint": "^0.3.4",
     "grunt-webpack": "^1.0.8",
     "jest-cli": "0.4.0",
-    "lodash": "^3.3.0",
     "react": ">=0.12 <0.14",
     "react-tools": ">=0.12 <0.14",
     "webpack": "^1.7.2",
@@ -48,7 +47,8 @@
   "dependencies": {
     "moment": "^2.8",
     "tether": "^1.0.1",
-    "react-onclickoutside": "0.2.2"
+    "react-onclickoutside": "0.2.2",
+    "lodash": "^3.3.0"
   },
   "scripts": {
     "test": "grunt travis --verbose"


### PR DESCRIPTION
Lodash is required in the source of 'calendar.jsx'. It should be a regular dependency instead of a 'devDependency'. The current dep configuration won't work for build environments that don't already have lodash installed.