### PR TITLE
Add ability to pass a custom input

### DIFF
--- a/docs-site/src/example_components.jsx
+++ b/docs-site/src/example_components.jsx
@@ -23,6 +23,7 @@ import TimeZoneDate from './examples/timezone_date'
 import Inline from './examples/inline'
 import OpenToDate from './examples/open_to_date'
 import FixedCalendar from './examples/fixed_calendar'
+import CustomInput from './examples/custom_input'
 
 import 'react-datepicker/dist/react-datepicker.css'
 import './style.scss'
@@ -118,6 +119,10 @@ export default React.createClass({
     {
       title: 'Fixed height of Calendar',
       component: <FixedCalendar />
+    },
+    {
+      title: 'Custom input',
+      component: <CustomInput />
     }
   ],
 

--- a/docs-site/src/examples.scss
+++ b/docs-site/src/examples.scss
@@ -83,3 +83,13 @@
 .red-border {
   border-color: #f00;
 }
+
+.example-custom-input {
+  cursor: pointer;
+  padding: 5px 15px;
+  border: 0;
+  border-radius: 4px;
+  background-color: #216ba5;
+  font: inherit;
+  color: #fff;
+}

--- a/docs-site/src/examples/custom_input.jsx
+++ b/docs-site/src/examples/custom_input.jsx
@@ -11,15 +11,10 @@ var ExampleCustomInput = React.createClass({
     value: React.PropTypes.string
   },
 
-  handleFocus () {
-    this.props.onFocus()
-  },
-
   render () {
     return (
       <button
           className="example-custom-input"
-          onFocus={this.handleFocus}
           onClick={this.props.onClick}>
           {this.props.value}
       </button>

--- a/docs-site/src/examples/custom_input.jsx
+++ b/docs-site/src/examples/custom_input.jsx
@@ -1,0 +1,84 @@
+import React from 'react'
+import DatePicker from 'react-datepicker'
+import moment from 'moment'
+
+/* eslint-disable react/no-multi-comp */
+var ExampleCustomInput = React.createClass({
+  displayName: 'ExampleCustomInput',
+
+  propTypes: {
+    onClick: React.PropTypes.func,
+    value: React.PropTypes.string
+  },
+
+  handleFocus () {
+    this.props.onFocus()
+  },
+
+  render () {
+    return (
+      <button
+          className="example-custom-input"
+          onFocus={this.handleFocus}
+          onClick={this.props.onClick}>
+          {this.props.value}
+      </button>
+    )
+  }
+})
+
+export default React.createClass({
+  displayName: 'Custom Input',
+
+  getInitialState () {
+    return {
+      startDate: moment()
+    }
+  },
+
+  handleChange (date) {
+    this.setState({
+      startDate: date
+    })
+  },
+
+  render () {
+    return <div className="row">
+      <pre className="column example__code">
+        <code className="jsx">
+          {"var ExampleCustomInput = React.createClass({"}<br />
+            {"displayName: 'ExampleCustomInput',"}<br />
+          <br />
+            {"propTypes: {"}<br />
+              {"onClick: React.PropTypes.func,"}<br />
+              {"value: React.PropTypes.string"}<br />
+            {"},"}<br />
+          <br />
+            {"render () {"}<br />
+              {"return ("}<br />
+                {"<button"}<br />
+                  {"className=\"example-custom-input\""}<br />
+                  {"onClick={this.props.onClick}>"}<br />
+                  {"{this.props.value}"}<br />
+                {"</button>"}<br />
+              {")"}<br />
+            {"}"}<br />
+          {"})"}<br />
+          <br />
+          {"..."}<br />
+          <br />
+          {"<DatePicker"}<br />
+              {"customInput={<ExampleCustomInput />}"}<br />
+              {"selected={this.state.startDate}"}<br />
+              {"onChange={this.handleChange} />"}
+        </code>
+      </pre>
+      <div className="column">
+        <DatePicker
+            customInput={<ExampleCustomInput />}
+            selected={this.state.startDate}
+            onChange={this.handleChange} />
+      </div>
+    </div>
+  }
+})

--- a/src/date_input.jsx
+++ b/src/date_input.jsx
@@ -6,6 +6,7 @@ var DateInput = React.createClass({
   displayName: 'DateInput',
 
   propTypes: {
+    customInput: React.PropTypes.element,
     date: React.PropTypes.object,
     dateFormat: React.PropTypes.oneOfType([
       React.PropTypes.string,
@@ -86,7 +87,18 @@ var DateInput = React.createClass({
   },
 
   render () {
-    const { date, locale, minDate, maxDate, excludeDates, includeDates, filterDate, dateFormat, onChangeDate, ...rest } = this.props // eslint-disable-line no-unused-vars
+    const { customInput, date, locale, minDate, maxDate, excludeDates, includeDates, filterDate, dateFormat, onChangeDate, ...rest } = this.props // eslint-disable-line no-unused-vars
+
+    if (customInput) {
+      return React.cloneElement(customInput, {
+        ...rest,
+        ref: 'input',
+        value: this.state.value,
+        onBlur: this.handleBlur,
+        onChange: this.handleChange
+      })
+    }
+
     return <input
         ref='input'
         type='text'

--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -18,6 +18,7 @@ var DatePicker = React.createClass({
   propTypes: {
     autoComplete: React.PropTypes.string,
     className: React.PropTypes.string,
+    customInput: React.PropTypes.element,
     dateFormat: React.PropTypes.oneOfType([
       React.PropTypes.string,
       React.PropTypes.array
@@ -189,7 +190,8 @@ var DatePicker = React.createClass({
         title={this.props.title}
         readOnly={this.props.readOnly}
         required={this.props.required}
-        tabIndex={this.props.tabIndex} />
+        tabIndex={this.props.tabIndex}
+        customInput={this.props.customInput} />
   },
 
   renderClearButton () {

--- a/test/date_input_test.js
+++ b/test/date_input_test.js
@@ -381,4 +381,16 @@ describe('DateInput', function () {
       expect(dateInput.find('input').prop('value')).to.equal(date.format(dateFormat))
     })
   })
+
+  it('should render custom input when customInput is passed as prop', function () {
+    var date = moment()
+    var dateFormat = 'YYYY-MM-DD'
+    var inputElement = <button className="test-input">Click me to open date</button>
+    var dateInput = shallow(
+      <DateInput customInput={inputElement} date={date} dateFormat={dateFormat}/>
+    )
+
+    expect(dateInput.find('.test-input').length).to.equal(1)
+    expect(dateInput.find('.test-input').type()).to.equal('button')
+  })
 })


### PR DESCRIPTION
Addresses https://github.com/Hacker0x01/react-datepicker/issues/529

Added a `customInput` prop which allows you to pass in your own component, allowing you to add custom functionality and styling.