### PR TITLE
Add peerDependency of webpack-dev-middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "style-loader": "^0.13.0",
     "webpack": "^1.7.2",
     "webpack-dev-middleware": "^1.4.0",
+    "webpack-dev-server": "^1.14.1",
     "webpack-hot-middleware": "^2.6.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
I guess this is a side effect of me upgrading to NPM 3. Did anyone else encounter the same issue? Didn’t had this issue with NPM 2.x