### PR TITLE
react-onclickoutside discontinued support for usage as mixin

### DIFF
--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -3,8 +3,9 @@ import YearDropdown from './year_dropdown'
 import Month from './month'
 import React from 'react'
 import { isSameDay, allDaysDisabledBefore, allDaysDisabledAfter, getEffectiveMinDate, getEffectiveMaxDate } from './date_utils'
+import onClickOutside from 'react-onclickoutside'
 
-var Calendar = React.createClass({
+var Calendar = onClickOutside(React.createClass({
   displayName: 'Calendar',
 
   propTypes: {
@@ -24,8 +25,6 @@ var Calendar = React.createClass({
     startDate: React.PropTypes.object,
     todayButton: React.PropTypes.string
   },
-
-  mixins: [require('react-onclickoutside')],
 
   getInitialState () {
     return {
@@ -181,6 +180,6 @@ var Calendar = React.createClass({
       </div>
     )
   }
-})
+}))
 
 module.exports = Calendar

--- a/src/year_dropdown_options.jsx
+++ b/src/year_dropdown_options.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import onClickOutside from 'react-onclickoutside'
 
 function generateYears (year) {
   var list = []
@@ -8,7 +9,7 @@ function generateYears (year) {
   return list
 }
 
-var YearDropdownOptions = React.createClass({
+var YearDropdownOptions = onClickOutside(React.createClass({
   displayName: 'YearDropdownOptions',
 
   propTypes: {
@@ -16,8 +17,6 @@ var YearDropdownOptions = React.createClass({
     onChange: React.PropTypes.func.isRequired,
     year: React.PropTypes.number.isRequired
   },
-
-  mixins: [require('react-onclickoutside')],
 
   getInitialState () {
     return {
@@ -88,6 +87,6 @@ var YearDropdownOptions = React.createClass({
       </div>
     )
   }
-})
+}))
 
 module.exports = YearDropdownOptions


### PR DESCRIPTION
Addresses the following error when using React v15: `Invariant Violation: ReactClass: You're attempting to use a component class or function as a mixin. Instead, just use a regular object`