### PR TITLE
Refactor calendar open state

### DIFF
--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -24,7 +24,7 @@ var Calendar = React.createClass({
     moment: React.PropTypes.func.isRequired,
     dateFormat: React.PropTypes.string.isRequired,
     onSelect: React.PropTypes.func.isRequired,
-    handleClick: React.PropTypes.func.isRequired,
+    onClickOutside: React.PropTypes.func.isRequired,
     minDate: React.PropTypes.object,
     maxDate: React.PropTypes.object,
     startDate: React.PropTypes.object,
@@ -37,7 +37,7 @@ var Calendar = React.createClass({
   },
 
   handleClickOutside(event) {
-    this.props.handleClick(event);
+    this.props.onClickOutside(event);
   },
 
   getInitialState() {
@@ -132,7 +132,7 @@ var Calendar = React.createClass({
 
   render() {
     return (
-      <div className="datepicker" onClick={this.props.handleClick}>
+      <div className="datepicker">
         <div className="datepicker__triangle"></div>
         <div className="datepicker__header">
           <a className="datepicker__navigation datepicker__navigation--previous"

--- a/src/date_input.jsx
+++ b/src/date_input.jsx
@@ -17,28 +17,11 @@ var DateInput = React.createClass({
     });
   },
 
-  componentDidMount() {
-    this.toggleFocus(this.props.focus);
-  },
-
   componentWillReceiveProps(newProps) {
-    this.toggleFocus(newProps.focus);
-
-    // If we're receiving a different date then apply it.
-    // If we're receiving a null date continue displaying the
-    // value currently in the textbox.
     if (newProps.date != this.props.date) {
         this.setState({
             maybeDate: this.safeDateFormat(newProps.date)
         });
-    }
-  },
-
-  toggleFocus(focus) {
-    if (focus) {
-      this.refs.input.focus();
-    } else {
-      this.refs.input.blur();
     }
   },
 
@@ -62,7 +45,9 @@ var DateInput = React.createClass({
   handleKeyDown(event) {
     if (event.key === "Enter" || event.key === "Escape") {
       event.preventDefault();
-      this.props.hideCalendar();
+      this.props.handleDone();
+    } else if (event.key === "Tab") {
+      this.props.handleDone();
     }
   },
 
@@ -70,6 +55,10 @@ var DateInput = React.createClass({
     if (!this.props.disabled) {
       this.props.handleClick(event);
     }
+  },
+
+  focus() {
+    this.refs.input.focus();
   },
 
   getClassNames() {

--- a/src/date_input.jsx
+++ b/src/date_input.jsx
@@ -5,6 +5,10 @@ import classnames from "classnames";
 
 var DateInput = React.createClass({
 
+  propTypes: {
+    open: React.PropTypes.bool
+  },
+
   getDefaultProps() {
     return {
       dateFormat: "YYYY-MM-DD"
@@ -64,7 +68,7 @@ var DateInput = React.createClass({
   getClassNames() {
     return classnames(
       "datepicker__input",
-      "ignore-react-onclickoutside",
+      { "ignore-react-onclickoutside": this.props.open },
       this.props.className);
   },
 

--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -154,7 +154,8 @@ var DatePicker = React.createClass({
           title={this.props.title}
           readOnly={this.props.readOnly}
           required={this.props.required}
-          tabIndex={this.props.tabIndex} />
+          tabIndex={this.props.tabIndex}
+          open={this.state.open} />
         {this.renderClearButton()}
         {this.props.disabled ? null : this.calendar()}
       </div>

--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -4,7 +4,6 @@ import DateInput from "./date_input";
 import Calendar from "./calendar";
 import Popover from "./popover";
 import React from "react";
-import ReactDOM from "react-dom";
 
 var DatePicker = React.createClass({
 
@@ -42,7 +41,7 @@ var DatePicker = React.createClass({
 
   getInitialState() {
     return {
-      focus: false
+      open: false
     };
   },
 
@@ -50,44 +49,30 @@ var DatePicker = React.createClass({
     return !(isEqual(nextProps, this.props) && isEqual(nextState, this.state));
   },
 
-  handleFocus() {
-    this.props.onFocus();
-    setTimeout(() => {
-      this.setState({ focus: true });
-    }, 200);
+  setOpen(open) {
+    this.setState({ open });
   },
 
-  handleBlur() {
-    setTimeout(() => {
-      if (!this.state.datePickerHasFocus) {
-        this.props.onBlur();
-        this.hideCalendar();
-      }
-    }, 200);
+  handleFocus(event) {
+    this.props.onFocus(event);
+    this.setOpen(true);
   },
 
-  hideCalendar() {
-    setTimeout(() => {
-      this.setState({
-        focus: false
-      });
-    }, 0);
-  },
-
-  doesDatePickerContainElement(element) {
-    var datePicker = ReactDOM.findDOMNode(this.refs.calendar);
-    if (!datePicker) {
-      return false;
+  handleBlur(event) {
+    if (this.state.open) {
+      this.refs.input.focus();
+    } else {
+      this.props.onBlur(event);
     }
-    return datePicker.contains(element);
+  },
+
+  handleCalendarClickOutside(event) {
+    this.setOpen(false);
   },
 
   handleSelect(date) {
     this.setSelected(date);
-
-    setTimeout(() => {
-      this.hideCalendar();
-    }, 200);
+    this.setOpen(false);
   },
 
   setSelected(date) {
@@ -96,18 +81,12 @@ var DatePicker = React.createClass({
     }
   },
 
-  onInputClick(event) {
-    var previousFocusState = this.state.focus;
+  onInputClick() {
+    this.setOpen(true);
+  },
 
-    this.setState({
-      focus: (event.target === ReactDOM.findDOMNode(this.refs.input) ? !this.state.focus : true),
-      datePickerHasFocus: this.doesDatePickerContainElement(event.target)
-    }, () => {
-      this.forceUpdate();
-      if (previousFocusState && !this.state.datePickerHasFocus) {
-        this.hideCalendar();
-      }
-    });
+  handleInputDone() {
+    this.setOpen(false);
   },
 
   onClearClick(event) {
@@ -116,7 +95,7 @@ var DatePicker = React.createClass({
   },
 
   calendar() {
-    if (this.state.focus) {
+    if (this.state.open) {
       return (
         <Popover
           attachment={this.props.popoverAttachment}
@@ -132,14 +111,13 @@ var DatePicker = React.createClass({
             dateFormat={this.props.dateFormatCalendar}
             selected={this.props.selected}
             onSelect={this.handleSelect}
-            hideCalendar={this.hideCalendar}
             minDate={this.props.minDate}
             maxDate={this.props.maxDate}
             startDate={this.props.startDate}
             endDate={this.props.endDate}
             excludeDates={this.props.excludeDates}
             filterDate={this.props.filterDate}
-            handleClick={this.onInputClick}
+            onClickOutside={this.handleCalendarClickOutside}
             includeDates={this.props.includeDates}
             weekStart={this.props.weekStart}
             showYearDropdown={this.props.showYearDropdown} />
@@ -165,11 +143,10 @@ var DatePicker = React.createClass({
           name={this.props.name}
           date={this.props.selected}
           dateFormat={this.props.dateFormat}
-          focus={this.state.focus}
           onFocus={this.handleFocus}
           onBlur={this.handleBlur}
           handleClick={this.onInputClick}
-          hideCalendar={this.hideCalendar}
+          handleDone={this.handleInputDone}
           setSelected={this.setSelected}
           placeholderText={this.props.placeholderText}
           disabled={this.props.disabled}

--- a/test/calendar_test.js
+++ b/test/calendar_test.js
@@ -12,7 +12,7 @@ describe("Calendar", function() {
       moment={moment}
       dateFormat="MMMM"
       onSelect={() => {}}
-      handleClick={() => {}}
+      onClickOutside={() => {}}
       hideCalendar={() => {}}
       {...extraProps} />;
   }

--- a/test/date_input_test.js
+++ b/test/date_input_test.js
@@ -6,34 +6,21 @@ import DatePicker from "../src/datepicker.jsx";
 import DateInput from "../src/date_input.jsx";
 
 describe("DateInput", function() {
-  it("hides calendar when the Enter key is pressed", function() {
-    var date = moment();
-    var handlerCalled = false;
-    function hideCalendar() {
-      handlerCalled = true;
+  describe("handleDone", function() {
+    function testHandleDoneWithKey(key) {
+      it(`calls handleDone when the ${key} key is pressed`, function() {
+        var spy = sinon.spy();
+        var dateInput = TestUtils.renderIntoDocument(
+          <DateInput handleDone={spy} />
+        );
+        TestUtils.Simulate.keyDown(ReactDOM.findDOMNode(dateInput), { key });
+        expect(spy.calledOnce).to.be.true;
+      });
     }
 
-    var dateInput = TestUtils.renderIntoDocument(
-      <DateInput date={date} hideCalendar={hideCalendar} />
-    );
-
-    TestUtils.Simulate.keyDown(ReactDOM.findDOMNode(dateInput), { key: "Enter" });
-    expect(handlerCalled).to.be.true;
-  });
-
-  it("hides calendar when the Escape key is pressed", function() {
-    var date = moment();
-    var handlerCalled = false;
-    function hideCalendar() {
-      handlerCalled = true;
-    }
-
-    var dateInput = TestUtils.renderIntoDocument(
-      <DateInput date={date} hideCalendar={hideCalendar} />
-    );
-
-    TestUtils.Simulate.keyDown(ReactDOM.findDOMNode(dateInput), { key: "Escape" });
-    expect(handlerCalled).to.be.true;
+    testHandleDoneWithKey("Enter");
+    testHandleDoneWithKey("Escape");
+    testHandleDoneWithKey("Tab");
   });
 
   it("adds disabled attribute to input field when disabled is passed as prop", function() {
@@ -59,22 +46,6 @@ describe("DateInput", function() {
     );
 
     expect(ReactDOM.findDOMNode(dateInput).tabIndex).to.equal(1);
-  });
-
-  it("toggles the calendar on and off when clicked", function(done) {
-    var datePicker = TestUtils.renderIntoDocument(
-      <DatePicker />
-    );
-    var dateInput = datePicker.refs.input;
-    TestUtils.Simulate.click(ReactDOM.findDOMNode(dateInput));
-    setTimeout(() => {
-      expect(datePicker.refs.calendar).to.exist;
-      TestUtils.Simulate.click(ReactDOM.findDOMNode(dateInput));
-    }, 300);
-    setTimeout(() => {
-      expect(datePicker.refs.calendar).to.not.exist;
-      done();
-    }, 300);
   });
 
   it("should call setSelected when changing from null to valid date", function() {

--- a/test/date_input_test.js
+++ b/test/date_input_test.js
@@ -115,4 +115,18 @@ describe("DateInput", function() {
     assert(callback.calledOnce, "must be called once");
     assert(dateTo.isSame(callback.getCall(0).args[0], "day"), "must be called with correct date");
   });
+
+  it("should not have the ignore-react-onclickoutside class when closed so other pickers will close", function() {
+    var dateInput = TestUtils.renderIntoDocument(
+      <DateInput />
+    );
+    expect(ReactDOM.findDOMNode(dateInput).className).to.not.contain("ignore-react-onclickoutside");
+  });
+
+  it("should have the ignore-react-onclickoutside class when open to prevent closing", function() {
+    var dateInput = TestUtils.renderIntoDocument(
+      <DateInput open />
+    );
+    expect(ReactDOM.findDOMNode(dateInput).className).to.contain("ignore-react-onclickoutside");
+  });
 });

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -2,32 +2,83 @@ import React from "react";
 import ReactDOM from "react-dom";
 import TestUtils from "react-addons-test-utils";
 import DatePicker from "../src/datepicker.jsx";
+import Day from "../src/day";
 import moment from "moment";
 
 describe("DatePicker", () => {
-  it("should show the calendar when focusing on the date input", done => {
+  it("should show the calendar when focusing on the date input", () => {
     var datePicker = TestUtils.renderIntoDocument(
       <DatePicker />
     );
     var dateInput = datePicker.refs.input;
     TestUtils.Simulate.focus(ReactDOM.findDOMNode(dateInput));
-    setTimeout(() => {
-      expect(datePicker.refs.calendar).to.exist;
-      done();
-    }, 200);
+    expect(datePicker.refs.calendar).to.exist;
   });
 
-  it("should hide the calendar when blurring the date input", done => {
+  it("should show the calendar when clicking on the date input", () => {
+    var datePicker = TestUtils.renderIntoDocument(
+      <DatePicker />
+    );
+    var dateInput = datePicker.refs.input;
+    TestUtils.Simulate.click(ReactDOM.findDOMNode(dateInput));
+    expect(datePicker.refs.calendar).to.exist;
+  });
+
+  it("should keep the calendar shown when blurring the date input", () => {
+    var datePicker = TestUtils.renderIntoDocument(
+      <DatePicker />
+    );
+    var dateInput = datePicker.refs.input;
+    var focusSpy = sinon.spy(dateInput, "focus");
+    TestUtils.Simulate.focus(ReactDOM.findDOMNode(dateInput));
+    TestUtils.Simulate.blur(ReactDOM.findDOMNode(dateInput));
+    expect(datePicker.refs.calendar).to.exist;
+    assert(focusSpy.calledOnce, "should refocus the date input");
+  });
+
+  it("should keep the calendar shown when clicking the calendar", () => {
+    var datePicker = TestUtils.renderIntoDocument(
+      <DatePicker />
+    );
+    var dateInput = datePicker.refs.input;
+    var focusSpy = sinon.spy(dateInput, "focus");
+    TestUtils.Simulate.focus(ReactDOM.findDOMNode(dateInput));
+    TestUtils.Simulate.click(ReactDOM.findDOMNode(datePicker.refs.calendar));
+    expect(datePicker.refs.calendar).to.exist;
+  });
+
+  it("should hide the calendar when clicking a day on the calendar", () => {
     var datePicker = TestUtils.renderIntoDocument(
       <DatePicker />
     );
     var dateInput = datePicker.refs.input;
     TestUtils.Simulate.focus(ReactDOM.findDOMNode(dateInput));
+    var day = TestUtils.scryRenderedComponentsWithType(datePicker.refs.calendar, Day)[0];
+    TestUtils.Simulate.click(ReactDOM.findDOMNode(day));
+    expect(datePicker.refs.calendar).to.not.exist;
+  });
+
+  it("should hide the calendar when the date input signals done", () => {
+    var datePicker = TestUtils.renderIntoDocument(
+      <DatePicker />
+    );
+    var dateInput = datePicker.refs.input;
+    TestUtils.Simulate.focus(ReactDOM.findDOMNode(dateInput));
+    TestUtils.Simulate.keyDown(ReactDOM.findDOMNode(dateInput), { key: "Enter" });
+    expect(datePicker.refs.calendar).to.not.exist;
+  });
+
+  it("should hide the calendar when tabbing from the date input", () => {
+    var onBlurSpy = sinon.spy();
+    var datePicker = TestUtils.renderIntoDocument(
+      <DatePicker onBlur={onBlurSpy} />
+    );
+    var dateInput = datePicker.refs.input;
+    TestUtils.Simulate.focus(ReactDOM.findDOMNode(dateInput));
+    TestUtils.Simulate.keyDown(ReactDOM.findDOMNode(dateInput), { key: "Tab" });
     TestUtils.Simulate.blur(ReactDOM.findDOMNode(dateInput));
-    setTimeout(() => {
-      expect(datePicker.refs.calendar).to.not.exist;
-      done();
-    }, 300);
+    expect(datePicker.refs.calendar).to.not.exist;
+    assert(onBlurSpy.calledOnce, "should call onBlur");
   });
 
   it("should allow clearing the date when isClearable is true", () => {
@@ -46,30 +97,5 @@ describe("DatePicker", () => {
     var clearButton = TestUtils.findRenderedDOMComponentWithClass(datePicker, "close-icon");
     TestUtils.Simulate.click(clearButton);
     expect(cleared).to.be.true;
-  });
-
-  it("should not hide the calendar if multiple clicks are made in a short interval", done => {
-    var datePicker = TestUtils.renderIntoDocument(
-      <DatePicker />
-    );
-    var dateInput = datePicker.refs.input;
-    TestUtils.Simulate.click(ReactDOM.findDOMNode(dateInput));
-
-    setTimeout(() => {
-      var calendar = datePicker.refs.calendar;
-      TestUtils.Simulate.blur(ReactDOM.findDOMNode(dateInput));
-
-      setTimeout(() => {
-        TestUtils.Simulate.click(ReactDOM.findDOMNode(calendar));
-        TestUtils.Simulate.click(ReactDOM.findDOMNode(calendar));
-      }, 0);
-
-      TestUtils.Simulate.blur(ReactDOM.findDOMNode(dateInput));
-    }, 0);
-
-    setTimeout(() => {
-      expect(datePicker.refs.calendar).to.exist;
-      done();
-    }, 300);
   });
 });


### PR DESCRIPTION
Re: #273; addresses #106, #161, #302, #309; supersedes #315; sets up #283 

The `setTimeout`s around showing and hiding the calendar were becoming a bit unwieldy and difficult to reason about/test.  Instead of using `focus` state, I instead started thinking in terms of `open` state, and refactoring with this mindset cleaned up the logic magnificently.  Many bug fixes easily fell into place.