### PR TITLE
Revert "Limit version of react-clickoutside to be between 4.0.1 - 4.1.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "lodash": "^3.10.0",
     "moment": "^2.10",
-    "react-onclickoutside": "4.0.1 - 4.1.1",
+    "react-onclickoutside": "^4.0.1",
     "tether": "^1.1.0"
   },
   "scripts": {


### PR DESCRIPTION
This reverts commit 7dbc7eda795efed9bebe505df5d83b5d8aa8734c.

OnClickOutside's issue was fixed upstream ([very quickly](https://github.com/Pomax/react-onclickoutside/issues/51)! :smile: ), so the caret range won't install the bad version any more.