### PR TITLE
Add option to hide year dropdown menu

### DIFF
--- a/docs/src/example_components.jsx
+++ b/docs/src/example_components.jsx
@@ -18,6 +18,7 @@ import Weekdays from "./examples/weekdays";
 import Placement from "./examples/placement";
 import DateRange from "./examples/date_range";
 import TabIndex from "./examples/tab_index";
+import HideYearDropdown from "./examples/hide_year_dropdown";
 
 import "react-datepicker/dist/react-datepicker.css";
 import "./style.scss";
@@ -96,6 +97,10 @@ export default React.createClass({
     {
       title: "TabIndex",
       component: <TabIndex />
+    },
+    {
+      title: "Hide year dropdown",
+      component: <HideYearDropdown />
     }
   ],
 

--- a/docs/src/examples/hide_year_dropdown.jsx
+++ b/docs/src/examples/hide_year_dropdown.jsx
@@ -1,0 +1,40 @@
+import React from "react";
+import DatePicker from "react-datepicker";
+import moment from "moment";
+
+export default React.createClass({
+  displayName: "Weekdays",
+
+  getInitialState() {
+    return {
+      startDate: moment()
+    };
+  },
+
+  handleChange(date) {
+    this.setState({
+      startDate: date
+    });
+  },
+
+  render() {
+    return <div className="row">
+      <pre className="column example__code">
+        <code className="jsx">
+          {"<DatePicker"}<br />
+              {"selected={this.state.startDate}"}<br />
+              {"onChange={this.handleChange}"} <br />
+              {"showYearDropdown={false}"} <br />
+              {"dateFormatCalendar=\"MMMM YYYY\" />"}
+        </code>
+      </pre>
+      <div className="column">
+        <DatePicker
+          selected={this.state.startDate}
+          onChange={this.handleChange}
+          showYearDropdown={false}
+          dateFormatCalendar="MMMM YYYY" />
+      </div>
+    </div>;
+  }
+});

--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -169,6 +169,18 @@ var Calendar = React.createClass({
     });
   },
 
+  renderCurrentMonth() {
+    var classes = ["datepicker__current-month"];
+    if (this.props.showYearDropdown) {
+      classes.push("datepicker__current-month--hasYearDropdown");
+    }
+    return (
+      <div className={classes.join(" ")}>
+        {this.state.date.localeFormat(this.props.locale, this.props.dateFormat)}
+      </div>
+    );
+  },
+
   renderYearDropdown() {
     if (!this.props.showYearDropdown) {
       return;
@@ -188,9 +200,7 @@ var Calendar = React.createClass({
           <a className="datepicker__navigation datepicker__navigation--previous"
               onClick={this.decreaseMonth}>
           </a>
-          <h2 className="datepicker__current-month">
-            {this.state.date.localeFormat(this.props.locale, this.props.dateFormat)}
-          </h2>
+          {this.renderCurrentMonth()}
           {this.renderYearDropdown()}
           <a className="datepicker__navigation datepicker__navigation--next"
               onClick={this.increaseMonth}>

--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -33,7 +33,8 @@ var Calendar = React.createClass({
     endDate: React.PropTypes.object,
     excludeDates: React.PropTypes.array,
     includeDates: React.PropTypes.array,
-    weekStart: React.PropTypes.string.isRequired
+    weekStart: React.PropTypes.string.isRequired,
+    showYearDropdown: React.PropTypes.bool
   },
 
   handleClickOutside() {
@@ -48,7 +49,8 @@ var Calendar = React.createClass({
 
   getDefaultProps() {
     return {
-      weekStart: "1"
+      weekStart: "1",
+      showYearDropdown: true
     };
   },
 
@@ -167,6 +169,17 @@ var Calendar = React.createClass({
     });
   },
 
+  renderYearDropdown() {
+    if (!this.props.showYearDropdown) {
+      return;
+    }
+    return (
+      <YearDropdown
+        onChange={this.changeYear}
+        year={this.state.date.year()} />
+    );
+  },
+
   render() {
     return (
       <div className="datepicker" onClick={this.props.handleClick}>
@@ -178,10 +191,7 @@ var Calendar = React.createClass({
           <h2 className="datepicker__current-month">
             {this.state.date.localeFormat(this.props.locale, this.props.dateFormat)}
           </h2>
-          <YearDropdown
-              onChange={this.changeYear}
-              year={this.state.date.year()}
-          />
+          {this.renderYearDropdown()}
           <a className="datepicker__navigation datepicker__navigation--next"
               onClick={this.increaseMonth}>
           </a>

--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -18,6 +18,7 @@ var DatePicker = React.createClass({
     popoverTargetAttachment: React.PropTypes.string,
     popoverTargetOffset: React.PropTypes.string,
     weekStart: React.PropTypes.string,
+    showYearDropdown: React.PropTypes.bool,
     onChange: React.PropTypes.func.isRequired,
     onBlur: React.PropTypes.func,
     onFocus: React.PropTypes.func,
@@ -33,7 +34,8 @@ var DatePicker = React.createClass({
       onChange() {},
       disabled: false,
       onFocus() {},
-      onBlur() {}
+      onBlur() {},
+      showYearDropdown: true
     };
   },
 
@@ -154,7 +156,8 @@ var DatePicker = React.createClass({
             excludeDates={this.props.excludeDates}
             handleClick={this.onInputClick}
             includeDates={this.props.includeDates}
-            weekStart={this.props.weekStart} />
+            weekStart={this.props.weekStart}
+            showYearDropdown={this.props.showYearDropdown} />
         </Popover>
       );
     }

--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -46,6 +46,10 @@
   color: #000;
   font-weight: bold;
   font-size: 13px;
+
+  &--hasYearDropdown {
+    margin-bottom: 16px;
+  }
 }
 
 .datepicker__navigation {

--- a/test/calendar_test.js
+++ b/test/calendar_test.js
@@ -3,6 +3,7 @@ import TestUtils from "react-addons-test-utils";
 import moment from "moment";
 import DateUtil from "../src/util/date";
 import Calendar from "../src/calendar";
+import YearDropdown from "../src/year_dropdown";
 
 describe("Calendar", function() {
   function getCalendar(extraProps) {
@@ -41,5 +42,17 @@ describe("Calendar", function() {
     var maxDate = moment().subtract(1, "year");
     var calendar = TestUtils.renderIntoDocument(getCalendar({ maxDate }));
     assert(calendar.state.date.sameDay(new DateUtil(maxDate)));
+  });
+
+  it("should show the year dropdown menu by default", function() {
+    var calendar = TestUtils.renderIntoDocument(getCalendar());
+    var yearReadView = TestUtils.findRenderedComponentWithType(calendar, YearDropdown);
+    expect(yearReadView).to.exist;
+  });
+
+  it("should not show the year dropdown menu if toggled off", function() {
+    var calendar = TestUtils.renderIntoDocument(getCalendar({ showYearDropdown: false }));
+    var yearReadView = TestUtils.scryRenderedComponentsWithType(calendar, YearDropdown);
+    expect(yearReadView).to.be.empty;
   });
 });


### PR DESCRIPTION
In many of my use cases, the user will be selecting dates near the present and will rarely need to navigate several years.  Having the year dropdown menu on a separate line takes up valuable screen real estate and IMO somewhat spoils the sleek look of the date picker.  This PR adds a `showYearDropdown` option to toggle its display (default true).