### PR TITLE
Allow multiple formats for date input.

### DIFF
--- a/src/date_input.jsx
+++ b/src/date_input.jsx
@@ -7,7 +7,10 @@ var DateInput = React.createClass({
 
   propTypes: {
     date: React.PropTypes.object,
-    dateFormat: React.PropTypes.string,
+    dateFormat: React.PropTypes.oneOfType([
+      React.PropTypes.string,
+      React.PropTypes.array
+    ]),
     disabled: React.PropTypes.bool,
     excludeDates: React.PropTypes.array,
     filterDate: React.PropTypes.func,

--- a/src/date_input.jsx
+++ b/src/date_input.jsx
@@ -69,7 +69,7 @@ var DateInput = React.createClass({
   safeDateFormat (props) {
     return props.date && props.date.clone()
       .locale(props.locale || moment.locale())
-      .format(props.dateFormat) || ''
+      .format(Array.isArray(props.dateFormat) ? props.dateFormat[0] : props.dateFormat) || ''
   },
 
   handleBlur (event) {

--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -17,7 +17,10 @@ var DatePicker = React.createClass({
   propTypes: {
     autoComplete: React.PropTypes.string,
     className: React.PropTypes.string,
-    dateFormat: React.PropTypes.string,
+    dateFormat: React.PropTypes.oneOfType([
+      React.PropTypes.string,
+      React.PropTypes.array
+    ]),
     dateFormatCalendar: React.PropTypes.string,
     disabled: React.PropTypes.bool,
     endDate: React.PropTypes.object,

--- a/test/date_input_test.js
+++ b/test/date_input_test.js
@@ -293,7 +293,9 @@ describe('DateInput', function () {
       expect(dateInput.refs.input.value).to.equal(date.format(dateFormat))
     })
 
+    it('should format the output date using the first format of the dateFormat prop array and use any of the provided formats for parsing input', function () {
       var locale = 'fr'
+      var dateFormats = ['LL','l']
       var date = moment().locale(locale)
       var dateInput = TestUtils.renderIntoDocument(
         <DateInput date={date} dateFormat={dateFormats} locale={locale} />

--- a/test/date_input_test.js
+++ b/test/date_input_test.js
@@ -301,7 +301,7 @@ describe('DateInput', function () {
         <DateInput date={date} dateFormat={dateFormats} locale={locale} />
       )
       var inputNode = dateInput.refs.input
-      inputNode.value = date.format(dateFormats[dateFormats-length-1])
+      inputNode.value = date.format(dateFormats[dateFormats.length - 1])
       TestUtils.Simulate.change(inputNode)
       TestUtils.Simulate.blur(inputNode)
       expect(inputNode.value).to.equal(date.format(dateFormats[0]))

--- a/test/date_input_test.js
+++ b/test/date_input_test.js
@@ -292,6 +292,18 @@ describe('DateInput', function () {
       )
       expect(dateInput.refs.input.value).to.equal(date.format(dateFormat))
     })
+
+      var locale = 'fr'
+      var date = moment().locale(locale)
+      var dateInput = TestUtils.renderIntoDocument(
+        <DateInput date={date} dateFormat={dateFormats} locale={locale} />
+      )
+      var inputNode = dateInput.refs.input
+      inputNode.value = date.format(dateFormats[dateFormats-length-1])
+      TestUtils.Simulate.change(inputNode)
+      TestUtils.Simulate.blur(inputNode)
+      expect(inputNode.value).to.equal(date.format(dateFormats[0]))
+    })
   })
 
   describe('localeChange', function () {

--- a/test/date_input_test.js
+++ b/test/date_input_test.js
@@ -295,7 +295,7 @@ describe('DateInput', function () {
 
     it('should format the output date using the first format of the dateFormat prop array and use any of the provided formats for parsing input', function () {
       var locale = 'fr'
-      var dateFormats = ['LL','l']
+      var dateFormats = ['LL', 'l']
       var date = moment().locale(locale)
       var dateInput = TestUtils.renderIntoDocument(
         <DateInput date={date} dateFormat={dateFormats} locale={locale} />


### PR DESCRIPTION
First, thanks for creating react-datepicker!

I would like to suggest allowing multiple formats for date entry. Our users often use the input box for manually typing or pasting dates. If the date provided does not __exactly__ match the specified dateFormat, this will fail. For example, if dateFormat is 'MM.DD.YYYY' and the user inputs '1.1.2016', the date will be rejected as invalid. 

As Moment.js already offers this functionality by simply providing an [array for formats](http://momentjs.com/guides/#/parsing/multiple-formats/). This requires only minimal changes (I hope I didn't miss anything).

If an array of formats is provided, the first format will be used to format the output but all other formats would be used to parse the input.

Would you please consider merging this PR? Thank you very much!