### PR TITLE
Remove react-tether dependency

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
-  "presets": ["react", "es2015"],
+  "presets": ["es2015", "stage-0", "react"],
   "env": {
     "development": {
       "plugins": [

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "babel-plugin-react-transform": "^2.0.0-beta1",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
+    "babel-preset-stage-0": "^6.3.13",
     "chai": "^3.2.0",
     "codecov.io": "^0.1.6",
     "css-loader": "^0.23.0",

--- a/package.json
+++ b/package.json
@@ -81,13 +81,14 @@
     "webpack-hot-middleware": "^2.6.0"
   },
   "peerDependencies": {
-    "react": "^0.14.0"
+    "react": "^0.14.0",
+    "react-dom": "^0.14.0"
   },
   "dependencies": {
     "classnames": "^2.2.1",
     "moment": "^2.11.2",
     "react-onclickoutside": "^4.8.0",
-    "react-tether": "^0.3.3"
+    "tether": "^1.3.2"
   },
   "scripts": {
     "build": "NODE_ENV=production grunt build",

--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -1,7 +1,7 @@
 import DateInput from './date_input'
 import Calendar from './calendar'
 import React from 'react'
-import TetherComponent from 'react-tether'
+import TetherComponent from './tether_component'
 import classnames from 'classnames'
 import { isSameDay } from './date_utils'
 

--- a/src/tether_component.jsx
+++ b/src/tether_component.jsx
@@ -1,0 +1,160 @@
+import React, { Children, PropTypes } from 'react'
+import ReactDOM from 'react-dom'
+import Tether from 'tether'
+
+function childrenPropType ({ children }, propName, componentName) {
+  const childCount = Children.count(children)
+  if (childCount <= 0) {
+    return new Error(`${componentName} expects at least one child to use as the target element.`)
+  } else if (childCount > 2) {
+    return new Error(`Only a max of two children allowed in ${componentName}.`)
+  }
+}
+
+const attachmentPositions = [
+  'top left',
+  'top center',
+  'top right',
+  'middle left',
+  'middle center',
+  'middle right',
+  'bottom left',
+  'bottom center',
+  'bottom right'
+]
+
+var TetherComponent = React.createClass({
+  displayName: 'TetherComponent',
+
+  propTypes: {
+    attachment: PropTypes.oneOf(attachmentPositions).isRequired,
+    children: childrenPropType,
+    className: PropTypes.string,
+    classPrefix: PropTypes.string,
+    classes: PropTypes.object,
+    constraints: PropTypes.array,
+    enabled: PropTypes.bool,
+    id: PropTypes.string,
+    offset: PropTypes.string,
+    optimizations: PropTypes.object,
+    renderElementTag: PropTypes.string,
+    renderElementTo: PropTypes.any,
+    style: PropTypes.object,
+    targetAttachment: PropTypes.oneOf(attachmentPositions),
+    targetModifier: PropTypes.string,
+    targetOffset: PropTypes.string
+  },
+
+  getDefaultProps () {
+    return {
+      renderElementTag: 'div',
+      renderElementTo: null
+    }
+  },
+
+  componentDidMount () {
+    this._targetNode = ReactDOM.findDOMNode(this)
+    this._update()
+  },
+
+  componentDidUpdate () {
+    this._update()
+  },
+
+  componentWillUnmount () {
+    this._destroy()
+  },
+
+  disable () {
+    this._tether.disable()
+  },
+
+  enable () {
+    this._tether.enable()
+  },
+
+  position () {
+    this._tether.position()
+  },
+
+  _destroy () {
+    if (this._elementParentNode) {
+      ReactDOM.unmountComponentAtNode(this._elementParentNode)
+      this._elementParentNode.parentNode.removeChild(this._elementParentNode)
+    }
+
+    if (this._tether) {
+      this._tether.destroy()
+    }
+
+    this._elementParentNode = null
+    this._tether = null
+  },
+
+  _update () {
+    const { children, renderElementTag, renderElementTo } = this.props
+    let elementComponent = children[1]
+
+    // if no element component provided, bail out
+    if (!elementComponent) {
+      // destroy Tether elements if they have been created
+      if (this._tether) {
+        this._destroy()
+      }
+      return
+    }
+
+    // create element node container if it hasn't been yet
+    if (!this._elementParentNode) {
+      // create a node that we can stick our content Component in
+      this._elementParentNode = document.createElement(renderElementTag)
+
+      // append node to the end of the body
+      const renderTo = renderElementTo || document.body
+      renderTo.appendChild(this._elementParentNode)
+    }
+
+    // render element component into the DOM
+    ReactDOM.unstable_renderSubtreeIntoContainer(
+      this, elementComponent, this._elementParentNode, () => {
+        // don't update Tether until the subtree has finished rendering
+        this._updateTether()
+      }
+    )
+  },
+
+  _updateTether () {
+    const { renderElementTag, renderElementTo, ...options } = this.props // eslint-disable-line no-unused-vars
+    const tetherOptions = {
+      target: this._targetNode,
+      element: this._elementParentNode,
+      ...options
+    }
+
+    if (!this._tether) {
+      this._tether = new Tether(tetherOptions)
+    } else {
+      this._tether.setOptions(tetherOptions)
+    }
+
+    this._tether.position()
+  },
+
+  render () {
+    const { children } = this.props
+    let firstChild = null
+
+    // we use forEach because the second child could be null
+    // causing children to not be an array
+    Children.forEach(children, (child, index) => {
+      if (index === 0) {
+        firstChild = child
+        return
+      }
+    })
+
+    return firstChild
+  }
+})
+
+module.exports = TetherComponent


### PR DESCRIPTION
Part of React v15 support (#444)

Unfortunately react-tether has changed their API, so we need to inline the component until the old API can be supported.  Perhaps we can revisit adding it back as a dependency in the future.