### PR TITLE
Reduced-bloat packaging for npm & webpack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules
 npm-debug.log
 .idea
 dist
+lib
 tmp
 coverage
 

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -88,6 +88,7 @@ module.exports = function (grunt) {
       }
     },
 
+    // standalone build for ./dist
     webpack: {
       unmin: mergeWebpackConfig({
         output: {
@@ -107,17 +108,30 @@ module.exports = function (grunt) {
         ]
       }),
       docs: require('./webpack.docs.config')
+    },
+
+    // source build for ./lib
+    babel: {
+      lib: {
+        files: [{
+          expand: true,
+          cwd: 'src/',
+          src: ['**/*.js', '**/*.jsx'],
+          dest: 'lib/'
+        }]
+      }
     }
   })
 
   grunt.loadNpmTasks('grunt-contrib-sass')
   grunt.loadNpmTasks('grunt-scss-lint')
   grunt.loadNpmTasks('grunt-contrib-watch')
+  grunt.loadNpmTasks('grunt-babel')
   grunt.loadNpmTasks('grunt-webpack')
   grunt.loadNpmTasks('grunt-karma')
   grunt.loadNpmTasks('grunt-eslint')
 
   grunt.registerTask('default', ['watch', 'scsslint'])
   grunt.registerTask('travis', ['eslint', 'karma', 'scsslint'])
-  grunt.registerTask('build', ['scsslint', 'webpack', 'sass'])
+  grunt.registerTask('build', ['scsslint', 'babel', 'webpack', 'sass'])
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "style": "dist/react-datepicker.min.css",
   "files": [
     "*.md",
-    "dist"
+    "dist",
+    "lib"
   ],
   "keywords": [
     "react",
@@ -42,6 +43,7 @@
     "express": "^4.13.3",
     "extract-text-webpack-plugin": "^1.0.1",
     "grunt": "0.4.5",
+    "grunt-babel": "^6.0.0",
     "grunt-contrib-sass": "0.9.2",
     "grunt-contrib-watch": "0.6.1",
     "grunt-eslint": "^17.3.2",

--- a/src/year_dropdown.jsx
+++ b/src/year_dropdown.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import YearDropdownOptions from './year_dropdown_options.jsx'
+import YearDropdownOptions from './year_dropdown_options'
 
 var YearDropdown = React.createClass({
   displayName: 'YearDropdown',


### PR DESCRIPTION
Reduced-bloat packaging for npm & webpack

`react-datepicker`'s npm module has a main file
`./dist/react-datepicker.min.js`. This file is built by webpack, so it
inlines both `classnames` and `react-tether` dependencies.  

The `classnames` and `react-tether` dependencies in package.json are
hence unused by consumers of `react-datepicker`. Right now they'd be
more appropriate in devDependencies. But this commit proposes another
solution.

I'm using `react-datepicker` with npm, and importing via webpack. My app
also uses `classnames`, and could presumably use `react-tether` too. But
since these `react-datepicker` dependencies are inlined, they cannot be
shared with the host application, despite being present in package.json.

This commit proposes that the main file for distribution via npm is
`./lib/datepicker.js`, compiled by Babel, but not webpack. This allows
users of `react-datepicker` to share the same version of `classnames`
and `react-tether` with `react-datepicker`.
