### PR TITLE
remove `dateFormatCalendar` prop from example

### DIFF
--- a/docs-site/src/examples/month_dropdown.jsx
+++ b/docs-site/src/examples/month_dropdown.jsx
@@ -24,16 +24,14 @@ export default React.createClass({
           {'<DatePicker'}<br />
               {'selected={this.state.startDate}'}<br />
               {'onChange={this.handleChange}'} <br />
-              {'showMonthDropdown'} <br />
-              {'dateFormatCalendar="MMMM" />'}
+              {'showMonthDropdown'} <br /> }
         </code>
       </pre>
       <div className="column">
         <DatePicker
             selected={this.state.startDate}
             onChange={this.handleChange}
-            showMonthDropdown
-            dateFormatCalendar="MMMM" />
+            showMonthDropdown />
       </div>
     </div>
   }


### PR DESCRIPTION
It doesn't accomplish anything useful here, in fact, it rather confused me that the year was not shown.