### PR TITLE
Add dateFormat to prop types

### DIFF
--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -13,6 +13,7 @@ var DatePicker = React.createClass({
   propTypes: {
     selected: React.PropTypes.object,
     locale: React.PropTypes.string,
+    dateFormat: React.PropTypes.string,
     dateFormatCalendar: React.PropTypes.string,
     disabled: React.PropTypes.bool,
     id: React.PropTypes.string,


### PR DESCRIPTION
Re #373

Adding `dateFormat` to the prop types will make it appear in the API docs