### PR TITLE
support other specs for preventDefault

### DIFF
--- a/src/date_input.jsx
+++ b/src/date_input.jsx
@@ -50,7 +50,7 @@ var DateInput = React.createClass({
     if (this.props.onChange) {
       this.props.onChange(event)
     }
-    if (event.defaultPrevented === false || (typeof event.isDefaultPrevented === 'function' && !event.isDefaultPrevented())) {
+    if (!event.defaultPrevented) {
       this.handleChangeDate(event.target.value)
     }
   },

--- a/src/date_input.jsx
+++ b/src/date_input.jsx
@@ -50,7 +50,7 @@ var DateInput = React.createClass({
     if (this.props.onChange) {
       this.props.onChange(event)
     }
-    if (!event.isDefaultPrevented()) {
+    if (event.defaultPrevented === false || (typeof event.isDefaultPrevented === 'function' && !event.isDefaultPrevented())) {
       this.handleChangeDate(event.target.value)
     }
   },

--- a/test/date_input_test.js
+++ b/test/date_input_test.js
@@ -198,7 +198,7 @@ describe('DateInput', function () {
       <DateInput date={null} dateFormat={dateFormat} onChange={onChange} onChangeDate={onChangeDate} />
     )
     dateInput.find('input').simulate('change', {
-      isDefaultPrevented: () => true,
+      defaultPrevented: true,
       preventDefault: () => {},
       target: {
         value: date.format(dateFormat)


### PR DESCRIPTION
With custom inputs, sometimes you could get a DOM event vs. a JS event. This change accommodates both. 