### PR TITLE
New calendarClassName prop to override datepicker class

### DIFF
--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -21,10 +21,17 @@ var Calendar = React.createClass({
     filterDate: React.PropTypes.func,
     showYearDropdown: React.PropTypes.string,
     selected: React.PropTypes.object,
-    todayButton: React.PropTypes.string
+    todayButton: React.PropTypes.string,
+    className: React.PropTypes.string
   },
 
   mixins: [require('react-onclickoutside')],
+
+  getDefaultProps () {
+    return {
+      className: 'datepicker'
+    }
+  },
 
   getInitialState () {
     return {
@@ -132,7 +139,7 @@ var Calendar = React.createClass({
 
   render () {
     return (
-      <div className="datepicker">
+      <div className={this.props.className}>
         <div className="datepicker__triangle"></div>
         <div className="datepicker__header">
           <a className="datepicker__navigation datepicker__navigation--previous"

--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -42,7 +42,8 @@ var DatePicker = React.createClass({
     title: React.PropTypes.string,
     readOnly: React.PropTypes.bool,
     required: React.PropTypes.bool,
-    renderCalendarTo: React.PropTypes.any
+    renderCalendarTo: React.PropTypes.any,
+    calendarClassName: React.PropTypes.string
   },
 
   getDefaultProps () {
@@ -134,7 +135,8 @@ var DatePicker = React.createClass({
         onClickOutside={this.handleCalendarClickOutside}
         includeDates={this.props.includeDates}
         showYearDropdown={this.props.showYearDropdown}
-        todayButton={this.props.todayButton} />
+        todayButton={this.props.todayButton}
+        className={this.props.calendarClassName} />
   },
 
   renderClearButton () {

--- a/test/calendar_test.js
+++ b/test/calendar_test.js
@@ -73,6 +73,21 @@ describe("Calendar", function() {
     expect(todayButton.textContent).to.equal("Vandaag");
   });
 
+  it("should have a class by default", function() {
+    var calendar = TestUtils.renderIntoDocument(getCalendar());
+    var calendarEl = TestUtils.findRenderedDOMComponentWithClass(calendar, "datepicker");
+    expect(calendarEl).to.exist;
+  });
+
+  it("should allow className to be overriden", function() {
+    var calendar = TestUtils.renderIntoDocument(getCalendar({className: 'datepicker__customClass'}));
+    var calendarEl = TestUtils.findRenderedDOMComponentWithClass(calendar, "datepicker__customClass");
+    expect(calendarEl).to.exist;
+
+    var calendarEls = TestUtils.scryRenderedDOMComponentsWithClass(calendar, "datepicker");
+    expect(calendarEls).to.be.empty;
+  });
+
   describe("localization", function() {
     function testLocale(calendar, selected, locale) {
       var localized = selected.clone().locale(locale);


### PR DESCRIPTION
By default a class of `datepicker` is used in the markup. This is
annoying because I already have something else using that class in my
app.

This PR introduces a `calendarClassName` prop which allows the caller to
override the `datepicker` class.

Test plan:

`npm test`