### PR TITLE
Show valid date range in initial view

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -37,7 +37,10 @@ module.exports = function(config) {
         new webpack.DefinePlugin({
           "process.env.NODE_ENV": JSON.stringify("test")
         })
-      ]
+      ],
+      resolve: {
+        extensions: ["", ".jsx", ".js"]
+      }
     },
 
     webpackServer: {

--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -10,7 +10,7 @@ var Calendar = React.createClass({
 
   propTypes: {
     weekdays: React.PropTypes.array.isRequired,
-    locale: React.PropTypes.string,
+    locale: React.PropTypes.string.isRequired,
     moment: React.PropTypes.func.isRequired,
     dateFormat: React.PropTypes.string.isRequired,
     onSelect: React.PropTypes.func.isRequired,

--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -5,6 +5,17 @@ import YearDropdown from "./year_dropdown";
 import Day from "./day";
 import React from "react";
 
+function getDateInView({ moment, minDate, maxDate }) {
+  var current = new DateUtil(moment());
+  if (minDate && new DateUtil(minDate).isAfter(current)) {
+    return minDate;
+  } else if (maxDate && new DateUtil(maxDate).isBefore(current)) {
+    return maxDate;
+  } else {
+    return current.moment();
+  }
+}
+
 var Calendar = React.createClass({
   mixins: [require("react-onclickoutside")],
 
@@ -31,7 +42,7 @@ var Calendar = React.createClass({
 
   getInitialState() {
     return {
-      date: new DateUtil(this.props.selected).safeClone(this.props.moment())
+      date: new DateUtil(this.props.selected).safeClone(getDateInView(this.props))
     };
   },
 

--- a/test/calendar_test.js
+++ b/test/calendar_test.js
@@ -1,0 +1,45 @@
+import React from "react";
+import TestUtils from "react-addons-test-utils";
+import moment from "moment";
+import DateUtil from "../src/util/date";
+import Calendar from "../src/calendar";
+
+describe("Calendar", function() {
+  function getCalendar(extraProps) {
+    return <Calendar
+      weekdays={["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"]}
+      locale="en"
+      moment={moment}
+      dateFormat="MMMM"
+      onSelect={() => {}}
+      handleClick={() => {}}
+      hideCalendar={() => {}}
+      {...extraProps} />;
+  }
+
+  it("should start with the current date in view if no date range", function() {
+    var now = new DateUtil(moment());
+    var calendar = TestUtils.renderIntoDocument(getCalendar());
+    assert(calendar.state.date.sameDay(now));
+  });
+
+  it("should start with the current date in view if in date range", function() {
+    var now = new DateUtil(moment());
+    var minDate = moment().subtract(1, "year");
+    var maxDate = moment().add(1, "year");
+    var calendar = TestUtils.renderIntoDocument(getCalendar({ minDate, maxDate }));
+    assert(calendar.state.date.sameDay(now));
+  });
+
+  it("should start with the min date in view if after the current date", function() {
+    var minDate = moment().add(1, "year");
+    var calendar = TestUtils.renderIntoDocument(getCalendar({ minDate }));
+    assert(calendar.state.date.sameDay(new DateUtil(minDate)));
+  });
+
+  it("should start with the max date in view if before the current date", function() {
+    var maxDate = moment().subtract(1, "year");
+    var calendar = TestUtils.renderIntoDocument(getCalendar({ maxDate }));
+    assert(calendar.state.date.sameDay(new DateUtil(maxDate)));
+  });
+});


### PR DESCRIPTION
Fixes #209

If minDate is after the current date, the focus is set to minDate, and if maxDate is before the current date, the focus is set to maxDate.