### PR TITLE
Make datepicker to be editable by user input

### DIFF
--- a/docs/src/example_components.jsx
+++ b/docs/src/example_components.jsx
@@ -15,6 +15,7 @@ import Disabled from "./examples/disabled";
 import ClearInput from "./examples/clear_input";
 import OnBlurCallbacks from "./examples/on_blur_callbacks";
 import OnClearCallbacks from "./examples/on_clear_callbacks";
+import Typeable from "./examples/typeable.jsx";
 import Weekdays from "./examples/weekdays";
 import Placement from "./examples/placement";
 import DateRange from "./examples/date_range";
@@ -50,6 +51,10 @@ export default React.createClass({
     {
       title: "Custom class name",
       component: <CustomClassName />
+    },
+    {
+      title: "Editable by user input",
+      component: <Typeable />
     },
     {
       title: "Placeholder text",

--- a/docs/src/examples/typeable.jsx
+++ b/docs/src/examples/typeable.jsx
@@ -1,0 +1,56 @@
+import React from "react";
+import DatePicker from "react-datepicker";
+import moment from "moment";
+
+export default React.createClass({
+  displayName: "Typeable",
+
+  getInitialState() {
+    return {
+      startDate: null
+    };
+  },
+
+  handleChange: function (date) {
+    this.setState({
+      startDate: date
+    });
+  },
+
+  handleOnClear: function () {
+    console.log("Date has been cleared");
+  },
+
+  render() {
+    return <div className="row">
+      <pre className="column example__code">
+        <code className="js">
+          {"handleOnClear: function (date) {"}<br />
+            {"console.log('Date has been cleared');"}<br />
+          {"};"}
+        </code>
+        <br />
+        <code className="jsx">
+          {"<DatePicker"}<br />
+              {"key='example9'"}<br />
+              {"selected={this.state.startDate}"}<br />
+              {"onChange={this.handleChange}"}<br />
+              {"onClear={this.handleOnClear}"}<br />
+              {"isClearable={true}"}<br />
+              <strong>{"isTypeable={true}"}</strong><br />
+              {"placeholderText=\"View clear callbacks in console\" />"}
+        </code>
+      </pre>
+      <div className="column">
+        <DatePicker
+          key="example9"
+          selected={this.state.startDate}
+          onChange={this.handleChange}
+          onClear={this.handleOnClear}
+          isClearable={true}
+          isTypeable={true}
+          placeholderText="View clear callbacks in console" />
+      </div>
+    </div>;
+  }
+});

--- a/docs/src/hero_example.jsx
+++ b/docs/src/hero_example.jsx
@@ -20,6 +20,7 @@ export default React.createClass({
   render() {
     return <DatePicker
         selected={this.state.startDate}
-        onChange={this.handleChange} />;
+        onChange={this.handleChange}
+        isTypeable={true} />;
   }
 });

--- a/src/date_input.jsx
+++ b/src/date_input.jsx
@@ -25,10 +25,19 @@ var DateInput = React.createClass({
   componentWillReceiveProps(newProps) {
     this.toggleFocus(newProps.focus);
 
+    // It checks that user is typing some date and
+    // we should skipp updating because it would clear date input.
+    // In particular, it checks that we pass the typeable flag in datepicker props
+    // and that input has focus
+    // and that new date is null (when input date is invalid the "this.props.invalidateSelected()" method sets state as null).
+    // The main disadvantage of this approach is that it is imposible to clear date
+    // while the input has focus.
+    var doesUserType = newProps.isTypeable && newProps.focus && !newProps.date;
+
     // If we're receiving a different date then apply it.
     // If we're receiving a null date continue displaying the
     // value currently in the textbox.
-    if (newProps.date != this.props.date) {
+    if (newProps.date != this.props.date && !doesUserType) {
         this.setState({
             maybeDate: this.safeDateFormat(newProps.date)
         });
@@ -48,7 +57,7 @@ var DateInput = React.createClass({
     var date = moment(value, this.props.dateFormat, true);
 
     if (date.isValid()) {
-      this.props.setSelected(new DateUtil(date));
+        this.props.setSelected(new DateUtil(date));
     } else {
         this.props.invalidateSelected();
     }

--- a/src/date_input.jsx
+++ b/src/date_input.jsx
@@ -29,7 +29,8 @@ var DateInput = React.createClass({
     // we should skipp updating because it would clear date input.
     // In particular, it checks that we pass the typeable flag in datepicker props
     // and that input has focus
-    // and that new date is null (when input date is invalid the "this.props.invalidateSelected()" method sets state as null).
+    // and that new date is null (when input date is invalid the "this.props.invalidateSelected()"
+    // method sets state as null).
     // The main disadvantage of this approach is that it is imposible to clear date
     // while the input has focus.
     var doesUserType = newProps.isTypeable && newProps.focus && !newProps.date;

--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -24,7 +24,8 @@ var DatePicker = React.createClass({
     onBlur: React.PropTypes.func,
     onFocus: React.PropTypes.func,
     onClear: React.PropTypes.func,
-    tabIndex: React.PropTypes.number
+    tabIndex: React.PropTypes.number,
+    isTypeable: React.PropTypes.bool
   },
 
   getDefaultProps() {
@@ -37,7 +38,8 @@ var DatePicker = React.createClass({
       disabled: false,
       onFocus() {},
       onBlur() {},
-      onClear() {}
+      onClear() {},
+      isTypeable: false
     };
   },
 
@@ -204,7 +206,8 @@ var DatePicker = React.createClass({
           title={this.props.title}
           readOnly={this.props.readOnly}
           required={this.props.required}
-          tabIndex={this.props.tabIndex} />
+          tabIndex={this.props.tabIndex}
+          isTypeable={this.props.isTypeable} />
         {clearButton}
         {this.props.disabled ? null : this.calendar()}
       </div>

--- a/test/date_input_test.js
+++ b/test/date_input_test.js
@@ -57,7 +57,7 @@ describe("DateInput", function() {
     }, 300);
   });
 
-  it("demonstrates that it is impossible to retype date without 'isTypeable' flag", function(done){
+  it("demonstrates that it is impossible to retype date without 'isTypeable' flag", function(done) {
     var DatePickerWrapper = React.createClass({
       getInitialState() {
         return {
@@ -72,7 +72,7 @@ describe("DateInput", function() {
       },
 
       render() {
-        return <DatePicker selected={this.state.startDate} onChange={this.handleChange} ref={'datePicker'} />
+        return <DatePicker selected={this.state.startDate} onChange={this.handleChange} ref={"datePicker"} />
       }
     });
 
@@ -84,15 +84,15 @@ describe("DateInput", function() {
     TestUtils.Simulate.focus(ReactDOM.findDOMNode(dateInput));
 
     setTimeout(() => {
-      TestUtils.Simulate.change(ReactDOM.findDOMNode(dateInput), { target: { value: '2015-12-08' }});
-      expect(dateInput.state.maybeDate).to.be.equal('2015-12-08');
-      TestUtils.Simulate.change(ReactDOM.findDOMNode(dateInput), { target: { value: '2015-12-0' }});
+      TestUtils.Simulate.change(ReactDOM.findDOMNode(dateInput), { target: { value: "2015-12-08" } });
+      expect(dateInput.state.maybeDate).to.be.equal("2015-12-08");
+      TestUtils.Simulate.change(ReactDOM.findDOMNode(dateInput), { target: { value: "2015-12-0" } });
       expect(dateInput.state.maybeDate).to.be.equal(null);
       done();
     }, 300);
   });
 
-  it("types custom date", function(done){
+  it("types custom date", function(done) {
     var DatePickerWrapper = React.createClass({
       getInitialState() {
         return {
@@ -123,10 +123,10 @@ describe("DateInput", function() {
     TestUtils.Simulate.focus(ReactDOM.findDOMNode(dateInput));
 
     setTimeout(() => {
-      TestUtils.Simulate.change(ReactDOM.findDOMNode(dateInput), { target: { value: '2015-12-08' }});
-      expect(dateInput.state.maybeDate).to.be.equal('2015-12-08');
-      TestUtils.Simulate.change(ReactDOM.findDOMNode(dateInput), { target: { value: '2015-12-0' }});
-      expect(dateInput.state.maybeDate).to.be.equal('2015-12-0');
+      TestUtils.Simulate.change(ReactDOM.findDOMNode(dateInput), { target: { value: "2015-12-08" } });
+      expect(dateInput.state.maybeDate).to.be.equal("2015-12-08");
+      TestUtils.Simulate.change(ReactDOM.findDOMNode(dateInput), { target: { value: "2015-12-0" } });
+      expect(dateInput.state.maybeDate).to.be.equal("2015-12-0");
       done();
     }, 300);
   });

--- a/test/date_input_test.js
+++ b/test/date_input_test.js
@@ -72,7 +72,7 @@ describe("DateInput", function() {
       },
 
       render() {
-        return <DatePicker selected={this.state.startDate} onChange={this.handleChange} ref={"datePicker"} />
+        return <DatePicker selected={this.state.startDate} onChange={this.handleChange} ref={"datePicker"} />;
       }
     });
 
@@ -111,7 +111,7 @@ describe("DateInput", function() {
               selected={this.state.startDate}
               onChange={this.handleChange}
               isTypeable={true}
-              ref={'datePicker'} />
+              ref={"datePicker"} />;
       }
     });
 

--- a/test/date_input_test.js
+++ b/test/date_input_test.js
@@ -1,4 +1,5 @@
 import React from "react";
+import moment from "moment";
 import ReactDOM from "react-dom";
 import TestUtils from "react-addons-test-utils";
 import DatePicker from "../src/datepicker.jsx";
@@ -52,6 +53,80 @@ describe("DateInput", function() {
     }, 300);
     setTimeout(() => {
       expect(datePicker.refs.calendar).to.not.exist;
+      done();
+    }, 300);
+  });
+
+  it("demonstrates that it is impossible to retype date without 'isTypeable' flag", function(done){
+    var DatePickerWrapper = React.createClass({
+      getInitialState() {
+        return {
+          startDate: moment()
+        };
+      },
+
+      handleChange(date) {
+        this.setState({
+          startDate: date
+        });
+      },
+
+      render() {
+        return <DatePicker selected={this.state.startDate} onChange={this.handleChange} ref={'datePicker'} />
+      }
+    });
+
+    var datepicker = TestUtils.renderIntoDocument(
+      <DatePickerWrapper />
+    );
+
+    var dateInput = datepicker.refs.datePicker.refs.input;
+    TestUtils.Simulate.focus(ReactDOM.findDOMNode(dateInput));
+
+    setTimeout(() => {
+      TestUtils.Simulate.change(ReactDOM.findDOMNode(dateInput), { target: { value: '2015-12-08' }});
+      expect(dateInput.state.maybeDate).to.be.equal('2015-12-08');
+      TestUtils.Simulate.change(ReactDOM.findDOMNode(dateInput), { target: { value: '2015-12-0' }});
+      expect(dateInput.state.maybeDate).to.be.equal(null);
+      done();
+    }, 300);
+  });
+
+  it("types custom date", function(done){
+    var DatePickerWrapper = React.createClass({
+      getInitialState() {
+        return {
+          startDate: moment()
+        };
+      },
+
+      handleChange(date) {
+        this.setState({
+          startDate: date
+        });
+      },
+
+      render() {
+        return <DatePicker
+              selected={this.state.startDate}
+              onChange={this.handleChange}
+              isTypeable={true}
+              ref={'datePicker'} />
+      }
+    });
+
+    var datepicker = TestUtils.renderIntoDocument(
+      <DatePickerWrapper />
+    );
+
+    var dateInput = datepicker.refs.datePicker.refs.input;
+    TestUtils.Simulate.focus(ReactDOM.findDOMNode(dateInput));
+
+    setTimeout(() => {
+      TestUtils.Simulate.change(ReactDOM.findDOMNode(dateInput), { target: { value: '2015-12-08' }});
+      expect(dateInput.state.maybeDate).to.be.equal('2015-12-08');
+      TestUtils.Simulate.change(ReactDOM.findDOMNode(dateInput), { target: { value: '2015-12-0' }});
+      expect(dateInput.state.maybeDate).to.be.equal('2015-12-0');
       done();
     }, 300);
   });

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -40,6 +40,16 @@ describe("DatePicker", () => {
     expect(ReactDOM.findDOMNode(dateInput).value).to.equal("");
   });
 
+  it("should allow clearing the date when isClearable is true and isTypeable is true", () => {
+    var datePicker = TestUtils.renderIntoDocument(
+      <DatePicker isClearable={true} selected={moment("2015-12-15")} isTypeable={true} />
+    );
+    var clearButton = TestUtils.findRenderedDOMComponentWithClass(datePicker, "close-icon");
+    TestUtils.Simulate.click(clearButton);
+    var dateInput = datePicker.refs.input;
+    expect(ReactDOM.findDOMNode(dateInput).value).to.equal("");
+  });
+
   it("should not hide the calendar if multiple clicks are made in a short interval", done => {
     var datePicker = TestUtils.renderIntoDocument(
       <DatePicker />


### PR DESCRIPTION
This improvement is connected with #250 issue. I haven't found better solution to make this enhancment and this one has one disadvantage that it is impossible to reset date to null when the date input has focus. 

P.S. I named the datepicker prop as 'isTypeable' because 'isEditable' may confuse user like it is imposible to change date.