### PR TITLE
Remove lodash as a consumer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "karma-sinon": "^1.0.4",
     "karma-sourcemap-loader": "^0.3.5",
     "karma-webpack": "^1.7.0",
+    "lodash": "^4.3.0",
     "mocha": "^2.2.5",
     "node-sass": "^3.4.2",
     "phantomjs": "^1.9.17",
@@ -75,7 +76,6 @@
   },
   "dependencies": {
     "classnames": "^2.2.1",
-    "lodash": "^4.3.0",
     "moment": "^2.11.2",
     "react-onclickoutside": "^4.5.0",
     "react-tether": "^0.1.2"

--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -1,4 +1,3 @@
-import isEqual from "lodash/isEqual";
 import moment from "moment";
 import DateInput from "./date_input";
 import Calendar from "./calendar";
@@ -43,10 +42,6 @@ var DatePicker = React.createClass({
     return {
       open: false
     };
-  },
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return !(isEqual(nextProps, this.props) && isEqual(nextState, this.state));
   },
 
   setOpen(open) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -51,14 +51,6 @@ module.exports = {
         commonjs: "react-onclickoutside",
         amd: "react-onclickoutside"
       }
-    },
-    {
-      "lodash": {
-        root: "_",
-        commonjs2: "lodash",
-        commonjs: "lodash",
-        amd: "lodash"
-      }
     }
   ],
   node: { Buffer: false },


### PR DESCRIPTION
The last remaining dependency on lodash in implementation code is in `shouldComponentUpdate`, which compares props/state to determine if an update should occur.  I thought about this for a bit and I think it is safe to remove -- it is an optimization that is probably no longer necessary.  Some good insights in this article: http://buildwithreact.com/article/optimizing-with-shouldcomponentupdate  Namely, "...If you have one take away from this article, only use `shouldComponentUpdate` if you know you need it."