### PR TITLE
Fixed down year arrow for rtl layout

### DIFF
--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -189,6 +189,12 @@
   }
 }
 
+body[dir=rtl] .react-datepicker__year-read-view--down-arrow {
+    right: 7px;
+    top: 10px;
+    left: auto;
+}
+
 .react-datepicker__year-dropdown {
   background-color: $background-color;
   position: absolute;


### PR DESCRIPTION
The down arrow for the year in RTL was overlapping with the text, just fixed its layout