### PR TITLE
Style days outside month

### DIFF
--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -126,8 +126,9 @@
   cursor: pointer;
 
   &:hover {
+    background-color: darken($selected-color, 5%);
     border-radius: $border-radius;
-    background-color: $background-color;
+    color: #fff;
   }
 
   &--today {
@@ -151,6 +152,17 @@
 
     &:hover {
       background-color: transparent;
+      color: $muted-color;
+    }
+  }
+
+  &--outside-month {
+    border-radius: $border-radius;
+    background-color: $background-color;
+
+    &:hover {
+      background-color: darken($selected-color, 5%);
+      color: #fff;
     }
   }
 }


### PR DESCRIPTION
Trying to solve the issue where the days outside a month have the same styling as days in the same month.

I’m not totally convinced by this solution yet, but maybe this could help as some inspiration.

1) Changed hover styling for normal days to the blue (selected) state the make this more explicit. Personally I like this change
2) Added styling for days outside the month by giving it a grey background.

Examples:
![screen shot 2016-03-19 at 15 30 34](https://cloud.githubusercontent.com/assets/1412392/13899179/8eb89be2-ede7-11e5-980e-6bc664f8db09.png)
![screen shot 2016-03-19 at 15 30 26](https://cloud.githubusercontent.com/assets/1412392/13899181/92c85448-ede7-11e5-83b7-5afaa09518ae.png)

Fixes #296
