### PR TITLE
Fix onBlur handling

### DIFF
--- a/src/date_input.jsx
+++ b/src/date_input.jsx
@@ -76,7 +76,8 @@ var DateInput = React.createClass({
       maybeDate: this.safeDateFormat(this.props)
     })
     if (this.props.onBlur) {
-      this.props.onBlur(event)
+      const blurredValue = moment(event.target.value, this.props.dateFormat)
+      this.props.onBlur(blurredValue.isValid() ? blurredValue : this.props.date)
     }
   },
 


### PR DESCRIPTION
Thanks for writing this component, I'm very happy with it, but encountered the following problem. I had solved it by adding this code to my own onBlur handler but figure that this should probably exist in the library so others can benefit.

Problem: When onBlur is fired we pass the event up rather than then the current date. This is problematic because:
a) we're expecting the date (even in the onBlur example in the docs-site)
b) if gibberish is entered into the input, we don't sanitize it

Solution: When the input is blurred we should try to format the current value in the input and if it's valid pass that as the value in onBlur or otherwise the currently selected date

Test Plan:
- Before the onBlur example wasn't even working! Now it is.
- Try blurring with a valid date, make sure that the onBlur example prints that date out
- Try blurring with gibberish in it, make sure that the onBlue example prints out the date that was there last and the input is changed to reflect it