### PR TITLE
Remove date input styles

### DIFF
--- a/docs-site/src/style.scss
+++ b/docs-site/src/style.scss
@@ -93,3 +93,18 @@ strong {
     }
   }
 }
+
+input {
+  font-size: 13px;
+  border-radius: 4px;
+  box-shadow: inset 0 2px 2px #e9e9e9;
+  border: 1px solid #aeaeae;
+  line-height: 16px;
+  padding: 6px 10px 5px;
+
+  &:focus {
+    outline: none;
+    border-color: #aeaeae;
+    box-shadow: inset 0 2px 2px #e9e9e9, 0 0 10px 0 rgba(73, 107, 125, .3);
+  }
+}

--- a/src/date_input.jsx
+++ b/src/date_input.jsx
@@ -1,13 +1,11 @@
 import moment from 'moment'
 import React from 'react'
-import classnames from 'classnames'
 import { isSameDay, isDayDisabled } from './date_utils'
 
 var DateInput = React.createClass({
   displayName: 'DateInput',
 
   propTypes: {
-    className: React.PropTypes.string,
     date: React.PropTypes.object,
     dateFormat: React.PropTypes.string,
     disabled: React.PropTypes.bool,
@@ -93,8 +91,7 @@ var DateInput = React.createClass({
         {...this.props}
         value={this.state.maybeDate}
         onBlur={this.handleBlur}
-        onChange={this.handleChange}
-        className={classnames('react-datepicker__input', this.props.className)} />
+        onChange={this.handleChange} />
   }
 })
 

--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -155,22 +155,6 @@
   }
 }
 
-.react-datepicker__input {
-  position: relative;
-  font-size: 13px;
-  border-radius: $border-radius;
-  box-shadow: inset 0 2px 2px #e9e9e9;
-  border: 1px solid $border-color;
-  line-height: 16px;
-  padding: 6px 10px 5px;
-
-  &:focus {
-    outline: none;
-    border-color: $border-color;
-    box-shadow: inset 0 2px 2px #e9e9e9, 0 0 10px 0 rgba(73, 107, 125, .3);
-  }
-}
-
 .react-datepicker__input-container {
   position: relative;
 }


### PR DESCRIPTION
Addresses #396

Removes the default styling applied to the `<input>` in `DateInput`, allowing for greater styling flexibility.  Moves the default styles to the CSS of the demo site so that the examples still look nice.