### PR TITLE
Upgrade react-onclickoutside

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "moment": "^2.13.0",
-    "react-onclickoutside": "^4.8.0",
+    "react-onclickoutside": "^5.7.1",
     "tether": "^1.3.2"
   },
   "scripts": {

--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -54,8 +54,6 @@ var Calendar = React.createClass({
     utcOffset: React.PropTypes.number
   },
 
-  mixins: [require('react-onclickoutside')],
-
   defaultProps: {
     onDropdownFocus: () => {}
   },

--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -6,8 +6,10 @@ import TetherComponent from './tether_component'
 import classnames from 'classnames'
 import { isSameDay } from './date_utils'
 import moment from 'moment'
+import onClickOutside from 'react-onclickoutside'
 
 var outsideClickIgnoreClass = 'react-datepicker-ignore-onclickoutside'
+var WrappedCalendar = onClickOutside(Calendar)
 
 /**
  * General datepicker component.
@@ -206,7 +208,7 @@ var DatePicker = React.createClass({
     if (!this.props.inline && (!this.state.open || this.props.disabled)) {
       return null
     }
-    return <Calendar
+    return <WrappedCalendar
         ref="calendar"
         locale={this.props.locale}
         dateFormat={this.props.dateFormatCalendar}

--- a/src/year_dropdown.jsx
+++ b/src/year_dropdown.jsx
@@ -1,5 +1,8 @@
 import React from 'react'
 import YearDropdownOptions from './year_dropdown_options'
+import onClickOutside from 'react-onclickoutside'
+
+var WrappedYearDropdownOptions = onClickOutside(YearDropdownOptions)
 
 var YearDropdown = React.createClass({
   displayName: 'YearDropdown',
@@ -56,7 +59,7 @@ var YearDropdown = React.createClass({
 
   renderDropdown () {
     return (
-      <YearDropdownOptions
+      <WrappedYearDropdownOptions
           ref="options"
           year={this.props.year}
           onChange={this.onChange}

--- a/src/year_dropdown_options.jsx
+++ b/src/year_dropdown_options.jsx
@@ -19,8 +19,6 @@ var YearDropdownOptions = React.createClass({
     year: React.PropTypes.number.isRequired
   },
 
-  mixins: [require('react-onclickoutside')],
-
   getInitialState () {
     return {
       yearsList: this.props.scrollableYearDropdown ? generateYears(this.props.year, 50) : generateYears(this.props.year, 5)


### PR DESCRIPTION
I moved the wrapping code outside of the actual class implementations to be able to unit-test those.