### PR TITLE
Use default date when initiating keyboard navigation

### DIFF
--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -154,7 +154,7 @@ var DatePicker = React.createClass({
   },
 
   onInputKeyDown (event) {
-    const copy = this.props.selected ? moment(this.props.selected) : moment();
+    const copy = this.props.selected ? moment(this.props.selected) : moment()
     if (event.key === 'Enter' || event.key === 'Escape') {
       event.preventDefault()
       this.setOpen(false)

--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -154,7 +154,7 @@ var DatePicker = React.createClass({
   },
 
   onInputKeyDown (event) {
-    const copy = moment(this.props.selected)
+    const copy = this.props.selected ? moment(this.props.selected) : moment();
     if (event.key === 'Enter' || event.key === 'Escape') {
       event.preventDefault()
       this.setOpen(false)


### PR DESCRIPTION
This resolves #607 by ensuring that there is a valid date available to start the keyboard navigation/selection from.
