### PR TITLE
Add option for fixed size of the calendar

### DIFF
--- a/docs-site/src/example_components.jsx
+++ b/docs-site/src/example_components.jsx
@@ -21,6 +21,7 @@ import YearDropdown from './examples/year_dropdown'
 import Today from './examples/today'
 import Inline from './examples/inline'
 import OpenToDate from './examples/open_to_date'
+import FixedCalendar from './examples/fixed_calendar'
 
 import 'react-datepicker/dist/react-datepicker.css'
 import './style.scss'
@@ -108,6 +109,10 @@ export default React.createClass({
     {
       title: 'Open to date',
       component: <OpenToDate />
+    },
+    {
+      title: 'Fixed size of Calendar',
+      component: <FixedCalendar />
     }
   ],
 

--- a/docs-site/src/example_components.jsx
+++ b/docs-site/src/example_components.jsx
@@ -111,7 +111,7 @@ export default React.createClass({
       component: <OpenToDate />
     },
     {
-      title: 'Fixed size of Calendar',
+      title: 'Fixed height of Calendar',
       component: <FixedCalendar />
     }
   ],

--- a/docs-site/src/examples/fixed_calendar.jsx
+++ b/docs-site/src/examples/fixed_calendar.jsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import DatePicker from 'react-datepicker'
+
+export default React.createClass({
+  displayName: 'FixedCalendar',
+
+  getInitialState () {
+    return {
+      startDate: null
+    }
+  },
+
+  handleChange (date) {
+    this.setState({
+      startDate: date
+    })
+  },
+
+  render () {
+    return <div className="row">
+      <pre className="column example__code">
+        <code className="jsx">
+          {"<DatePicker"}<br />
+              {"isCalendarFixed"}<br />
+              {"selected={this.state.startDate}"}<br />
+              {"onChange={this.handleChange} />"}
+        </code>
+      </pre>
+      <div className="column">
+        <DatePicker
+            isCalendarFixed
+            selected={this.state.startDate}
+            onChange={this.handleChange} />
+      </div>
+    </div>
+  }
+})

--- a/docs-site/src/examples/fixed_calendar.jsx
+++ b/docs-site/src/examples/fixed_calendar.jsx
@@ -21,14 +21,14 @@ export default React.createClass({
       <pre className="column example__code">
         <code className="jsx">
           {"<DatePicker"}<br />
-              {"isCalendarFixed"}<br />
+              {"fixedHeight"}<br />
               {"selected={this.state.startDate}"}<br />
               {"onChange={this.handleChange} />"}
         </code>
       </pre>
       <div className="column">
         <DatePicker
-            isCalendarFixed
+            fixedHeight
             selected={this.state.startDate}
             onChange={this.handleChange} />
       </div>

--- a/docs/datepicker.md
+++ b/docs/datepicker.md
@@ -48,6 +48,11 @@ type: `array`
 type: `func`
 
 
+### `fixedHeight`
+
+type: `bool`
+
+
 ### `id`
 
 type: `string`
@@ -62,10 +67,6 @@ type: `array`
 
 type: `bool`
 
-
-### `isCalendarFixed`
-
-type: `bool`
 
 ### `isClearable`
 

--- a/docs/datepicker.md
+++ b/docs/datepicker.md
@@ -63,6 +63,10 @@ type: `array`
 type: `bool`
 
 
+### `isCalendarFixed`
+
+type: `bool`
+
 ### `isClearable`
 
 type: `bool`

--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -12,8 +12,8 @@ var Calendar = React.createClass({
     endDate: React.PropTypes.object,
     excludeDates: React.PropTypes.array,
     filterDate: React.PropTypes.func,
+    fixedHeight: React.PropTypes.bool,
     includeDates: React.PropTypes.array,
-    isFixed: React.PropTypes.bool,
     locale: React.PropTypes.string,
     maxDate: React.PropTypes.object,
     minDate: React.PropTypes.object,
@@ -174,7 +174,7 @@ var Calendar = React.createClass({
             maxDate={this.props.maxDate}
             excludeDates={this.props.excludeDates}
             includeDates={this.props.includeDates}
-            isFixed={this.props.isFixed}
+            fixedHeight={this.props.fixedHeight}
             filterDate={this.props.filterDate}
             selected={this.props.selected}
             startDate={this.props.startDate}

--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -13,6 +13,7 @@ var Calendar = React.createClass({
     excludeDates: React.PropTypes.array,
     filterDate: React.PropTypes.func,
     includeDates: React.PropTypes.array,
+    isFixed: React.PropTypes.bool,
     locale: React.PropTypes.string,
     maxDate: React.PropTypes.object,
     minDate: React.PropTypes.object,
@@ -173,6 +174,7 @@ var Calendar = React.createClass({
             maxDate={this.props.maxDate}
             excludeDates={this.props.excludeDates}
             includeDates={this.props.includeDates}
+            isFixed={this.props.isFixed}
             filterDate={this.props.filterDate}
             selected={this.props.selected}
             startDate={this.props.startDate}

--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -26,6 +26,7 @@ var DatePicker = React.createClass({
     id: React.PropTypes.string,
     includeDates: React.PropTypes.array,
     inline: React.PropTypes.bool,
+    isCalendarFixed: React.PropTypes.bool,
     isClearable: React.PropTypes.bool,
     locale: React.PropTypes.string,
     maxDate: React.PropTypes.object,
@@ -149,7 +150,8 @@ var DatePicker = React.createClass({
         includeDates={this.props.includeDates}
         showYearDropdown={this.props.showYearDropdown}
         todayButton={this.props.todayButton}
-        outsideClickIgnoreClass={outsideClickIgnoreClass} />
+        outsideClickIgnoreClass={outsideClickIgnoreClass}
+        isFixed={this.props.isCalendarFixed} />
   },
 
   renderDateInput () {

--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -23,10 +23,10 @@ var DatePicker = React.createClass({
     endDate: React.PropTypes.object,
     excludeDates: React.PropTypes.array,
     filterDate: React.PropTypes.func,
+    fixedHeight: React.PropTypes.bool,
     id: React.PropTypes.string,
     includeDates: React.PropTypes.array,
     inline: React.PropTypes.bool,
-    isCalendarFixed: React.PropTypes.bool,
     isClearable: React.PropTypes.bool,
     locale: React.PropTypes.string,
     maxDate: React.PropTypes.object,
@@ -151,7 +151,7 @@ var DatePicker = React.createClass({
         showYearDropdown={this.props.showYearDropdown}
         todayButton={this.props.todayButton}
         outsideClickIgnoreClass={outsideClickIgnoreClass}
-        isFixed={this.props.isCalendarFixed} />
+        fixedHeight={this.props.fixedHeight} />
   },
 
   renderDateInput () {

--- a/src/month.jsx
+++ b/src/month.jsx
@@ -10,6 +10,7 @@ var Month = React.createClass({
     excludeDates: React.PropTypes.array,
     filterDate: React.PropTypes.func,
     includeDates: React.PropTypes.array,
+    isFixed: React.PropTypes.bool,
     maxDate: React.PropTypes.object,
     minDate: React.PropTypes.object,
     onDayClick: React.PropTypes.func,
@@ -33,7 +34,7 @@ var Month = React.createClass({
     const startOfMonth = this.props.day.clone().startOf('month').startOf('week')
     return [0, 1, 2, 3, 4, 5]
       .map(offset => startOfMonth.clone().add(offset, 'weeks'))
-      .filter(startOfWeek => this.isWeekInMonth(startOfWeek))
+      .filter(startOfWeek => this.props.isFixed ? true : this.isWeekInMonth(startOfWeek))
       .map((startOfWeek, offset) =>
         <Week
             key={offset}

--- a/src/month.jsx
+++ b/src/month.jsx
@@ -9,8 +9,8 @@ var Month = React.createClass({
     endDate: React.PropTypes.object,
     excludeDates: React.PropTypes.array,
     filterDate: React.PropTypes.func,
+    fixedHeight: React.PropTypes.bool,
     includeDates: React.PropTypes.array,
-    isFixed: React.PropTypes.bool,
     maxDate: React.PropTypes.object,
     minDate: React.PropTypes.object,
     onDayClick: React.PropTypes.func,
@@ -34,7 +34,7 @@ var Month = React.createClass({
     const startOfMonth = this.props.day.clone().startOf('month').startOf('week')
     return [0, 1, 2, 3, 4, 5]
       .map(offset => startOfMonth.clone().add(offset, 'weeks'))
-      .filter(startOfWeek => this.props.isFixed ? true : this.isWeekInMonth(startOfWeek))
+      .filter(startOfWeek => this.props.fixedHeight ? true : this.isWeekInMonth(startOfWeek))
       .map((startOfWeek, offset) =>
         <Week
             key={offset}

--- a/src/month.jsx
+++ b/src/month.jsx
@@ -34,7 +34,7 @@ var Month = React.createClass({
     const startOfMonth = this.props.day.clone().startOf('month').startOf('week')
     return [0, 1, 2, 3, 4, 5]
       .map(offset => startOfMonth.clone().add(offset, 'weeks'))
-      .filter(startOfWeek => this.props.fixedHeight ? true : this.isWeekInMonth(startOfWeek))
+      .filter(startOfWeek => this.props.fixedHeight || this.isWeekInMonth(startOfWeek))
       .map((startOfWeek, offset) =>
         <Week
             key={offset}


### PR DESCRIPTION
Lets to set fixed size of the calendar (6 rows of weeks). In addition, lets to prevent issue with top position of the calendar.

Without fixed size:
![react-datepicker-before](https://cloud.githubusercontent.com/assets/17114669/16640942/7f3045e0-443f-11e6-8cfe-c456b0e36c2e.gif)

Fixed size:
![react-datepicker-fixed](https://cloud.githubusercontent.com/assets/17114669/16640951/8e9ffa3e-443f-11e6-9736-e6780bb828c2.gif)
