### PR TITLE
Use react-tether for popovers

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "lodash": "^3.10.0",
     "moment": "^2.10",
     "react-onclickoutside": "^4.5.0",
-    "tether": "^1.1.0"
+    "react-tether": "^0.1.2"
   },
   "scripts": {
     "build": "NODE_ENV=production grunt build",

--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -98,6 +98,7 @@ var DatePicker = React.createClass({
     if (this.state.open) {
       return (
         <Popover
+          target={this.refs.input.refs.input}
           attachment={this.props.popoverAttachment}
           targetAttachment={this.props.popoverTargetAttachment}
           targetOffset={this.props.popoverTargetOffset}

--- a/src/popover.jsx
+++ b/src/popover.jsx
@@ -1,13 +1,15 @@
 import React from "react";
-import ReactDOM from "react-dom";
+import TetherElement from "react-tether";
 
 var Popover = React.createClass({
   displayName: "Popover",
 
   propTypes: {
+    target: React.PropTypes.object.isRequired,
     attachment: React.PropTypes.string,
     targetAttachment: React.PropTypes.string,
-    targetOffset: React.PropTypes.string
+    targetOffset: React.PropTypes.string,
+    constraints: React.PropTypes.array
   },
 
   getDefaultProps() {
@@ -24,67 +26,20 @@ var Popover = React.createClass({
     };
   },
 
-  componentWillMount() {
-    var popoverContainer = document.createElement("span");
-    popoverContainer.className = "datepicker__container";
-
-    this._popoverElement = popoverContainer;
-
-    document.querySelector("body").appendChild(this._popoverElement);
-  },
-
-  componentDidMount() {
-    this._renderPopover();
-  },
-
-  componentDidUpdate() {
-    this._renderPopover();
-  },
-
-  _popoverComponent() {
-    var className = this.props.className;
-    return (
-      <div className={className}>
-        {this.props.children}
-      </div>
-    );
-  },
-
-  _tetherOptions() {
-    return {
-      element: this._popoverElement,
-      target: this.refs.span.parentElement.querySelector("input"),
-      attachment: this.props.attachment,
-      targetAttachment: this.props.targetAttachment,
-      targetOffset: this.props.targetOffset,
-      optimizations: {
-        moveElement: false // Always moves to <body> anyway!
-      },
-      constraints: this.props.constraints
-    };
-  },
-
-  _renderPopover() {
-    ReactDOM.render(this._popoverComponent(), this._popoverElement);
-
-    if (this._tether != null) {
-      this._tether.setOptions(this._tetherOptions());
-    } else if (window && document) {
-      var Tether = require("tether");
-      this._tether = new Tether(this._tetherOptions());
-    }
-  },
-
-  componentWillUnmount() {
-    this._tether.destroy();
-    ReactDOM.unmountComponentAtNode(this._popoverElement);
-    if (this._popoverElement.parentNode) {
-      this._popoverElement.parentNode.removeChild(this._popoverElement);
-    }
-  },
-
   render() {
-    return <span ref="span"/>;
+    return (
+      <TetherElement
+        target={this.props.target}
+        options={{
+          classPrefix: "datepicker__tether",
+          attachment: this.props.attachment,
+          targetAttachment: this.props.targetAttachment,
+          targetOffset: this.props.targetOffset,
+          constraints: this.props.constraints
+        }}>
+        {this.props.children}
+      </TetherElement>
+    );
   }
 });
 

--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -12,26 +12,20 @@
   position: relative;
 }
 
-.datepicker__container {
-  position: absolute;
-  display: inline-block;
-  z-index: 2147483647;
-}
-
 .datepicker__triangle {
   position: absolute;
   left: 50px;
 }
 
-.tether-element-attached-top .datepicker__triangle {
+.datepicker__tether-element-attached-top .datepicker__triangle {
   @extend %triangle-arrow-up;
 }
 
-.tether-element-attached-bottom .datepicker__triangle {
+.datepicker__tether-element-attached-bottom .datepicker__triangle {
   @extend %triangle-arrow-down;
 }
 
-.tether-target-attached-top.datepicker__container {
+.datepicker__tether-element-attached-bottom.datepicker__tether-element {
   margin-top: -20px;
 }
 


### PR DESCRIPTION
This deletes a large portion of untested code implementing the popover functionality and replaces it with [`react-tether`](https://github.com/souporserious/react-tether), a small wrapper around `tether`.