### PR TITLE
Use localized date format for DateInput

### DIFF
--- a/src/date_input.jsx
+++ b/src/date_input.jsx
@@ -9,6 +9,7 @@ var DateInput = React.createClass({
   propTypes: {
     date: React.PropTypes.object,
     locale: React.PropTypes.string,
+    dateFormat: React.PropTypes.string,
     minDate: React.PropTypes.object,
     maxDate: React.PropTypes.object,
     excludeDates: React.PropTypes.array,
@@ -19,7 +20,7 @@ var DateInput = React.createClass({
 
   getDefaultProps() {
     return {
-      dateFormat: "YYYY-MM-DD"
+      dateFormat: "L"
     };
   },
 

--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -13,6 +13,7 @@ var DatePicker = React.createClass({
   propTypes: {
     selected: React.PropTypes.object,
     locale: React.PropTypes.string,
+    dateFormat: React.PropTypes.string,
     dateFormatCalendar: React.PropTypes.string,
     disabled: React.PropTypes.bool,
     id: React.PropTypes.string,

--- a/test/date_input_test.js
+++ b/test/date_input_test.js
@@ -235,4 +235,33 @@ describe("DateInput", function() {
       testLocale(dateInput, date, locale);
     });
   });
+
+  describe("dateFormat", function() {
+    it("should use the date format of the global locale by default", function() {
+      var date = moment();
+      var dateInput = TestUtils.renderIntoDocument(
+        <DateInput date={date} />
+      );
+      expect(dateInput.refs.input.value).to.equal(date.format("L"));
+    });
+
+    it("should use the date format of the locale prop", function() {
+      var locale = "fr";
+      var date = moment().locale(locale);
+      var dateInput = TestUtils.renderIntoDocument(
+        <DateInput date={date} locale={locale} />
+      );
+      expect(dateInput.refs.input.value).to.equal(date.format("L"));
+    });
+
+    it("should use the date format of the dateFormat prop", function() {
+      var locale = "fr";
+      var dateFormat = "LL";
+      var date = moment().locale(locale);
+      var dateInput = TestUtils.renderIntoDocument(
+        <DateInput date={date} dateFormat={dateFormat} locale={locale} />
+      );
+      expect(dateInput.refs.input.value).to.equal(date.format(dateFormat));
+    });
+  });
 });


### PR DESCRIPTION
As part of our localization overhaul, I think we should use the default date format for the selected locale in `DateInput`.  The `L` format expands to the locale-specific format.  Examples:

* `en` : `MM/DD/YYYY`
* `en-gb` : `DD/MM/YYYY`
* `ko` : `YYYY.MM.DD`