### PR TITLE
Correct proptypes to reflect updated docs

### DIFF
--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -25,7 +25,7 @@ var Calendar = React.createClass({
     dateFormat: React.PropTypes.oneOfType([
       React.PropTypes.string,
       React.PropTypes.array
-    ]),
+    ]).isRequired,
     dropdownMode: React.PropTypes.oneOf(['scroll', 'select']).isRequired,
     endDate: React.PropTypes.object,
     excludeDates: React.PropTypes.array,
@@ -59,7 +59,6 @@ var Calendar = React.createClass({
 
   getDefaultProps () {
     return {
-      dateFormat: 'L',
       utcOffset: moment.utc().utcOffset()
     }
   },

--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -22,7 +22,10 @@ var Calendar = React.createClass({
   displayName: 'Calendar',
 
   propTypes: {
-    dateFormat: React.PropTypes.string.isRequired,
+    dateFormat: React.PropTypes.oneOfType([
+      React.PropTypes.string,
+      React.PropTypes.array
+    ]),
     dropdownMode: React.PropTypes.oneOf(['scroll', 'select']).isRequired,
     endDate: React.PropTypes.object,
     excludeDates: React.PropTypes.array,
@@ -56,6 +59,7 @@ var Calendar = React.createClass({
 
   getDefaultProps () {
     return {
+      dateFormat: 'L',
       utcOffset: moment.utc().utcOffset()
     }
   },


### PR DESCRIPTION
In 441edf887e76f51e631527d6c03c45bda673c046 we manually updated the docs, this won’t hold if we’re releasing new docs. I updated the code that’s used to generate docs. Please make sure this is correct.