### PR TITLE
Use rem units for size to improve visibility on pages with a larger font

### DIFF
--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -3,7 +3,7 @@
 
 .react-datepicker {
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-  font-size: 11px;
+  font-size: $font-size;
   background-color: #fff;
   color: $text-color;
   border: 1px solid $border-color;
@@ -43,7 +43,7 @@
   margin-top: 0;
   color: #000;
   font-weight: bold;
-  font-size: 13px;
+  font-size: $font-size * 1.18;
 
   &--hasYearDropdown {
     margin-bottom: 16px;
@@ -261,7 +261,7 @@
     color: #fff;
     content: "\00d7";
     cursor: pointer;
-    font-size: 12px;
+    font-size: $font-size * 1.09;
     height: 16px;
     width: 16px;
     line-height: 1;

--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -261,7 +261,7 @@
     color: #fff;
     content: "\00d7";
     cursor: pointer;
-    font-size: $font-size * 1.09;
+    font-size: 12px;
     height: 16px;
     width: 16px;
     line-height: 1;

--- a/src/stylesheets/variables.scss
+++ b/src/stylesheets/variables.scss
@@ -4,10 +4,10 @@ $selected-color: #216ba5;
 $muted-color: #ccc;
 $text-color: #000;
 
-$font-size: 0.8rem;
-$border-radius: 0.3rem;
+$font-size: .8rem;
+$border-radius: .3rem;
 $item-size: 1.7rem;
-$day-margin: 0.166rem;
+$day-margin: .166rem;
 $triangle-size: 8px;
-$datepicker__margin: 0.4rem;
-$navigation-size: 0.45rem;
+$datepicker__margin: .4rem;
+$navigation-size: .45rem;

--- a/src/stylesheets/variables.scss
+++ b/src/stylesheets/variables.scss
@@ -5,9 +5,9 @@ $muted-color: #ccc;
 $text-color: #000;
 
 $font-size: 0.8rem;
-$border-radius: 0.33rem;
+$border-radius: 0.3rem;
 $item-size: 1.7rem;
 $day-margin: 0.166rem;
-$triangle-size: 0.67rem;
+$triangle-size: 8px;
 $datepicker__margin: 0.4rem;
 $navigation-size: 0.45rem;

--- a/src/stylesheets/variables.scss
+++ b/src/stylesheets/variables.scss
@@ -4,9 +4,10 @@ $selected-color: #216ba5;
 $muted-color: #ccc;
 $text-color: #000;
 
-$border-radius: 4px;
-$item-size: 24px;
-$day-margin: 2px;
-$triangle-size: 8px;
-$datepicker__margin: 5px;
-$navigation-size: 6px;
+$font-size: 0.8rem;
+$border-radius: 0.33rem;
+$item-size: 1.7rem;
+$day-margin: 0.166rem;
+$triangle-size: 0.67rem;
+$datepicker__margin: 0.4rem;
+$navigation-size: 0.45rem;


### PR DESCRIPTION
The rem units I used were calculated such that the calendar would appear the same on a page with `html, body { font-size: 14px; }` as it does currently on a page with any font size.