### PR TITLE
use locale for text input date

### DIFF
--- a/src/date_input.jsx
+++ b/src/date_input.jsx
@@ -53,7 +53,7 @@ var DateInput = React.createClass({
 
   handleChange (event) {
     var value = event.target.value
-    var date = moment(value, this.props.dateFormat, true)
+    var date = moment(value, this.props.dateFormat, this.props.locale || moment.locale(), true)
     if (date.isValid() && !isDayDisabled(date, this.props)) {
       this.props.setSelected(date)
     } else if (value === '') {

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -126,4 +126,25 @@ describe('DatePicker', () => {
     var element = TestUtils.renderIntoDocument(<TestComponent />)
     element.setState({ mounted: false }, done)
   })
+
+  it('should able to format date when typed in the date input field', function () {
+    var state = {}
+
+    function handleChange (date) {
+      state.date = date
+    }
+
+    var datePicker = TestUtils.renderIntoDocument(
+      <DatePicker
+          locale='fr'
+          dateFormat='ll'
+          onChange={handleChange}/>
+    )
+
+    var dateInput = datePicker.refs.input
+    dateInput.refs.input.value = '10 mars 2016'
+    TestUtils.Simulate.change(ReactDOM.findDOMNode(dateInput))
+
+    expect(state.date.format('ll')).to.equal('10 mars 2016')
+  })
 })


### PR DESCRIPTION
The props locale wasn't being used when typing into the date input field and not using the calendar
and instead would clear the input, even if it was exactly what would be output by the clicking on a date in the calendar.

This passes the locale to moment.

