### PR TITLE
Verify we have input 'ref' before calling 'focus()' to avoid NPE

### DIFF
--- a/src/date_input.jsx
+++ b/src/date_input.jsx
@@ -83,7 +83,9 @@ var DateInput = React.createClass({
   },
 
   focus () {
-    this.refs.input.focus()
+    if(this.refs.input) {
+      this.refs.input.focus()
+    }
   },
 
   render () {

--- a/src/date_input.jsx
+++ b/src/date_input.jsx
@@ -83,7 +83,7 @@ var DateInput = React.createClass({
   },
 
   focus () {
-    if(this.refs.input) {
+    if (this.refs.input) {
       this.refs.input.focus()
     }
   },


### PR DESCRIPTION
If you're wrapping a `stateless functional component` you will not have a ref. 