### PR TITLE
fix regression when clearing input field

### DIFF
--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -145,7 +145,7 @@ var DatePicker = React.createClass({
     let changedDate = date
 
     if (!isSameDay(this.props.selected, changedDate)) {
-      if (this.props.selected) {
+      if (this.props.selected && changedDate != null) {
         changedDate = moment(changedDate).set({
           hour: this.props.selected.hour(),
           minute: this.props.selected.minute(),

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -329,4 +329,24 @@ describe('DatePicker', () => {
     datePicker.setFocus()
     expect(div.querySelector('input')).to.equal(document.activeElement)
   })
+
+  it('should correctly clear date with empty input string', () => {
+    var cleared = false
+    function handleChange (d) {
+      // Internally DateInput calls it's onChange prop with null
+      // when the input value is an empty string
+      if (d === null) {
+        cleared = true
+      }
+    }
+    var datePicker = TestUtils.renderIntoDocument(
+      <DatePicker
+          selected={moment('2016-11-22')}
+          onChange={handleChange} />
+    )
+    var input = ReactDOM.findDOMNode(datePicker.refs.input)
+    input.value = ''
+    TestUtils.Simulate.change(input)
+    expect(cleared).to.be.true
+  })
 })


### PR DESCRIPTION
A regression was introduced in this pull request #608

DateInput calls it's `onChange` prop with a `null` date if the input value is and empty string (https://github.com/Hacker0x01/react-datepicker/blob/master/src/date_input.jsx#L64). That value is then parsed by moment into an 'Invalid Date' in the DatePicker (https://github.com/Hacker0x01/react-datepicker/blob/master/src/datepicker.jsx#L149) and then passed as a parameter to it's `onChange` prop.

This pull request fixes the regression and passes `null` instead. This is the same behavior that DatePicker had before #608