### PR TITLE
Make openToDate work with minDate and maxDate

### DIFF
--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -53,8 +53,14 @@ var Calendar = React.createClass({
     const current = moment()
     if (selected) {
       return selected
+    } else if (minDate && maxDate && openToDate && openToDate.isBetween(minDate, maxDate)) {
+      return openToDate
+    } else if (minDate && openToDate && openToDate.isAfter(minDate)) {
+      return openToDate
     } else if (minDate && minDate.isAfter(current)) {
       return minDate
+    } else if (maxDate && openToDate && openToDate.isBefore(maxDate)) {
+      return openToDate
     } else if (maxDate && maxDate.isBefore(current)) {
       return maxDate
     } else if (openToDate) {

--- a/test/calendar_test.js
+++ b/test/calendar_test.js
@@ -66,6 +66,28 @@ describe('Calendar', function () {
     assert(calendar.state.date.isSame(openToDate, 'day'))
   })
 
+  it('should start with the open to date in view if given and after a min date', function () {
+    var openToDate = moment('09/28/1993')
+    var minDate = moment('01/01/1993', 'MM/DD/YYYY')
+    var calendar = TestUtils.renderIntoDocument(getCalendar({ openToDate, minDate }))
+    assert(calendar.state.date.isSame(openToDate, 'day'))
+  })
+
+  it('should start with the open to date in view if given and before a max date', function () {
+    var openToDate = moment('09/28/1993')
+    var maxDate = moment('12/31/1993', 'MM/DD/YYYY')
+    var calendar = TestUtils.renderIntoDocument(getCalendar({ openToDate, maxDate }))
+    assert(calendar.state.date.isSame(openToDate, 'day'))
+  })
+
+  it('should start with the open to date in view if given and in range of the min/max dates', function () {
+    var openToDate = moment('09/28/1993')
+    var minDate = moment('01/01/1993', 'MM/DD/YYYY')
+    var maxDate = moment('12/31/1993', 'MM/DD/YYYY')
+    var calendar = TestUtils.renderIntoDocument(getCalendar({ openToDate, minDate, maxDate }))
+    assert(calendar.state.date.isSame(openToDate, 'day'))
+  })
+
   it('should not show the year dropdown menu by default', function () {
     var calendar = TestUtils.renderIntoDocument(getCalendar())
     var yearReadView = TestUtils.scryRenderedComponentsWithType(calendar, YearDropdown)


### PR DESCRIPTION
See #525 

With this PR, when setting an openToDate along with a minDate and/or a maxDate, the calendar will initially open to the openToDate if it falls within the range.