### PR TITLE
Limit version of react-clickoutside to be between 4.0.1 - 4.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "lodash": "^3.10.0",
     "moment": "^2.10",
-    "react-onclickoutside": "^4.0.1",
+    "react-onclickoutside": "4.0.1 - 4.1.1",
     "tether": "^1.1.0"
   },
   "scripts": {


### PR DESCRIPTION
Addresses #234 