### PR TITLE
emit errors for unused prop types

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -46,6 +46,7 @@
     "react/no-multi-comp": 2,
     "react/no-set-state": 0,
     "react/no-unknown-property": 2,
+    "react/no-unused-prop-types": 2,
     "react/prefer-es6-class": 0,
     "react/prop-types": 2,
     "react/react-in-jsx-scope": 2,

--- a/src/day.jsx
+++ b/src/day.jsx
@@ -9,12 +9,7 @@ var Day = React.createClass({
   propTypes: {
     day: React.PropTypes.object.isRequired,
     endDate: React.PropTypes.object,
-    excludeDates: React.PropTypes.array,
-    filterDate: React.PropTypes.func,
     highlightDates: React.PropTypes.array,
-    includeDates: React.PropTypes.array,
-    maxDate: React.PropTypes.object,
-    minDate: React.PropTypes.object,
     month: React.PropTypes.number,
     onClick: React.PropTypes.func,
     onMouseEnter: React.PropTypes.func,


### PR DESCRIPTION
Since the PropTypes are the only documentation for a lot of features, they should be correct. Otherwise, they only cause confusion.