### PR TITLE
Add portal for mobile support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ dist
 lib
 tmp
 coverage
+docs-site/bundle.js
+docs-site/style.css
 
 docs/calendar.md
 docs/date_input.md

--- a/docs-site/src/example_components.jsx
+++ b/docs-site/src/example_components.jsx
@@ -31,6 +31,7 @@ import CustomInput from './examples/custom_input'
 import MultiMonth from './examples/multi_month'
 import MultiMonthDrp from './examples/multi_month_drp'
 import Children from './examples/children'
+import Portal from './examples/portal'
 
 import 'react-datepicker/dist/react-datepicker.css'
 import './style.scss'
@@ -110,6 +111,10 @@ export default React.createClass({
     {
       title: 'Configure Popover Placement',
       component: <Placement />
+    },
+    {
+      title: 'Portal version',
+      component: <Portal />
     },
     {
       title: 'TabIndex',

--- a/docs-site/src/examples/portal.jsx
+++ b/docs-site/src/examples/portal.jsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import DatePicker from 'react-datepicker'
+import moment from 'moment'
+
+export default React.createClass({
+  displayName: 'With Portal',
+
+  getInitialState () {
+    return {
+      startDate: moment()
+    }
+  },
+
+  handleChange (date) {
+    this.setState({
+      startDate: date
+    })
+  },
+
+  render () {
+    return <div className="row">
+      <pre className="column example__code">
+        <code className="jsx">
+          {'<DatePicker'}<br />
+              {'selected={this.state.startDate}'}<br />
+              {'onChange={this.handleChange}'}<br />
+              {'withPortal />'}
+        </code>
+      </pre>
+      <div className="column">
+        <DatePicker
+            selected={this.state.startDate}
+            onChange={this.handleChange}
+            withPortal />
+      </div>
+    </div>
+  }
+})

--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -71,7 +71,8 @@ var DatePicker = React.createClass({
     tetherConstraints: React.PropTypes.array,
     title: React.PropTypes.string,
     todayButton: React.PropTypes.string,
-    utcOffset: React.PropTypes.number
+    utcOffset: React.PropTypes.number,
+    withPortal: React.PropTypes.bool
   },
 
   getDefaultProps () {
@@ -93,7 +94,8 @@ var DatePicker = React.createClass({
         }
       ],
       utcOffset: moment.utc().utcOffset(),
-      monthsShown: 1
+      monthsShown: 1,
+      withPortal: false
     }
   },
 
@@ -302,23 +304,41 @@ var DatePicker = React.createClass({
 
     if (this.props.inline) {
       return calendar
-    } else {
+    }
+
+    if (this.props.withPortal) {
       return (
-        <TetherComponent
-            classPrefix={'react-datepicker__tether'}
-            attachment={this.props.popoverAttachment}
-            targetAttachment={this.props.popoverTargetAttachment}
-            targetOffset={this.props.popoverTargetOffset}
-            renderElementTo={this.props.renderCalendarTo}
-            constraints={this.props.tetherConstraints}>
+        <div>
           <div className="react-datepicker__input-container">
             {this.renderDateInput()}
             {this.renderClearButton()}
           </div>
-          {calendar}
-        </TetherComponent>
+          {
+          this.state.open
+          ? <div className="react-datepicker__portal">
+              {calendar}
+            </div>
+          : null
+          }
+        </div>
       )
     }
+
+    return (
+      <TetherComponent
+          classPrefix={'react-datepicker__tether'}
+          attachment={this.props.popoverAttachment}
+          targetAttachment={this.props.popoverTargetAttachment}
+          targetOffset={this.props.popoverTargetOffset}
+          renderElementTo={this.props.renderCalendarTo}
+          constraints={this.props.tetherConstraints}>
+        <div className="react-datepicker__input-container">
+          {this.renderDateInput()}
+          {this.renderClearButton()}
+        </div>
+        {calendar}
+      </TetherComponent>
+    )
   }
 })
 

--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -329,3 +329,57 @@
 .react-datepicker__tether-element {
   z-index: 2147483647;
 }
+
+.react-datepicker__portal {
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, .8);
+  left: 0;
+  top: 0;
+  justify-content: center;
+  align-items: center;
+  display: flex;
+  z-index: 2147483647;
+
+  .react-datepicker__day-name,
+  .react-datepicker__day {
+    width: 3rem;
+    line-height: 3rem;
+  }
+
+  // Resize for small screens
+  @media (max-width: 400px), (max-height: 400px)  {
+    .react-datepicker__day-name,
+    .react-datepicker__day {
+      width: 2rem;
+      line-height: 2rem;
+    }
+  }
+
+  .react-datepicker__current-month {
+    font-size: $font-size * 1.8;
+  }
+
+  .react-datepicker__navigation {
+    border: 1.8 * $navigation-size solid transparent;
+  }
+
+  .react-datepicker__navigation--previous {
+    border-right-color: $muted-color;
+
+    &:hover {
+      border-right-color: darken($muted-color, 10%);
+    }
+  }
+
+  .react-datepicker__navigation--next {
+    border-left-color: $muted-color;
+
+    &:hover {
+      border-left-color: darken($muted-color, 10%);
+    }
+  }
+}
+
+

--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -332,8 +332,8 @@
 
 .react-datepicker__portal {
   position: fixed;
-  width: 100%;
-  height: 100%;
+  width: 100vw;
+  height: 100vh;
   background-color: rgba(0, 0, 0, .8);
   left: 0;
   top: 0;

--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -349,7 +349,7 @@
   }
 
   // Resize for small screens
-  @media (max-width: 400px), (max-height: 400px)  {
+  @media (max-width: 400px), (max-height: 550px)  {
     .react-datepicker__day-name,
     .react-datepicker__day {
       width: 2rem;

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -237,6 +237,26 @@ describe('DatePicker', () => {
     expect(datePicker.refs.calendar).to.exist
   })
 
+  it('should render Calendar in portal when withPortal is set and input has focus', () => {
+    var datePicker = TestUtils.renderIntoDocument(
+      <DatePicker withPortal />
+    )
+    var dateInput = datePicker.refs.input
+    TestUtils.Simulate.focus(ReactDOM.findDOMNode(dateInput))
+
+    expect(function () { TestUtils.findRenderedDOMComponentWithClass(datePicker, 'react-datepicker__portal') }).to.not.throw()
+    expect(datePicker.refs.calendar).to.exist
+  })
+
+  it('should not render Calendar when withPortal is set and no focus is given to input', () => {
+    var datePicker = TestUtils.renderIntoDocument(
+      <DatePicker withPortal />
+    )
+
+    expect(function () { TestUtils.findRenderedDOMComponentWithClass(datePicker, 'react-datepicker__portal') }).to.throw()
+    expect(datePicker.refs.calendar).not.to.exist
+  })
+
   function getOnInputKeyDownStuff () {
     var m = moment()
     var copyM = moment(m)


### PR DESCRIPTION
This PR adds a new prop which creates a Portal/Overlay version of the calendar, and fixes issue #695 

This helps if the calendar is being used by a mobile device, or other small screen.

If the prop `withPortal` is passed, it will create a portal version of the calendar.

Example:
```js
<DatePicker
selected={this.state.startDate}
onChange={this.handleChange}
withPortal />
```

<img src="https://cloud.githubusercontent.com/assets/9244507/21877472/3b62b79e-d8f0-11e6-82b4-8e689a463754.png" width="400" />

The docs have been updated. No tests have been updated as this did not affect any, and no new tests added as the logic is very straight forward.

Happy to hear feedback/changes.