### PR TITLE
Add grunt-cli to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "extract-text-webpack-plugin": "^1.0.1",
     "grunt": "0.4.5",
     "grunt-babel": "^6.0.0",
+    "grunt-cli": "^0.1.13",
     "grunt-contrib-sass": "0.9.2",
     "grunt-contrib-watch": "0.6.1",
     "grunt-eslint": "^17.3.2",


### PR DESCRIPTION
`npm run build` depends on `grunt`. Before this commit, that required
a global version of `grunt-cli`. Now the project installs a local
version.