### PR TITLE
Prevent browsers autocomplete suggestions.

### DIFF
--- a/src/date_input.jsx
+++ b/src/date_input.jsx
@@ -105,7 +105,8 @@ var DateInput = React.createClass({
         {...rest}
         value={this.state.value}
         onBlur={this.handleBlur}
-        onChange={this.handleChange} />
+        onChange={this.handleChange} 
+        autocomplete="off" />
   }
 })
 


### PR DESCRIPTION
Using react-datepicker i noticed that the browser still show autocomplete suggestions based on previous values used on the field. This suggestion is a dropdown and overlaps the calendar.