### PR TITLE
Fix month arrow visibility issue

### DIFF
--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -68,6 +68,7 @@
   top: 10px;
   width: 0;
   border: $navigation-size solid transparent;
+  z-index: 1;
 
   &--previous {
     left: 10px;


### PR DESCRIPTION
When manually testing my other pull request, I noticed that the month navigation arrows were missing. I added a z-index to the react-datepicker__navigation class to fix.