### PR TITLE
Fix positioning of calendar when month is changed

### DIFF
--- a/src/tether_component.jsx
+++ b/src/tether_component.jsx
@@ -74,7 +74,7 @@ var TetherComponent = React.createClass({
   },
 
   position () {
-    this._tether.position()
+    this._updatePosition()
   },
 
   _destroy () {
@@ -124,20 +124,27 @@ var TetherComponent = React.createClass({
   },
 
   _updateTether () {
-    const { renderElementTag, renderElementTo, ...options } = this.props // eslint-disable-line no-unused-vars
-    const tetherOptions = {
-      target: this._targetNode,
-      element: this._elementParentNode,
-      ...options
-    }
+    setTimeout(() => {
+      const { renderElementTag, renderElementTo, ...options } = this.props // eslint-disable-line no-unused-vars
+      const tetherOptions = {
+        target: this._targetNode,
+        element: this._elementParentNode,
+        ...options
+      }
 
-    if (!this._tether) {
-      this._tether = new Tether(tetherOptions)
-    } else {
-      this._tether.setOptions(tetherOptions)
-    }
+      if (!this._tether) {
+        this._tether = new Tether(tetherOptions)
+      } else {
+        this._tether.setOptions(tetherOptions)
+      }
 
-    this._tether.position()
+      this._updatePosition()
+    }, 100)
+  },
+
+  _updatePosition () {
+    for (var i = 0; i < 10; i++)
+      this._tether.position()
   },
 
   render () {


### PR DESCRIPTION
For some months there is an extra row of days. Tether component calls
position method of tether instance but at the moment that method called
react doesn't update the real dom. As well as fixing this asynchronous
problem, there is an another bug in tether library, which can not
recalculate the position for the first call of `position()` method. I
observed if you call that method many times (between 1 - 10) it finally
recalculate correctly.

PS: I'm aware of how `setTimout` and `for loop` looks ugly. If you have a better idea i would like to hear.