### PR TITLE
Returned false in forEach in the render of TetherComponent components

### DIFF
--- a/src/tether_component.jsx
+++ b/src/tether_component.jsx
@@ -149,7 +149,7 @@ var TetherComponent = React.createClass({
     Children.forEach(children, (child, index) => {
       if (index === 0) {
         firstChild = child
-        return
+        return false
       }
     })
 


### PR DESCRIPTION
If this loop:
```
Children.forEach(children, (child, index) => {
       if (index === 0) {
         firstChild = child
        return
}
```
don't returned any value (now return `undefined`), this code will be compiled (only for minimize version) to:
```
return s.Children.forEach(e, function(e, n) {
    if (0 === n) return void(t = e)
}), t
```
(You can see `dist/react-datepicker.min`). And the expression in operator `void` will not be invoked. And component will not be rendered.

I added `return false` in the loop, and now for minimize version operator `will not appear` will not appear.