### PR TITLE
Added readonly

### DIFF
--- a/src/date_input.jsx
+++ b/src/date_input.jsx
@@ -76,7 +76,7 @@ var DateInput = React.createClass( {
         className={this.props.className}
         disabled={this.props.disabled}
         placeholder={this.props.placeholderText}
-        readonly={this.props.readOnly} />;
+        readOnly={this.props.readOnly} />;
   }
 } );
 

--- a/src/date_input.jsx
+++ b/src/date_input.jsx
@@ -75,7 +75,8 @@ var DateInput = React.createClass( {
         onChange={this.handleChange}
         className={this.props.className}
         disabled={this.props.disabled}
-        placeholder={this.props.placeholderText} />;
+        placeholder={this.props.placeholderText}
+        readonly={this.props.readOnly} />;
   }
 } );
 

--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -161,7 +161,8 @@ var DatePicker = React.createClass( {
           placeholderText={this.props.placeholderText}
           disabled={this.props.disabled}
           className={this.props.className}
-          title={this.props.title} />
+          title={this.props.title}
+          readOnly={this.props.readOnly} />
         {clearButton}
         {this.props.disabled ? null : this.calendar()}
       </div>


### PR DESCRIPTION
When using the datepicker on mobile the keyboard will pop up when selecting a date, using readonly will prevent this from happening.