### PR TITLE
Allow data-* attributes in date input

### DIFF
--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -17,6 +17,7 @@ var DatePicker = React.createClass({
   propTypes: {
     autoComplete: React.PropTypes.string,
     className: React.PropTypes.string,
+    dataAttributes: React.PropTypes.object,
     dateFormat: React.PropTypes.string,
     dateFormatCalendar: React.PropTypes.string,
     disabled: React.PropTypes.bool,
@@ -180,7 +181,8 @@ var DatePicker = React.createClass({
         title={this.props.title}
         readOnly={this.props.readOnly}
         required={this.props.required}
-        tabIndex={this.props.tabIndex} />
+        tabIndex={this.props.tabIndex}
+        {...this.props.dataAttributes} />
   },
 
   renderClearButton () {

--- a/test/date_input_test.js
+++ b/test/date_input_test.js
@@ -38,6 +38,14 @@ describe('DateInput', function () {
     expect(ReactDOM.findDOMNode(dateInput).tabIndex).to.equal(1)
   })
 
+  it('uses custom data-* attributes if provided', function () {
+    var dateInput = TestUtils.renderIntoDocument(
+      <DateInput data-color='pink' />
+    )
+
+    expect(ReactDOM.findDOMNode(dateInput).getAttribute('data-color')).to.equal('pink')
+  })
+
   it('should call onChangeDate when changing from null to valid date', function () {
     var date = moment()
     var dateFormat = 'YYYY-MM-DD'

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -188,4 +188,12 @@ describe('DatePicker', () => {
 
     expect(datePicker.refs.calendar).to.exist
   })
+
+  it('should render data-* attributes in DateInput if provided', () => {
+    var datePicker = TestUtils.renderIntoDocument(
+      <DatePicker dataAttributes={{'data-color': 'pink'}} />
+    )
+
+    expect(ReactDOM.findDOMNode(datePicker).querySelector('input').getAttribute('data-color')).to.equal('pink')
+  })
 })


### PR DESCRIPTION
I am using `react-datepicker` in a form where I need all the inputs to have `data-*` attributes.

With this PR, a DatePicker component created with the following:
```
<DatePicker dataAttributes={{'data-foo': 'bar'}} />
```
Creates the following input element:
```
<input type="text" class="datepicker__input" data-foo="bar">
```