### PR TITLE
Properly hide calendar on blur

### DIFF
--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -32,7 +32,8 @@ var DatePicker = React.createClass({
       moment: moment,
       onChange() {},
       disabled: false,
-      onFocus() {}
+      onFocus() {},
+      onBlur() {}
     };
   },
 
@@ -68,7 +69,7 @@ var DatePicker = React.createClass({
   handleBlur() {
     this.setState({ virtualFocus: false }, () => {
       setTimeout(() => {
-        if (!this.state.virtualFocus && typeof this.props.onBlur === "function") {
+        if (!this.state.virtualFocus) {
           this.props.onBlur(this.state.selected);
           this.hideCalendar();
         }

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -1,0 +1,28 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import TestUtils from "react-addons-test-utils";
+import DatePicker from "../src/datepicker.jsx";
+
+describe("DatePicker", () => {
+  it("should show the calendar when focusing on the date input", () => {
+    var datePicker = TestUtils.renderIntoDocument(
+      <DatePicker />
+    );
+    var dateInput = datePicker.refs.input;
+    TestUtils.Simulate.focus(ReactDOM.findDOMNode(dateInput));
+    expect(datePicker.refs.calendar).to.exist;
+  });
+
+  it("should hide the calendar when blurring the date input", done => {
+    var datePicker = TestUtils.renderIntoDocument(
+      <DatePicker />
+    );
+    var dateInput = datePicker.refs.input;
+    TestUtils.Simulate.focus(ReactDOM.findDOMNode(dateInput));
+    TestUtils.Simulate.blur(ReactDOM.findDOMNode(dateInput));
+    setTimeout(() => {
+      expect(datePicker.refs.calendar).to.not.exist;
+      done();
+    }, 300);
+  });
+});


### PR DESCRIPTION
Fixes #156 

It seemed fishy that `hideCalendar` was only called when an `onBlur` function is passed in as a prop.  I could have simply refactored the `if` statement, but I decided to follow the style of `onFocus` by having a default no-op `onBlur`.