### PR TITLE
Change calendar class to be more specific

### DIFF
--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -132,7 +132,7 @@ var Calendar = React.createClass({
 
   render () {
     return (
-      <div className="datepicker">
+      <div className="datepicker__calendar">
         <div className="datepicker__triangle"></div>
         <div className="datepicker__header">
           <a className="datepicker__navigation datepicker__navigation--previous"

--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -1,7 +1,7 @@
 @import "variables";
 @import "mixins";
 
-.datepicker {
+.datepicker__calendar {
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 11px;
   background-color: #fff;


### PR DESCRIPTION
Re #387

Change the class name of the calendar component from `datepicker` to `datepicker__calendar` to help avoid potential naming conflicts.