### PR TITLE
added transform-es2015-destructuring to .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -9,7 +9,8 @@
             "imports": ["react"],
             "locals": ["module"]
           }]
-        }]
+        }, 
+        "transform-es2015-destructuring"]
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "babel-core": "^6.8.0",
     "babel-loader": "^6.2.4",
     "babel-plugin-react-transform": "^2.0.2",
+    "babel-plugin-transform-es2015-destructuring": "^6.16.0",
     "babel-preset-airbnb": "^2.0.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",


### PR DESCRIPTION
After upgrading to React 15.3.2 I started seeing a bunch of 'Unknown props' warnings (shown below).  Apparently babel does not handle 'rest' destructuring unless the transform-es2015-destructuring plugin is enabled.  Adding this transform ensures the 'Unknown props' shown below are excluded from the props set on the 'input' element (src/date_input.jsx:90).

warning.js:36Warning: Unknown props `date`, `locale`, `minDate`, `maxDate`, `excludeDates`, `includeDates`, `filterDate`, `dateFormat`, `onChangeDate` on <input> tag. Remove these props from the element. For details, see https://fb.me/react-unknown-prop