### PR TITLE
Don't modify dates when calling inRange

### DIFF
--- a/src/util/date.js
+++ b/src/util/date.js
@@ -20,8 +20,8 @@ DateUtil.prototype.sameMonth = function(other) {
 
 DateUtil.prototype.inRange = function(startDate, endDate) {
   if (!startDate || !endDate) return false;
-  var before = startDate._date.startOf("day").subtract(1, "seconds");
-  var after = endDate._date.startOf("day").add(1, "seconds");
+  var before = startDate._date.clone().startOf("day").subtract(1, "seconds");
+  var after = endDate._date.clone().startOf("day").add(1, "seconds");
   return this._date.isBetween(before, after);
 };
 

--- a/test/util/date_test.js
+++ b/test/util/date_test.js
@@ -140,6 +140,18 @@ describe("DateUtil", function() {
 
       expect(date.inRange(startDate, null)).to.eq(false);
     });
+
+    it("does not modify the input dates", function() {
+      var startDate = new DateUtil(moment("2014-02-09"));
+      var endDate = new DateUtil(moment("2014-02-10"));
+      var startDateClone = startDate.clone();
+      var endDateClone = endDate.clone();
+      var date = new DateUtil(moment("2014-02-09"));
+      date.inRange(startDate, endDate);
+
+      expect(startDate.moment().isSame(startDateClone.moment())).to.eq(true);
+      expect(endDate.moment().isSame(endDateClone.moment())).to.eq(true);
+    });
   });
 
   describe("#day", function() {


### PR DESCRIPTION
Fixes #267 

The `inRange` method is modifying the input dates, which cascades into other failures.