### PR TITLE
Add inline-block to react-datepicker__input-container

### DIFF
--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -157,6 +157,7 @@
 
 .react-datepicker__input-container {
   position: relative;
+  display: inline-block;
 }
 
 .react-datepicker__year-read-view {


### PR DESCRIPTION
`input` elements are inline-block but `div` is a block element.

react-datepicker wraps its input with a div. As far as I can tell, the
purpose of the wrapper is setting up a positioned container for the
absolutely positioned `react-datepicker__close-icon`. But since the
`input` isn't a block element, the close-icon doesn't line up with the
`input`. Making the wrapper `div` have `display: inline-block` fixes 
that.

Before:

![image](https://cloud.githubusercontent.com/assets/4427/14010661/56c07e7e-f154-11e5-8912-bc22f613e996.png)

After:

![image](https://cloud.githubusercontent.com/assets/4427/14010664/5cbfee90-f154-11e5-9a0f-c14c077b82d9.png)
