### PR TITLE
Add accessibility tags to month and day jsx

### DIFF
--- a/src/day.jsx
+++ b/src/day.jsx
@@ -66,7 +66,12 @@ var Day = React.createClass({
 
   render () {
     return (
-      <div className={this.getClassNames()} onClick={this.handleClick}>
+      <div
+        className={this.getClassNames()}
+        onClick={this.handleClick}
+        aria-label={`day-${this.props.day.date()}`}
+        role="option"
+      >
         {this.props.day.date()}
       </div>
     )

--- a/src/day.jsx
+++ b/src/day.jsx
@@ -71,7 +71,7 @@ var Day = React.createClass({
           onClick={this.handleClick}
           aria-label={`day-${this.props.day.date()}`}
           role="option">
-        {this.props.day.date()}
+          {this.props.day.date()}
       </div>
     )
   }

--- a/src/day.jsx
+++ b/src/day.jsx
@@ -67,11 +67,10 @@ var Day = React.createClass({
   render () {
     return (
       <div
-        className={this.getClassNames()}
-        onClick={this.handleClick}
-        aria-label={`day-${this.props.day.date()}`}
-        role="option"
-      >
+          className={this.getClassNames()}
+          onClick={this.handleClick}
+          aria-label={`day-${this.props.day.date()}`}
+          role="option">
         {this.props.day.date()}
       </div>
     )

--- a/src/month.jsx
+++ b/src/month.jsx
@@ -54,7 +54,7 @@ var Month = React.createClass({
 
   render () {
     return (
-      <div className="react-datepicker__month">
+      <div className="react-datepicker__month" role="listbox">
         {this.renderWeeks()}
       </div>
     )


### PR DESCRIPTION
I was writing a ui test and realized that I can't click the div element containing a specific day text without using XPath. The unique aria-labels will change that while also helping screen readers better understand the elements and their roles as date options.