### PR TITLE
Include dates enhancement

### DIFF
--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -3,6 +3,7 @@ import YearDropdown from './year_dropdown'
 import Month from './month'
 import React from 'react'
 import { isSameDay, allDaysDisabledBefore, allDaysDisabledAfter } from './date_utils'
+import minBy from 'lodash/minBy'
 
 var Calendar = React.createClass({
   displayName: 'Calendar',
@@ -45,10 +46,19 @@ var Calendar = React.createClass({
   },
 
   getDateInView () {
-    const { selected, minDate, maxDate } = this.props
+    const { selected, includeDates, minDate, maxDate } = this.props
     const current = moment()
     if (selected) {
       return selected
+    } else if (includeDates) {
+      const futureDates = includeDates.filter(d => d.isSameOrAfter(current))
+      if (futureDates.length) {
+        return minBy(futureDates, d => d.diff(current, 'days'))
+      }
+      const pastDates = includeDates.filter(d => d.isSameOrBefore(current))
+      if (pastDates.length) {
+        return minBy(pastDates, d => current.diff(d, 'days'))
+      }
     } else if (minDate && minDate.isAfter(current)) {
       return minDate
     } else if (maxDate && maxDate.isBefore(current)) {

--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -54,17 +54,17 @@ var Calendar = React.createClass({
     const current = moment()
 
     if (includeDates) {
-      const earliestDate = minDate ? moment.max(minDate, current) : current
+      const earliestPossibleDate = minDate ? moment.max(minDate, current) : current
       const futureDates = includeDates
-        .filter(d => d.isSameOrAfter(earliestDate, 'day'))
+        .filter(d => d.isSameOrAfter(earliestPossibleDate, 'day'))
         .sort((a, b) => a.diff(b, 'days'))
       if (futureDates.length) {
         return futureDates[0]
       }
 
-      const latestDate = maxDate ? moment.min(maxDate, current) : current
+      const latestPossibleDate = maxDate ? moment.min(maxDate, current) : current
       const pastDates = includeDates
-        .filter(d => d.isSameOrBefore(latestDate, 'day'))
+        .filter(d => d.isSameOrBefore(latestPossibleDate, 'day'))
         .sort((a, b) => b.diff(a, 'days'))
       if (pastDates.length) {
         return pastDates[0]

--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -52,24 +52,32 @@ var Calendar = React.createClass({
     }
 
     const current = moment()
-    const startDate = minDate && minDate.isSameOrAfter(current) ? minDate : null
-    const endDate = maxDate && maxDate.isSameOrBefore(current) ? maxDate : null
 
     if (includeDates) {
-      const rangeDates = includeDates.filter(d => (
-        (!startDate || d.isSameOrAfter(startDate, 'day')) && (!endDate || d.isSameOrBefore(endDate, 'day'))
-      )).sort(d => d.diff(current, 'days'))
-      if (rangeDates.length) {
-        if (rangeDates[0].isSameOrAfter(current, 'day')) {
-          return rangeDates[0]
-        }
-        if (rangeDates[rangeDates.length - 1].isSameOrBefore(current, 'day')) {
-          return rangeDates[rangeDates.length - 1]
-        }
+      const earliestDate = minDate ? moment.max(minDate, current) : current
+      const futureDates = includeDates
+        .filter(d => d.isSameOrAfter(earliestDate, 'day'))
+        .sort((a, b) => a.diff(b, 'days'))
+      if (futureDates.length) {
+        return futureDates[0]
+      }
+
+      const latestDate = maxDate ? moment.min(maxDate, current) : current
+      const pastDates = includeDates
+        .filter(d => d.isSameOrBefore(latestDate, 'day'))
+        .sort((a, b) => b.diff(a, 'days'))
+      if (pastDates.length) {
+        return pastDates[0]
       }
     }
 
-    return startDate || endDate || current
+    if (minDate && minDate.isAfter(current)) {
+      return minDate
+    }
+    if (maxDate && maxDate.isBefore(current)) {
+      return maxDate
+    }
+    return current
   },
 
   localizeMoment (date) {

--- a/test/calendar_test.js
+++ b/test/calendar_test.js
@@ -28,6 +28,35 @@ describe('Calendar', function () {
     assert(calendar.state.date.isSame(selected, 'day'))
   })
 
+  it('should start with the earliest in view in included dates', function () {
+    var now = moment()
+    var includeDates = [ now.clone().add(1, 'year') ]
+    var calendar = TestUtils.renderIntoDocument(getCalendar({ includeDates }))
+    assert(calendar.state.date.isSame(includeDates[0], 'day'))
+  })
+
+  it('should start with the earliest current/future date in view in included dates', function () {
+    var now = moment()
+    var includeDates = [
+      now.clone().subtract(1, 'year'),
+      now.clone(),
+      now.clone().add(1, 'year')
+    ]
+    var calendar = TestUtils.renderIntoDocument(getCalendar({ includeDates }))
+    assert(calendar.state.date.isSame(includeDates[1], 'day'))
+  })
+
+  it('should start with the most recent past date in view in included dates', function () {
+    var now = moment()
+    var includeDates = [
+      now.clone().subtract(3, 'year'),
+      now.clone().subtract(2, 'year'),
+      now.clone().subtract(1, 'year')
+    ]
+    var calendar = TestUtils.renderIntoDocument(getCalendar({ includeDates }))
+    assert(calendar.state.date.isSame(includeDates[2], 'day'))
+  })
+
   it('should start with the current date in view if in date range', function () {
     var now = moment()
     var minDate = now.clone().subtract(1, 'year')

--- a/test/calendar_test.js
+++ b/test/calendar_test.js
@@ -35,26 +35,38 @@ describe('Calendar', function () {
     assert(calendar.state.date.isSame(includeDates[0], 'day'))
   })
 
-  it('should start with the earliest current/future date in view in included dates', function () {
+  it('should start with the earliest current date in view in included dates', function () {
     var now = moment()
     var includeDates = [
-      now.clone().subtract(1, 'year'),
+      now.clone().subtract(2, 'year'),
       now.clone(),
-      now.clone().add(1, 'year')
+      now.clone().add(2, 'year')
     ]
     var calendar = TestUtils.renderIntoDocument(getCalendar({ includeDates }))
     assert(calendar.state.date.isSame(includeDates[1], 'day'))
   })
 
-  it('should start with the most recent past date in view in included dates', function () {
+  it('should start with the earliest future date in view in included dates', function () {
     var now = moment()
     var includeDates = [
-      now.clone().subtract(3, 'year'),
       now.clone().subtract(2, 'year'),
-      now.clone().subtract(1, 'year')
+      now.clone().subtract(1, 'year'),
+      now.clone().add(1, 'year'),
+      now.clone().add(2, 'year')
     ]
     var calendar = TestUtils.renderIntoDocument(getCalendar({ includeDates }))
     assert(calendar.state.date.isSame(includeDates[2], 'day'))
+  })
+
+  it('should start with the most recent past date in view in included dates', function () {
+    var now = moment()
+    var includeDates = [
+      now.clone().subtract(1, 'year'),
+      now.clone().subtract(2, 'year'),
+      now.clone().subtract(3, 'year')
+    ]
+    var calendar = TestUtils.renderIntoDocument(getCalendar({ includeDates }))
+    assert(calendar.state.date.isSame(includeDates[0], 'day'))
   })
 
   it('should start with the current date in view if in date range', function () {


### PR DESCRIPTION
This is my third attempt at this change. Aborted attempts [here](https://github.com/Hacker0x01/react-datepicker/pull/431) and [here](https://github.com/Hacker0x01/react-datepicker/pull/432). To quote the original intent of this change:

> Use case: I had a list of dates starting in April, but my calendar still defaulted to a March display. I could fix this by explicitly setting minDate. But this seemed redundant, since the minimum date can be derived from the includeDates.

> Solution: I've rewritten getDateInView() to derive an implied minimum date from includeDates. That is, the earliest current or future date. For symmetry, I've also derived an implied maximum date where no implied minimum exists.

I've also taken into account that minDate and maxDate can be used alongside includeDates. Some additional unit tests have been added to validate the new logic.
