### PR TITLE
Highlight dates

### DIFF
--- a/docs-site/src/example_components.jsx
+++ b/docs-site/src/example_components.jsx
@@ -9,6 +9,7 @@ import PlaceholderText from './examples/placeholder_text'
 import SpecificDateRange from './examples/specific_date_range'
 import Locale from './examples/locale'
 import ExcludeDates from './examples/exclude_dates'
+import HighlightDates from './examples/highlight_dates'
 import IncludeDates from './examples/include_dates'
 import FilterDates from './examples/filter_dates'
 import Disabled from './examples/disabled'
@@ -71,6 +72,10 @@ export default React.createClass({
     {
       title: 'Exclude dates',
       component: <ExcludeDates />
+    },
+    {
+      title: 'Highlight dates',
+      component: <HighlightDates />
     },
     {
       title: 'Include dates',

--- a/docs-site/src/examples/highlight_dates.jsx
+++ b/docs-site/src/examples/highlight_dates.jsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import DatePicker from 'react-datepicker'
+import moment from 'moment'
+
+export default React.createClass({
+  displayName: 'highlightDates',
+
+  getInitialState () {
+    return {
+      startDate: null
+    }
+  },
+
+  handleChange (date) {
+    this.setState({
+      startDate: date
+    })
+  },
+
+  render () {
+    return <div className="row">
+      <pre className="column example__code">
+        <code className="jsx">
+          {"<DatePicker"}<br />
+              {"selected={this.state.startDate}"}<br />
+              {"onChange={this.handleChange}"}<br />
+        <strong>    {"highlightDates={[moment().subtract(7, 'days'), moment().add(7, 'days')]}"}</strong><br />
+              {"placeholderText=\"This highlights a week ago and a week from today\" />"}
+        </code>
+      </pre>
+      <div className="column">
+        <DatePicker
+            selected={this.state.startDate}
+            onChange={this.handleChange}
+            highlightDates={[moment().subtract(7, 'days'), moment().add(7, 'days')]}
+            placeholderText="This highlights a week ago and a week from today" />
+      </div>
+    </div>
+  }
+})

--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -13,6 +13,7 @@ var Calendar = React.createClass({
     excludeDates: React.PropTypes.array,
     filterDate: React.PropTypes.func,
     fixedHeight: React.PropTypes.bool,
+    highlightDates: React.PropTypes.array,
     includeDates: React.PropTypes.array,
     locale: React.PropTypes.string,
     maxDate: React.PropTypes.object,
@@ -186,6 +187,7 @@ var Calendar = React.createClass({
             minDate={this.props.minDate}
             maxDate={this.props.maxDate}
             excludeDates={this.props.excludeDates}
+            highlightDates={this.props.highlightDates}
             includeDates={this.props.includeDates}
             fixedHeight={this.props.fixedHeight}
             filterDate={this.props.filterDate}

--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -29,6 +29,7 @@ var DatePicker = React.createClass({
     excludeDates: React.PropTypes.array,
     filterDate: React.PropTypes.func,
     fixedHeight: React.PropTypes.bool,
+    highlightDates: React.PropTypes.array,
     id: React.PropTypes.string,
     includeDates: React.PropTypes.array,
     inline: React.PropTypes.bool,
@@ -154,6 +155,7 @@ var DatePicker = React.createClass({
         excludeDates={this.props.excludeDates}
         filterDate={this.props.filterDate}
         onClickOutside={this.handleCalendarClickOutside}
+        highlightDates={this.props.highlightDates}
         includeDates={this.props.includeDates}
         showYearDropdown={this.props.showYearDropdown}
         todayButton={this.props.todayButton}

--- a/src/day.jsx
+++ b/src/day.jsx
@@ -11,6 +11,7 @@ var Day = React.createClass({
     endDate: React.PropTypes.object,
     excludeDates: React.PropTypes.array,
     filterDate: React.PropTypes.func,
+    highlightDates: React.PropTypes.array,
     includeDates: React.PropTypes.array,
     maxDate: React.PropTypes.object,
     minDate: React.PropTypes.object,
@@ -37,6 +38,12 @@ var Day = React.createClass({
 
   isDisabled () {
     return isDayDisabled(this.props.day, this.props)
+  },
+
+  isHighlighted () {
+    const { day, highlightDates } = this.props
+    if (!highlightDates) return false
+    return highlightDates.some((testDay) => { return isSameDay(day, testDay) })
   },
 
   isInRange () {
@@ -74,6 +81,7 @@ var Day = React.createClass({
     return classnames('react-datepicker__day', {
       'react-datepicker__day--disabled': this.isDisabled(),
       'react-datepicker__day--selected': this.isSameDay(this.props.selected),
+      'react-datepicker__day--highlighted': this.isHighlighted(),
       'react-datepicker__day--range-start': this.isRangeStart(),
       'react-datepicker__day--range-end': this.isRangeEnd(),
       'react-datepicker__day--in-range': this.isInRange(),

--- a/src/month.jsx
+++ b/src/month.jsx
@@ -10,6 +10,7 @@ var Month = React.createClass({
     excludeDates: React.PropTypes.array,
     filterDate: React.PropTypes.func,
     fixedHeight: React.PropTypes.bool,
+    highlightDates: React.PropTypes.array,
     includeDates: React.PropTypes.array,
     maxDate: React.PropTypes.object,
     minDate: React.PropTypes.object,
@@ -46,6 +47,7 @@ var Month = React.createClass({
             maxDate={this.props.maxDate}
             excludeDates={this.props.excludeDates}
             includeDates={this.props.includeDates}
+            highlightDates={this.props.highlightDates}
             filterDate={this.props.filterDate}
             selected={this.props.selected}
             startDate={this.props.startDate}

--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -131,6 +131,16 @@
     font-weight: bold;
   }
 
+  &--highlighted {
+    border-radius: $border-radius;
+    background-color: $highlighted-color;
+    color: #fff;
+
+    &:hover {
+      background-color: darken($highlighted-color, 5%);
+    }
+  }
+
   &--selected,
   &--in-range {
     border-radius: $border-radius;

--- a/src/stylesheets/variables.scss
+++ b/src/stylesheets/variables.scss
@@ -1,6 +1,7 @@
 $border-color: #aeaeae;
 $background-color: #f0f0f0;
 $selected-color: #216ba5;
+$highlighted-color: #3dcc4a;
 $muted-color: #ccc;
 $text-color: #000;
 

--- a/src/week.jsx
+++ b/src/week.jsx
@@ -9,6 +9,7 @@ var Week = React.createClass({
     endDate: React.PropTypes.object,
     excludeDates: React.PropTypes.array,
     filterDate: React.PropTypes.func,
+    highlightDates: React.PropTypes.array,
     includeDates: React.PropTypes.array,
     maxDate: React.PropTypes.object,
     minDate: React.PropTypes.object,
@@ -39,6 +40,7 @@ var Week = React.createClass({
             maxDate={this.props.maxDate}
             excludeDates={this.props.excludeDates}
             includeDates={this.props.includeDates}
+            highlightDates={this.props.highlightDates}
             filterDate={this.props.filterDate}
             selected={this.props.selected}
             startDate={this.props.startDate}

--- a/test/day_test.js
+++ b/test/day_test.js
@@ -35,6 +35,28 @@ describe('Day', () => {
     })
   })
 
+  describe('highlighted', () => {
+    const className = 'react-datepicker__day--highlighted'
+
+    it('should apply the highlighted class if in highlighted array', () => {
+      const day = moment()
+      const highlightDay1 = day.clone()
+      const highlightDay2 = day.clone().add(1, 'day')
+      const highlightDates = [highlightDay1, highlightDay2]
+      const shallowDay = renderDay(day, { highlightDates })
+      expect(shallowDay.hasClass(className)).to.equal(true)
+    })
+
+    it('should not apply the highlighted class if not in highlighted array', () => {
+      const day = moment()
+      const highlightDay1 = day.clone().subtract(1, 'day')
+      const highlightDay2 = day.clone().add(1, 'day')
+      const highlightDates = [highlightDay1, highlightDay2]
+      const shallowDay = renderDay(day, { highlightDates })
+      expect(shallowDay.hasClass(className)).to.equal(false)
+    })
+  })
+
   describe('in range', () => {
     const className = 'react-datepicker__day--in-range'
 


### PR DESCRIPTION
This just adds another parameter `highlightDates` to the `DatePicker` component which accepts an array of Moment objects representing the dates to be highlighted.

Highlighted dates will display with a green background in the calendar.

I've used this in my own log/journal app to indicate days that already have existing entries.  
  

![2016-08-06 14_18_34-localhost_3000](https://cloud.githubusercontent.com/assets/8106053/17459308/188e8882-5be7-11e6-9fb4-8c41fc3aa5d1.png)
