### PR TITLE
Remove Object.assign for node v0.12 compatibility

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,7 +1,8 @@
 var path = require("path");
 var express = require("express");
 var webpack = require("webpack");
-var config = Object.assign({}, require("./webpack.docs.config"));
+var merge = require("lodash/object/merge");
+var config = merge({}, require("./webpack.docs.config"));
 
 config.devtool = "cheap-module-eval-source-map";
 config.entry.unshift("webpack-hot-middleware/client");


### PR DESCRIPTION
Most of my dev'ing happens on a box running node v0.12.  This is the only line that needs to be changed to make running the docs page compatible.