### PR TITLE
Close year dropdown when clicking outside

### DIFF
--- a/src/year_dropdown.jsx
+++ b/src/year_dropdown.jsx
@@ -27,7 +27,8 @@ var YearDropdown = React.createClass({
       <YearDropdownOptions
         ref="options"
         year={this.props.year}
-        onChange={this.onChange} />
+        onChange={this.onChange}
+        onCancel={this.toggleDropdown} />
     );
   },
 

--- a/src/year_dropdown.jsx
+++ b/src/year_dropdown.jsx
@@ -1,20 +1,14 @@
-import moment from "moment";
-import DateUtil from "./util/date";
-import ReactDOM from "react-dom";
 import React from "react";
+import YearDropdownOptions from "./year_dropdown_options.jsx";
 
-var DateInput = React.createClass({
+var YearDropdown = React.createClass({
+  propTypes: {
+    year: React.PropTypes.number.isRequired,
+    onChange: React.PropTypes.func.isRequired
+  },
+
   getInitialState() {
-    function generateYears(year) {
-      var list = [];
-      for (var i = 0; i < 5; i++) {
-        list.push(year - i);
-      }
-      return list;
-    }
     return {
-      year: this.props.year,
-      yearsList: generateYears(this.props.year),
       dropdownVisible: false
     };
   },
@@ -30,45 +24,16 @@ var DateInput = React.createClass({
 
   renderDropdown() {
     return (
-      <div className="datepicker__year-dropdown"
-        value={this.props.year}
-        onChange={this.onChange}>
-        { this.renderOptions() }
-      </div>
+      <YearDropdownOptions
+        ref="options"
+        year={this.props.year}
+        onChange={this.onChange} />
     );
-  },
-
-  renderOptions() {
-    var selectedYear = this.props.year;
-    var options = this.state.yearsList.map(year =>
-      <div className="datepicker__year-option"
-        key={year}
-        onClick={this.onChange.bind(this, year)}>
-        { selectedYear === year ? <span className="datepicker__year-option--selected">✓</span> : "" }
-        { year }
-      </div>
-    );
-
-    options.unshift(
-      <div className="datepicker__year-option"
-        key={"upcoming"}
-        onClick={this.incrementYears}>
-        <a className="datepicker__navigation datepicker__navigation--years datepicker__navigation--years-upcoming"></a>
-      </div>
-    );
-    options.push(
-      <div className="datepicker__year-option"
-        key={"previous"}
-        onClick={this.decrementYears}>
-        <a className="datepicker__navigation datepicker__navigation--years datepicker__navigation--years-previous"></a>
-      </div>
-    );
-    return options;
   },
 
   onChange(year) {
     this.toggleDropdown();
-    if (parseInt(year) === this.props.year) return;
+    if (year === this.props.year) return;
     this.props.onChange(year);
   },
 
@@ -76,24 +41,6 @@ var DateInput = React.createClass({
     this.setState({
       dropdownVisible: !this.state.dropdownVisible
     });
-  },
-
-  shiftYears(amount) {
-    var years = this.state.yearsList.map(function(year) {
-      return year + amount;
-    });
-
-    this.setState({
-      yearsList: years
-    });
-  },
-
-  incrementYears() {
-    return this.shiftYears(1);
-  },
-
-  decrementYears() {
-    return this.shiftYears(-1);
   },
 
   render() {
@@ -105,4 +52,4 @@ var DateInput = React.createClass({
   }
 });
 
-module.exports = DateInput;
+module.exports = YearDropdown;

--- a/src/year_dropdown_options.jsx
+++ b/src/year_dropdown_options.jsx
@@ -9,9 +9,12 @@ function generateYears(year) {
 }
 
 var YearDropdownOptions = React.createClass({
+  mixins: [require("react-onclickoutside")],
+
   propTypes: {
     year: React.PropTypes.number.isRequired,
-    onChange: React.PropTypes.func.isRequired
+    onChange: React.PropTypes.func.isRequired,
+    onCancel: React.PropTypes.func.isRequired
   },
 
   getInitialState() {
@@ -60,6 +63,10 @@ var YearDropdownOptions = React.createClass({
 
   onChange(year) {
     this.props.onChange(year);
+  },
+
+  handleClickOutside() {
+    this.props.onCancel();
   },
 
   shiftYears(amount) {

--- a/src/year_dropdown_options.jsx
+++ b/src/year_dropdown_options.jsx
@@ -1,0 +1,84 @@
+import React from "react";
+
+function generateYears(year) {
+  var list = [];
+  for (var i = 0; i < 5; i++) {
+    list.push(year - i);
+  }
+  return list;
+}
+
+var YearDropdownOptions = React.createClass({
+  propTypes: {
+    year: React.PropTypes.number.isRequired,
+    onChange: React.PropTypes.func.isRequired
+  },
+
+  getInitialState() {
+    return {
+      yearsList: generateYears(this.props.year)
+    };
+  },
+
+  render() {
+    return (
+      <div className="datepicker__year-dropdown">
+        {this.renderOptions()}
+      </div>
+    );
+  },
+
+  renderOptions() {
+    var selectedYear = this.props.year;
+    var options = this.state.yearsList.map(year =>
+      <div className="datepicker__year-option"
+        key={year}
+        onClick={this.onChange.bind(this, year)}>
+        { selectedYear === year ? <span className="datepicker__year-option--selected">✓</span> : "" }
+        { year }
+      </div>
+    );
+
+    options.unshift(
+      <div className="datepicker__year-option"
+        ref={"upcoming"}
+        key={"upcoming"}
+        onClick={this.incrementYears}>
+        <a className="datepicker__navigation datepicker__navigation--years datepicker__navigation--years-upcoming"></a>
+      </div>
+    );
+    options.push(
+      <div className="datepicker__year-option"
+        ref={"previous"}
+        key={"previous"}
+        onClick={this.decrementYears}>
+        <a className="datepicker__navigation datepicker__navigation--years datepicker__navigation--years-previous"></a>
+      </div>
+    );
+    return options;
+  },
+
+  onChange(year) {
+    this.props.onChange(year);
+  },
+
+  shiftYears(amount) {
+    var years = this.state.yearsList.map(function(year) {
+      return year + amount;
+    });
+
+    this.setState({
+      yearsList: years
+    });
+  },
+
+  incrementYears() {
+    return this.shiftYears(1);
+  },
+
+  decrementYears() {
+    return this.shiftYears(-1);
+  }
+});
+
+module.exports = YearDropdownOptions;

--- a/test/year_dropdown_options_test.js
+++ b/test/year_dropdown_options_test.js
@@ -1,0 +1,57 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import TestUtils from "react-addons-test-utils";
+import YearDropdownOptions from "../src/year_dropdown_options.jsx";
+
+describe("YearDropdownOptions", () => {
+  var yearDropdown,
+      handleChangeResult;
+  var mockHandleChange = function(changeInput) {
+      handleChangeResult = changeInput;
+  };
+
+  beforeEach(function() {
+    yearDropdown = TestUtils.renderIntoDocument(
+      <YearDropdownOptions year={2015} onChange={mockHandleChange}/>
+    );
+  });
+
+  it("shows the available years in the initial view", () => {
+    var yearDropdownDOM = ReactDOM.findDOMNode(yearDropdown);
+    var yearDropdownNode = TestUtils.scryRenderedDOMComponentsWithTag(yearDropdown, "div");
+    expect(yearDropdownNode.length).to.equal(8);
+    expect(yearDropdownDOM.textContent).to.contain("2015");
+    expect(yearDropdownDOM.textContent).to.contain("2014");
+    expect(yearDropdownDOM.textContent).to.contain("2013");
+    expect(yearDropdownDOM.textContent).to.contain("2012");
+    expect(yearDropdownDOM.textContent).to.contain("2011");
+  });
+
+  it("increments the available years when the 'upcoming years' button is clicked", () => {
+    TestUtils.Simulate.click(yearDropdown.refs.upcoming);
+    var yearDropdownDOM = ReactDOM.findDOMNode(yearDropdown);
+    expect(yearDropdownDOM.textContent).to.contain("2016");
+    expect(yearDropdownDOM.textContent).to.contain("2015");
+    expect(yearDropdownDOM.textContent).to.contain("2014");
+    expect(yearDropdownDOM.textContent).to.contain("2013");
+    expect(yearDropdownDOM.textContent).to.contain("2012");
+    expect(yearDropdownDOM.textContent).to.not.contain("2011");
+  });
+
+  it("decrements the available years when the 'previous years' button is clicked", () => {
+    TestUtils.Simulate.click(yearDropdown.refs.previous);
+    var yearDropdownDOM = ReactDOM.findDOMNode(yearDropdown);
+    expect(yearDropdownDOM.textContent).to.not.contain("2015");
+    expect(yearDropdownDOM.textContent).to.contain("2014");
+    expect(yearDropdownDOM.textContent).to.contain("2013");
+    expect(yearDropdownDOM.textContent).to.contain("2012");
+    expect(yearDropdownDOM.textContent).to.contain("2011");
+    expect(yearDropdownDOM.textContent).to.contain("2010");
+  });
+
+  it("calls the supplied onChange function when a year is clicked", () => {
+    var yearDropdownNode = TestUtils.scryRenderedDOMComponentsWithTag(yearDropdown, "div");
+    TestUtils.Simulate.click(yearDropdownNode[2]);
+    expect(handleChangeResult).to.equal(2015);
+  });
+});

--- a/test/year_dropdown_options_test.js
+++ b/test/year_dropdown_options_test.js
@@ -10,9 +10,12 @@ describe("YearDropdownOptions", () => {
       handleChangeResult = changeInput;
   };
 
-  beforeEach(function() {
+  beforeEach(() => {
     yearDropdown = TestUtils.renderIntoDocument(
-      <YearDropdownOptions year={2015} onChange={mockHandleChange}/>
+      <YearDropdownOptions
+        year={2015}
+        onChange={mockHandleChange}
+        onCancel={() => {}} />
     );
   });
 

--- a/test/year_dropdown_test.js
+++ b/test/year_dropdown_test.js
@@ -2,8 +2,9 @@ import React from "react";
 import ReactDOM from "react-dom";
 import TestUtils from "react-addons-test-utils";
 import YearDropdown from "../src/year_dropdown.jsx";
+import YearDropdownOptions from "../src/year_dropdown_options.jsx";
 
-describe("YearDropdown", function() {
+describe("YearDropdown", () => {
   var yearDropdown,
       handleChangeResult;
   var mockHandleChange = function(changeInput) {
@@ -12,72 +13,53 @@ describe("YearDropdown", function() {
 
   beforeEach(function() {
     yearDropdown = TestUtils.renderIntoDocument(
-      <YearDropdown year={"2015"} onChange={mockHandleChange}/>
+      <YearDropdown year={2015} onChange={mockHandleChange}/>
     );
+    handleChangeResult = null;
   });
 
-  it("opens a list when read view is clicked", function(done) {
-    var readView = TestUtils.scryRenderedDOMComponentsWithTag(yearDropdown, "div");
-    TestUtils.Simulate.click(readView[1]);
+  it("shows the selected year in the initial view", () => {
     var yearDropdownDOM = ReactDOM.findDOMNode(yearDropdown);
-    var yearDropdownNode = TestUtils.scryRenderedDOMComponentsWithTag(yearDropdown, "div");
-    expect(yearDropdownNode.length).to.equal(9);
     expect(yearDropdownDOM.textContent).to.contain("2015");
-    expect(yearDropdownDOM.textContent).to.contain("2014");
-    expect(yearDropdownDOM.textContent).to.contain("2013");
-    expect(yearDropdownDOM.textContent).to.contain("2012");
-    expect(yearDropdownDOM.textContent).to.contain("2011");
-    done();
   });
 
-  it("increments the available years when the 'upcoming years' button is clicked", function(done) {
-    var readView = TestUtils.scryRenderedDOMComponentsWithTag(yearDropdown, "div");
-    TestUtils.Simulate.click(readView[1]);
-    var yearDropdownDOM = ReactDOM.findDOMNode(yearDropdown);
-    var yearDropdownNode = TestUtils.scryRenderedDOMComponentsWithTag(yearDropdown, "div");
-    TestUtils.Simulate.click(yearDropdownNode[2]);
-    expect(yearDropdownDOM.textContent).to.contain("2016");
-    expect(yearDropdownDOM.textContent).to.contain("2015");
-    expect(yearDropdownDOM.textContent).to.contain("2014");
-    expect(yearDropdownDOM.textContent).to.contain("2013");
-    expect(yearDropdownDOM.textContent).to.contain("2012");
-    expect(yearDropdownDOM.textContent).to.not.contain("2011");
-    done();
+  it("starts with the year options list hidden", () => {
+    var optionsView = TestUtils.scryRenderedComponentsWithType(yearDropdown, YearDropdownOptions);
+    expect(optionsView).to.be.empty;
   });
 
-  it("decrements the available years when the 'previous years' button is clicked", function(done) {
-    var readView = TestUtils.scryRenderedDOMComponentsWithTag(yearDropdown, "div");
-    TestUtils.Simulate.click(readView[1]);
-    var yearDropdownDOM = ReactDOM.findDOMNode(yearDropdown);
-    var yearDropdownNode = TestUtils.scryRenderedDOMComponentsWithTag(yearDropdown, "div");
-    TestUtils.Simulate.click(yearDropdownNode[8]);
-    expect(yearDropdownDOM.textContent).to.not.contain("2015");
-    expect(yearDropdownDOM.textContent).to.contain("2014");
-    expect(yearDropdownDOM.textContent).to.contain("2013");
-    expect(yearDropdownDOM.textContent).to.contain("2012");
-    expect(yearDropdownDOM.textContent).to.contain("2011");
-    expect(yearDropdownDOM.textContent).to.contain("2010");
-    done();
+  it("opens a list when read view is clicked", () => {
+    var readView = TestUtils.findRenderedDOMComponentWithClass(yearDropdown, "datepicker__year-read-view");
+    TestUtils.Simulate.click(readView);
+    var optionsView = TestUtils.findRenderedComponentWithType(yearDropdown, YearDropdownOptions);
+    expect(optionsView).to.exist;
   });
 
-  it("calls the supplied onChange function when a year is clicked", function(done) {
-    var readView = TestUtils.scryRenderedDOMComponentsWithTag(yearDropdown, "div");
-    TestUtils.Simulate.click(readView[1]);
-    var yearDropdownDOM = ReactDOM.findDOMNode(yearDropdown);
-    var yearDropdownNode = TestUtils.scryRenderedDOMComponentsWithTag(yearDropdown, "div");
-    TestUtils.Simulate.click(yearDropdownNode[3]);
-    expect(handleChangeResult).to.equal(2015);
-    done();
+  it("closes the dropdown when a year is clicked", () => {
+    var readView = TestUtils.findRenderedDOMComponentWithClass(yearDropdown, "datepicker__year-read-view");
+    TestUtils.Simulate.click(readView);
+    var optionsView = TestUtils.findRenderedComponentWithType(yearDropdown, YearDropdownOptions);
+    var optionNodes = TestUtils.scryRenderedDOMComponentsWithTag(optionsView, "div");
+    TestUtils.Simulate.click(optionNodes[2]);
+    var optionsViewAfterClick = TestUtils.scryRenderedComponentsWithType(yearDropdown, YearDropdownOptions);
+    expect(optionsViewAfterClick).to.be.empty;
   });
 
-  it("closes the dropdown when a year is clicked", function(done) {
-    var readView = TestUtils.scryRenderedDOMComponentsWithTag(yearDropdown, "div");
-    TestUtils.Simulate.click(readView[1]);
-    var yearDropdownDOM = ReactDOM.findDOMNode(yearDropdown);
-    var yearDropdownNode = TestUtils.scryRenderedDOMComponentsWithTag(yearDropdown, "div");
-    TestUtils.Simulate.click(yearDropdownNode[3]);
-    yearDropdownDOM = ReactDOM.findDOMNode(yearDropdown);
-    expect(yearDropdownDOM.textContent).to.equal("2015");
-    done();
+  it("does not call the supplied onChange function when the same year is clicked", () => {
+    var readView = TestUtils.findRenderedDOMComponentWithClass(yearDropdown, "datepicker__year-read-view");
+    TestUtils.Simulate.click(readView);
+    var optionsView = TestUtils.findRenderedComponentWithType(yearDropdown, YearDropdownOptions);
+    var optionNodes = TestUtils.scryRenderedDOMComponentsWithTag(optionsView, "div");
+    TestUtils.Simulate.click(optionNodes[2]);
+    expect(handleChangeResult).to.not.exist;
+  });
+
+  it("calls the supplied onChange function when a different year is clicked", () => {
+    var readView = TestUtils.findRenderedDOMComponentWithClass(yearDropdown, "datepicker__year-read-view");
+    TestUtils.Simulate.click(readView);
+    var optionsView = TestUtils.findRenderedComponentWithType(yearDropdown, YearDropdownOptions);
+    var optionNodes = TestUtils.scryRenderedDOMComponentsWithTag(optionsView, "div");
+    TestUtils.Simulate.click(optionNodes[3]);
+    expect(handleChangeResult).to.equal(2014);
   });
 });


### PR DESCRIPTION
Fixes #262

I refactored the year dropdown menu to separate the options into a separate component so that I could use `react-onclickoutside`.  As a bonus this improved the component's testability.