### PR TITLE
respect date format change on rerender

### DIFF
--- a/src/date_input.jsx
+++ b/src/date_input.jsx
@@ -30,14 +30,16 @@ var DateInput = React.createClass({
 
   getInitialState () {
     return {
-      maybeDate: this.safeDateFormat(this.props.date)
+      maybeDate: this.safeDateFormat(this.props)
     }
   },
 
   componentWillReceiveProps (newProps) {
-    if (!isSameDay(newProps.date, this.props.date)) {
+    if (!isSameDay(newProps.date, this.props.date) ||
+          newProps.locale !== this.props.locale ||
+          newProps.dateFormat !== this.props.dateFormat) {
       this.setState({
-        maybeDate: this.safeDateFormat(newProps.date)
+        maybeDate: this.safeDateFormat(newProps)
       })
     }
   },
@@ -65,15 +67,15 @@ var DateInput = React.createClass({
     })
   },
 
-  safeDateFormat (date) {
-    return date && date.clone()
-      .locale(this.props.locale || moment.locale())
-      .format(this.props.dateFormat)
+  safeDateFormat (props) {
+    return props.date && props.date.clone()
+      .locale(props.locale || moment.locale())
+      .format(props.dateFormat)
   },
 
   handleBlur (event) {
     this.setState({
-      maybeDate: this.safeDateFormat(this.props.date)
+      maybeDate: this.safeDateFormat(this.props)
     })
     if (this.props.onBlur) {
       this.props.onBlur(event)

--- a/test/date_input_test.js
+++ b/test/date_input_test.js
@@ -285,4 +285,40 @@ describe('DateInput', function () {
       expect(dateInput.refs.input.value).to.equal(date.format(dateFormat))
     })
   })
+
+  describe('localeChange', function () {
+    it('should rerender with correct format on locale props change', function () {
+      // Need to use ReactDom Render
+      var node = document.createElement('div')
+      var date = moment()
+      date.locale('fr')
+      var dateInput = ReactDOM.render(
+        <DateInput date={date} locale='fr'/>
+      , node)
+      expect(dateInput.refs.input.value).to.equal(date.format('L'))
+
+      date.locale('en')
+      dateInput = ReactDOM.render(
+        <DateInput date={date} locale='en'/>
+      , node)
+      expect(dateInput.refs.input.value).to.equal(date.format('L'))
+    })
+
+    it('should rerender with correct format on format props change', function () {
+      // Need to use ReactDom Render
+      var node = document.createElement('div')
+      var date = moment()
+      var dateFormat = 'YYYY-MM-DD'
+      var dateInput = ReactDOM.render(
+        <DateInput date={date} dateFormat={dateFormat}/>
+      , node)
+      expect(dateInput.refs.input.value).to.equal(date.format(dateFormat))
+
+      dateFormat = 'DD-MM-YYYY'
+      dateInput = ReactDOM.render(
+        <DateInput date={date} dateFormat={dateFormat}/>
+      , node)
+      expect(dateInput.refs.input.value).to.equal(date.format(dateFormat))
+    })
+  })
 })


### PR DESCRIPTION
Hello,
I changed `componentWillReceiveProps` to compare formatted date instead of raw date - and added arguments locale and dateFormat to `safeDateFormat` because props are not set at this time.

Also added test cases for rerendering on format change...

Regards