### PR TITLE
Prevent setOpen after clicking the input meanwhile component is disabled

### DIFF
--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -106,7 +106,9 @@ var DatePicker = React.createClass({
   },
 
   onInputClick () {
-    this.setOpen(true)
+    if (!this.props.disabled) {
+      this.setOpen(true)
+    }
   },
 
   onInputKeyDown (event) {

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -24,6 +24,18 @@ describe('DatePicker', () => {
     expect(datePicker.refs.calendar).to.exist
   })
 
+  it('should not show calendar when focusing on date input and disabled turns false', function () {
+    var divNode = document.createElement('div')
+    var disabledDatePicker = ReactDOM.render(<DatePicker disabled/>, divNode)
+    var dateInput = disabledDatePicker.refs.input
+    // click on disabled DatePicker
+    TestUtils.Simulate.click(ReactDOM.findDOMNode(dateInput))
+    expect(disabledDatePicker.refs.calendar).not.to.exist
+    // DatePicker rerenders as enabled
+    var enabledDatePicker = ReactDOM.render(<DatePicker />, divNode)
+    expect(enabledDatePicker.refs.calendar).not.to.exist
+  })
+
   it('should render the calendar into a specified node', () => {
     var node = document.createElement('div')
     document.body.appendChild(node)

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -24,16 +24,13 @@ describe('DatePicker', () => {
     expect(datePicker.refs.calendar).to.exist
   })
 
-  it('should not show calendar when focusing on date input and disabled turns false', function () {
-    var divNode = document.createElement('div')
-    var disabledDatePicker = ReactDOM.render(<DatePicker disabled/>, divNode)
-    var dateInput = disabledDatePicker.refs.input
-    // click on disabled DatePicker
+  it('should not set open state when it is disabled and gets clicked', function () {
+    var datePicker = TestUtils.renderIntoDocument(
+      <DatePicker disabled/>
+    )
+    var dateInput = datePicker.refs.input
     TestUtils.Simulate.click(ReactDOM.findDOMNode(dateInput))
-    expect(disabledDatePicker.refs.calendar).not.to.exist
-    // DatePicker rerenders as enabled
-    var enabledDatePicker = ReactDOM.render(<DatePicker />, divNode)
-    expect(enabledDatePicker.refs.calendar).not.to.exist
+    expect(datePicker.state.open).to.be.false
   })
 
   it('should render the calendar into a specified node', () => {


### PR DESCRIPTION
Fix issue w.r.t disabled state.

Currently, if you disable the date picker and click on it, nothing happens until the date picker  is enabled again. Then, it shows the calendar without any user interaction.

This fix prevents this from happen, disabling any status change meanwhile the component is disabled.
