### PR TITLE
Transpile to .js

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -117,7 +117,8 @@ module.exports = function (grunt) {
           expand: true,
           cwd: 'src/',
           src: ['**/*.js', '**/*.jsx'],
-          dest: 'lib/'
+          dest: 'lib/',
+          ext: '.js'
         }]
       }
     }

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-rm -rf ./node_modules
+rm -rf ./node_modules ./lib ./dist
 npm install
 
 git checkout .


### PR DESCRIPTION
Currently the file extensions from `src` are being preserved, which means that the transpiled files have the `.jsx` extension.  This makes it semi-painful to consume `lib` because the module bundler must be configured to recognize `.jsx`.

In the long run I think we should probably just rename `.jsx` files in `src` to `.js`