### PR TITLE
Adding some handy refs

### DIFF
--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -134,6 +134,7 @@ var DatePicker = React.createClass( {
           constraints={this.props.tetherConstraints}>
 
           <Calendar
+            ref='calendar'
             weekdays={this.props.weekdays}
             locale={this.props.locale}
             moment={this.props.moment}
@@ -163,6 +164,7 @@ var DatePicker = React.createClass( {
     return (
       <div className="datepicker__input-container">
         <DateInput
+          ref='input'
           id={this.props.id}
           name={this.props.name}
           date={this.state.selected}


### PR DESCRIPTION
Refs allow for external access to components without having to rely on component functions which may change if you decide to rejigger the implementation.

Addresses https://github.com/Hacker0x01/react-datepicker/issues/205