### PR TITLE
Fix bug with clearing dates

### DIFF
--- a/src/date_input.jsx
+++ b/src/date_input.jsx
@@ -28,7 +28,7 @@ var DateInput = React.createClass({
     // If we're receiving a different date then apply it.
     // If we're receiving a null date continue displaying the
     // value currently in the textbox.
-    if (newProps.date != null && newProps.date != this.props.date) {
+    if (newProps.date != this.props.date) {
         this.setState({
             maybeDate: this.safeDateFormat(newProps.date)
         });

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -2,6 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import TestUtils from "react-addons-test-utils";
 import DatePicker from "../src/datepicker.jsx";
+import moment from "moment";
 
 describe("DatePicker", () => {
   it("should show the calendar when focusing on the date input", () => {
@@ -24,5 +25,15 @@ describe("DatePicker", () => {
       expect(datePicker.refs.calendar).to.not.exist;
       done();
     }, 300);
+  });
+
+  it("should allow clearing the date when isClearable is true", () => {
+    var datePicker = TestUtils.renderIntoDocument(
+      <DatePicker isClearable={true} selected={moment("2015-12-15")} />
+    );
+    var clearButton = TestUtils.findRenderedDOMComponentWithClass(datePicker, "close-icon");
+    TestUtils.Simulate.click(clearButton);
+    var dateInput = datePicker.refs.input;
+    expect(ReactDOM.findDOMNode(dateInput).value).to.equal("");
   });
 });


### PR DESCRIPTION
The null check in date_input.jsx introduced a bug (from e39175a9) where the date was no longer clearable. Not sure why the null check was added, but removed it and added a test.