### PR TITLE
startDate and endDate props should not be required

### DIFF
--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -16,6 +16,8 @@ var Calendar = React.createClass( {
     hideCalendar: React.PropTypes.func.isRequired,
     minDate: React.PropTypes.object,
     maxDate: React.PropTypes.object,
+    startDate: React.PropTypes.object,
+    endDate: React.PropTypes.object,
     excludeDates: React.PropTypes.array,
     weekStart: React.PropTypes.string.isRequired
   },

--- a/src/util/date.js
+++ b/src/util/date.js
@@ -19,9 +19,10 @@ DateUtil.prototype.sameMonth = function( other ) {
 };
 
 DateUtil.prototype.inRange = function( startDate, endDate ) {
-  var startDate = startDate._date.startOf( "day" ).subtract( 1, "seconds" );
-  var endDate = endDate._date.startOf( "day" ).add( 1, "seconds" );
-  return this._date.isBetween( startDate, endDate );
+  if ( !startDate || !endDate ) return false;
+  var before = startDate._date.startOf( "day" ).subtract( 1, "seconds" );
+  var after = endDate._date.startOf( "day" ).add( 1, "seconds" );
+  return this._date.isBetween( before, after );
 };
 
 DateUtil.prototype.day = function() {

--- a/test/util/date_test.js
+++ b/test/util/date_test.js
@@ -126,6 +126,20 @@ describe( "DateUtil", function() {
 
       expect( date.inRange( start_date, end_date ) ).to.eq( true );
     } );
+
+    it( "returns false when the start of range is missing", function() {
+      var date = new DateUtil( moment( "2014-02-09" ) );
+      var end_date = new DateUtil( moment( "2014-02-10" ) );
+
+      expect( date.inRange( null, end_date ) ).to.eq( false );
+    } );
+
+    it( "returns false when the end of range is missing", function() {
+      var date = new DateUtil( moment( "2014-02-09" ) );
+      var start_date = new DateUtil( moment( "2014-02-09" ) );
+
+      expect( date.inRange( start_date, null ) ).to.eq( false );
+    } );
   } );
 
   describe( "#day", function() {


### PR DESCRIPTION
This PR fixes errors being thrown when either `startDate` or `endDate`
props are not supplied.

Fixes https://github.com/Hacker0x01/react-datepicker/commit/9715c69f4ad68866de35c350a6b0c42c5bd6cc0e#commitcomment-14071280

/cc @Reggino