### PR TITLE
Add on clear callback

### DIFF
--- a/docs/src/example_components.jsx
+++ b/docs/src/example_components.jsx
@@ -14,6 +14,7 @@ import IncludeDates from "./examples/include_dates";
 import Disabled from "./examples/disabled";
 import ClearInput from "./examples/clear_input";
 import OnBlurCallbacks from "./examples/on_blur_callbacks";
+import OnClearCallbacks from "./examples/on_clear_callbacks";
 import Weekdays from "./examples/weekdays";
 import Placement from "./examples/placement";
 import DateRange from "./examples/date_range";
@@ -85,6 +86,10 @@ export default React.createClass({
     {
       title: "onBlur callbacks in console",
       component: <OnBlurCallbacks />
+    },
+    {
+      title: "onClear callbacks in console",
+      component: <OnClearCallbacks />
     },
     {
       title: "Custom weekdays",

--- a/docs/src/examples/on_clear_callbacks.jsx
+++ b/docs/src/examples/on_clear_callbacks.jsx
@@ -1,0 +1,58 @@
+import React from "react";
+import DatePicker from "react-datepicker";
+import moment from "moment";
+
+export default React.createClass({
+  displayName: "Disabled",
+
+  getInitialState() {
+    return {
+      startDate: null
+    };
+  },
+
+  handleChange: function (date) {
+    this.setState({
+      startDate: date
+    });
+  },
+
+  handleOnClear: function () {
+    console.log("Date has been cleared");
+  },
+
+  render() {
+    return <div className="row">
+      <pre className="column example__code">
+        <code className="js">
+          {"handleOnClear: function (date) {"}<br />
+              {"if (date === null) {"}<br />
+                  {"console.log('selected date: %s', date);"}<br />
+              {"}"}<br />
+              {"else {"}<br />
+                  {"console.log('selected date: %s', date.format('DD/MM/YYYY'));"}<br />
+              {"}"}<br />
+          {"};"}
+        </code>
+        <br />
+        <code className="jsx">
+          {"<DatePicker"}<br />
+              {"key='example9'"}<br />
+              {"selected={this.state.startDate}"}<br />
+              {"onChange={this.handleChange}"}<br />
+          <strong>    {"onClear={this.handleOnClear}"}</strong><br />
+              {"placeholderText=\"View clear callbacks in console\" />"}
+        </code>
+      </pre>
+      <div className="column">
+        <DatePicker
+          key="example9"
+          selected={this.state.startDate}
+          onChange={this.handleChange}
+          onClear={this.handleOnClear}
+          isClearable={true}
+          placeholderText="View clear callbacks in console" />
+      </div>
+    </div>;
+  }
+});

--- a/docs/src/examples/on_clear_callbacks.jsx
+++ b/docs/src/examples/on_clear_callbacks.jsx
@@ -3,7 +3,7 @@ import DatePicker from "react-datepicker";
 import moment from "moment";
 
 export default React.createClass({
-  displayName: "Disabled",
+  displayName: "ClearCallbacks",
 
   getInitialState() {
     return {
@@ -26,12 +26,7 @@ export default React.createClass({
       <pre className="column example__code">
         <code className="js">
           {"handleOnClear: function (date) {"}<br />
-              {"if (date === null) {"}<br />
-                  {"console.log('selected date: %s', date);"}<br />
-              {"}"}<br />
-              {"else {"}<br />
-                  {"console.log('selected date: %s', date.format('DD/MM/YYYY'));"}<br />
-              {"}"}<br />
+            {"console.log('Date has been cleared');"}<br />
           {"};"}
         </code>
         <br />
@@ -41,6 +36,7 @@ export default React.createClass({
               {"selected={this.state.startDate}"}<br />
               {"onChange={this.handleChange}"}<br />
           <strong>    {"onClear={this.handleOnClear}"}</strong><br />
+              {"isClearable={true}"}<br />
               {"placeholderText=\"View clear callbacks in console\" />"}
         </code>
       </pre>

--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -23,6 +23,7 @@ var DatePicker = React.createClass({
     onChange: React.PropTypes.func.isRequired,
     onBlur: React.PropTypes.func,
     onFocus: React.PropTypes.func,
+    onClear: React.PropTypes.func,
     tabIndex: React.PropTypes.number
   },
 
@@ -35,7 +36,8 @@ var DatePicker = React.createClass({
       onChange() {},
       disabled: false,
       onFocus() {},
-      onBlur() {}
+      onBlur() {},
+      onClear(){}
     };
   },
 
@@ -136,6 +138,7 @@ var DatePicker = React.createClass({
     this.setState({
       selected: null
     }, () => {
+      this.props.onClear();
       this.props.onChange(null);
     });
   },

--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -37,7 +37,7 @@ var DatePicker = React.createClass({
       disabled: false,
       onFocus() {},
       onBlur() {},
-      onClear(){}
+      onClear() {}
     };
   },
 


### PR DESCRIPTION
Sometimes it is useful to have different callbacks for on change and on clear events. For example in on change handler we can't distinguish incorrect data input from clear button click because in both cases the handler will receive null. Of course there are maybe another use cases.