### PR TITLE
Fix onClickOutside reference

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,7 +46,7 @@ module.exports = {
     },
     {
       'react-onclickoutside': {
-        root: 'OnClickOutside',
+        root: 'onClickOutside',
         commonjs2: 'react-onclickoutside',
         commonjs: 'react-onclickoutside',
         amd: 'react-onclickoutside'


### PR DESCRIPTION
TLDR: react-onclickoutside [exposes itself](https://github.com/Pomax/react-onclickoutside/blob/v5.3.3/index.js#L222) as `onClickOutside`, not `OnClickOutside`.

Having externalized React Date Picker (i.e. including `react-datepicker/dist/react-datepicker.js` via HTML rather than bundling it with webpack), I end up with the following warning:

> Warning: ReactClass: You're attempting to include a mixin that is either null or not an object. Check the mixins included by the component, as well as any mixins they include themselves. Expected object but got undefined

After some digging¹, I figured out that what's missing is [react-onclickoutside](https://github.com/Pomax/react-onclickoutside) (I'd already externalized React, ReactDOM and Moment.js anyway).

However, including (externalizing²) that as well didn't work. After more digging, it turns out to be due to this simply typo.

---

¹ These external dependencies don't seem to be documented as such, so I had to refer to `webpack.config.js`.

² Required to ensure proper load order: react-onclickoutside must be available upon react-datepicker initialization.
