### PR TITLE
Inline calendar

### DIFF
--- a/docs-site/src/example_components.jsx
+++ b/docs-site/src/example_components.jsx
@@ -19,6 +19,7 @@ import DateRange from './examples/date_range'
 import TabIndex from './examples/tab_index'
 import YearDropdown from './examples/year_dropdown'
 import Today from './examples/today'
+import Inline from './examples/inline'
 
 import 'react-datepicker/dist/react-datepicker.css'
 import './style.scss'
@@ -98,6 +99,10 @@ export default React.createClass({
     {
       title: 'Year dropdown',
       component: <YearDropdown />
+    },
+    {
+      title: 'Inline version',
+      component: <Inline />
     }
   ],
 

--- a/docs-site/src/examples/inline.jsx
+++ b/docs-site/src/examples/inline.jsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import DatePicker from 'react-datepicker'
+import moment from 'moment'
+
+export default React.createClass({
+  displayName: 'Inline',
+
+  getInitialState () {
+    return {
+      startDate: moment()
+    }
+  },
+
+  handleChange (date) {
+    this.setState({
+      startDate: date
+    })
+  },
+
+  render () {
+    return <div className="row">
+      <pre className="column example__code">
+        <code className="jsx">
+          {"<DatePicker"}<br />
+              {"inline"}<br />
+              {"selected={this.state.startDate}"}<br />
+              {"onChange={this.handleChange} />"}
+        </code>
+      </pre>
+      <div className="column">
+        <DatePicker
+            inline
+            selected={this.state.startDate}
+            onChange={this.handleChange} />
+      </div>
+    </div>
+  }
+})

--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -203,7 +203,7 @@ var DatePicker = React.createClass({
             {this.renderDateInput()}
             {this.renderClearButton()}
           </div>
-          {this.renderCalendar()}
+          {calendar}
         </TetherComponent>
       )
     }

--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -24,6 +24,7 @@ var DatePicker = React.createClass({
     filterDate: React.PropTypes.func,
     id: React.PropTypes.string,
     includeDates: React.PropTypes.array,
+    inline: React.PropTypes.bool,
     isClearable: React.PropTypes.bool,
     locale: React.PropTypes.string,
     maxDate: React.PropTypes.object,
@@ -124,7 +125,7 @@ var DatePicker = React.createClass({
   },
 
   renderCalendar () {
-    if (!this.state.open || this.props.disabled) {
+    if (!this.props.inline && (!this.state.open || this.props.disabled)) {
       return null
     }
     return <Calendar
@@ -185,21 +186,27 @@ var DatePicker = React.createClass({
   },
 
   render () {
-    return (
-      <TetherComponent
-          classPrefix={"react-datepicker__tether"}
-          attachment={this.props.popoverAttachment}
-          targetAttachment={this.props.popoverTargetAttachment}
-          targetOffset={this.props.popoverTargetOffset}
-          renderElementTo={this.props.renderCalendarTo}
-          constraints={this.props.tetherConstraints}>
-        <div className="react-datepicker__input-container">
-          {this.renderDateInput()}
-          {this.renderClearButton()}
-        </div>
-        {this.renderCalendar()}
-      </TetherComponent>
-    )
+    const calendar = this.renderCalendar()
+
+    if (this.props.inline) {
+      return calendar
+    } else {
+      return (
+        <TetherComponent
+            classPrefix={"react-datepicker__tether"}
+            attachment={this.props.popoverAttachment}
+            targetAttachment={this.props.popoverTargetAttachment}
+            targetOffset={this.props.popoverTargetOffset}
+            renderElementTo={this.props.renderCalendarTo}
+            constraints={this.props.tetherConstraints}>
+          <div className="react-datepicker__input-container">
+            {this.renderDateInput()}
+            {this.renderClearButton()}
+          </div>
+          {this.renderCalendar()}
+        </TetherComponent>
+      )
+    }
   }
 })
 

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom'
 import TestUtils from 'react-addons-test-utils'
 import DatePicker from '../src/datepicker.jsx'
 import Day from '../src/day'
+import TetherComponent from 'react-tether'
 import moment from 'moment'
 
 describe('DatePicker', () => {
@@ -152,5 +153,30 @@ describe('DatePicker', () => {
     })
     var element = TestUtils.renderIntoDocument(<TestComponent />)
     element.setState({ mounted: false }, done)
+  })
+
+  it('should render calendar inside TetherComponent when inline prop is not set', () => {
+    var datePicker = TestUtils.renderIntoDocument(
+      <DatePicker />
+    )
+
+    expect(function () { TestUtils.findRenderedComponentWithType(datePicker, TetherComponent) }).to.not.throw()
+  })
+
+  it('should render calendar directly without TetherComponent when inline prop is set', () => {
+    var datePicker = TestUtils.renderIntoDocument(
+      <DatePicker inline />
+    )
+
+    expect(function () { TestUtils.findRenderedComponentWithType(datePicker, TetherComponent) }).to.throw()
+    expect(datePicker.refs.calendar).to.exist
+  })
+
+  it('should ignore disable prop when inline prop is set', () => {
+    var datePicker = TestUtils.renderIntoDocument(
+      <DatePicker inline disabled />
+    )
+
+    expect(datePicker.refs.calendar).to.exist
   })
 })


### PR DESCRIPTION
Hi,

I needed inline version of calendar for my project (calendar rendered directly without TetherComponent), so I added new prop `inline` to achieve this behavior for the user and implemented this functionality. I also added new example with `inline` prop.

I can use my enhanced component directly, but maybe you will find this feature useful for other people and you will merge it directly into your code.

Thank You very much for awesome date picker!
Michal