### PR TITLE
Lock version of react-tether

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "classnames": "^2.2.1",
     "moment": "^2.11.2",
     "react-onclickoutside": "^4.5.0",
-    "react-tether": "^0.3.1"
+    "react-tether": "0.3.1"
   },
   "scripts": {
     "build": "NODE_ENV=production grunt build",


### PR DESCRIPTION
I'm having issues on #359 and I'm not quite sure what's going on yet.  In the meantime we should lock down the version of react-tether and make a release.

@martijnrusschen, can you merge this and make a patch release?