### PR TITLE
Manually control clickoutside class

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   "dependencies": {
     "classnames": "^2.2.1",
     "moment": "^2.11.2",
-    "react-onclickoutside": "^4.5.0",
+    "react-onclickoutside": "^4.7.1",
     "react-tether": "^0.3.3"
   },
   "scripts": {

--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -5,6 +5,8 @@ import TetherComponent from 'react-tether'
 import classnames from 'classnames'
 import { isSameDay } from './date_utils'
 
+var outsideClickIgnoreClass = 'react-datepicker-ignore-onclickoutside'
+
 /**
  * General datepicker component.
  */
@@ -140,12 +142,13 @@ var DatePicker = React.createClass({
         onClickOutside={this.handleCalendarClickOutside}
         includeDates={this.props.includeDates}
         showYearDropdown={this.props.showYearDropdown}
-        todayButton={this.props.todayButton} />
+        todayButton={this.props.todayButton}
+        outsideClickIgnoreClass={outsideClickIgnoreClass} />
   },
 
   renderDateInput () {
     var className = classnames(this.props.className, {
-      'ignore-react-onclickoutside': this.state.open
+      [outsideClickIgnoreClass]: this.state.open
     })
     return <DateInput
         ref='input'

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -104,21 +104,21 @@ describe('DatePicker', () => {
     assert(onBlurSpy.calledOnce, 'should call onBlur')
   })
 
-  it('should not apply the ignore-react-onclickoutside class to the date input when closed', () => {
+  it('should not apply the react-datepicker-ignore-onclickoutside class to the date input when closed', () => {
     var datePicker = TestUtils.renderIntoDocument(
       <DatePicker />
     )
     var dateInput = datePicker.refs.input
-    expect(ReactDOM.findDOMNode(dateInput).className).to.not.contain('ignore-react-onclickoutside')
+    expect(ReactDOM.findDOMNode(dateInput).className).to.not.contain('react-datepicker-ignore-onclickoutside')
   })
 
-  it('should apply the ignore-react-onclickoutside class to date input when open', () => {
+  it('should apply the react-datepicker-ignore-onclickoutside class to date input when open', () => {
     var datePicker = TestUtils.renderIntoDocument(
       <DatePicker />
     )
     var dateInput = datePicker.refs.input
     TestUtils.Simulate.focus(ReactDOM.findDOMNode(dateInput))
-    expect(ReactDOM.findDOMNode(dateInput).className).to.contain('ignore-react-onclickoutside')
+    expect(ReactDOM.findDOMNode(dateInput).className).to.contain('react-datepicker-ignore-onclickoutside')
   })
 
   it('should allow clearing the date when isClearable is true', () => {


### PR DESCRIPTION
If the default clickoutside class were to change it would be an API break, so theoretically we are already protected against that.  But manually specifying the class avoids having to match the "magic" string in the clickoutside library.