### PR TITLE
Use includeDates to derive implied minDate or maxDate for getDateInVi…

### DIFF
--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -3,6 +3,7 @@ import YearDropdown from './year_dropdown'
 import Month from './month'
 import React from 'react'
 import { isSameDay, allDaysDisabledBefore, allDaysDisabledAfter } from './date_utils'
+import minBy from 'lodash/minBy'
 
 var Calendar = React.createClass({
   displayName: 'Calendar',
@@ -45,10 +46,19 @@ var Calendar = React.createClass({
   },
 
   getDateInView () {
-    const { selected, minDate, maxDate } = this.props
+    const { selected, includeDates, minDate, maxDate } = this.props
     const current = moment()
     if (selected) {
       return selected
+    } else if (includeDates) {
+      const futureDates = includeDates.filter(d => d.isSameOrAfter(current))
+      if (futureDates.length) {
+        return minBy(futureDates, d => d.diff(current, 'days'))
+      }
+      const pastDates = includeDates.filter(d => d.isSameOrBefore(current))
+      if (pastDates.length) {
+        return minBy(pastDates, d => current.diff(d, 'days'))
+      }
     } else if (minDate && minDate.isAfter(current)) {
       return minDate
     } else if (maxDate && maxDate.isBefore(current)) {

--- a/test/calendar_test.js
+++ b/test/calendar_test.js
@@ -28,6 +28,35 @@ describe('Calendar', function () {
     assert(calendar.state.date.isSame(selected, 'day'))
   })
 
+  it('should start with the earliest in view in included dates', function () {
+    var now = moment()
+    var includeDates = [ now.clone().add(1, 'year') ]
+    var calendar = TestUtils.renderIntoDocument(getCalendar({ includeDates }))
+    assert(calendar.state.date.isSame(includeDates[0], 'day'))
+  })
+
+  it('should start with the earliest current/future date in view in included dates', function () {
+    var now = moment()
+    var includeDates = [
+      now.clone().subtract(1, 'year'),
+      now.clone(),
+      now.clone().add(1, 'year')
+    ]
+    var calendar = TestUtils.renderIntoDocument(getCalendar({ includeDates }))
+    assert(calendar.state.date.isSame(includeDates[1], 'day'))
+  })
+
+  it('should start with the most recent past date in view in included dates', function () {
+    var now = moment()
+    var includeDates = [
+      now.clone().subtract(3, 'year'),
+      now.clone().subtract(2, 'year'),
+      now.clone().subtract(1, 'year')
+    ]
+    var calendar = TestUtils.renderIntoDocument(getCalendar({ includeDates }))
+    assert(calendar.state.date.isSame(includeDates[2], 'day'))
+  })
+
   it('should start with the current date in view if in date range', function () {
     var now = moment()
     var minDate = now.clone().subtract(1, 'year')


### PR DESCRIPTION
Use case: I had a list of dates starting in April, but my calendar still defaulted to a March display. I could fix this by explicitly setting minDate. But this seemed redundant, since the minimum date can be derived from the includeDates.

Solution: I've rewritten getDateInView() to derive an implied minimum date from includeDates. That is, the earliest current or future date. For symmetry, I've also derived an implied maximum date where no implied minimum exists.