### PR TITLE
Add an option that disabled navigation keys

### DIFF
--- a/docs-site/src/example_components.jsx
+++ b/docs-site/src/example_components.jsx
@@ -13,7 +13,7 @@ import HighlightDates from './examples/highlight_dates'
 import IncludeDates from './examples/include_dates'
 import FilterDates from './examples/filter_dates'
 import Disabled from './examples/disabled'
-import DisabledNavigation from './examples/disabled_navigation'
+import DisabledKeyboardNavigation from './examples/disabled_keyboard_navigation'
 import ClearInput from './examples/clear_input'
 import OnBlurCallbacks from './examples/on_blur_callbacks'
 import Placement from './examples/placement'
@@ -101,8 +101,8 @@ export default React.createClass({
       component: <Disabled />
     },
     {
-      title: 'Disable navigation',
-      component: <DisabledNavigation />
+      title: 'Disable keyboard navigation',
+      component: <DisabledKeyboardNavigation />
     },
     {
       title: 'Clear datepicker input',

--- a/docs-site/src/example_components.jsx
+++ b/docs-site/src/example_components.jsx
@@ -13,6 +13,7 @@ import HighlightDates from './examples/highlight_dates'
 import IncludeDates from './examples/include_dates'
 import FilterDates from './examples/filter_dates'
 import Disabled from './examples/disabled'
+import DisabledNavigation from './examples/disabled_navigation'
 import ClearInput from './examples/clear_input'
 import OnBlurCallbacks from './examples/on_blur_callbacks'
 import Placement from './examples/placement'
@@ -98,6 +99,10 @@ export default React.createClass({
     {
       title: 'Disable datepicker',
       component: <Disabled />
+    },
+    {
+      title: 'Disable navigation',
+      component: <DisabledNavigation />
     },
     {
       title: 'Clear datepicker input',

--- a/docs-site/src/examples/disabled_keyboard_navigation.jsx
+++ b/docs-site/src/examples/disabled_keyboard_navigation.jsx
@@ -3,7 +3,7 @@ import DatePicker from 'react-datepicker'
 import moment from 'moment'
 
 export default React.createClass({
-  displayName: 'DisabledNavigation',
+  displayName: 'DisabledKeyboardNavigation',
 
   getInitialState () {
     return {
@@ -24,16 +24,16 @@ export default React.createClass({
           {'<DatePicker'}<br />
               {'selected={this.state.startDate}'}<br />
               {'onChange={this.handleChange}'}<br />
-              <strong>{'disabledNavigation />'}</strong><br />
-              {'placeholderText="This has disabled navigation"'}
+              <strong>{'disabledKeyboardNavigation />'}</strong><br />
+              {'placeholderText="This has disabled keyboard navigation"'}
         </code>
       </pre>
       <div className="column">
         <DatePicker
             selected={this.state.startDate}
             onChange={this.handleChange}
-            disabledNavigation
-            placeholderText="This has disabled navigation" />
+            disabledKeyboardNavigation
+            placeholderText="This has disabled keyboard navigation" />
       </div>
     </div>
   }

--- a/docs-site/src/examples/disabled_navigation.jsx
+++ b/docs-site/src/examples/disabled_navigation.jsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import DatePicker from 'react-datepicker'
+import moment from 'moment'
+
+export default React.createClass({
+  displayName: 'DisabledNavigation',
+
+  getInitialState () {
+    return {
+      startDate: moment()
+    }
+  },
+
+  handleChange (date) {
+    this.setState({
+      startDate: date
+    })
+  },
+
+  render () {
+    return <div className="row">
+      <pre className="column example__code">
+        <code className="jsx">
+          {'<DatePicker'}<br />
+              {'selected={this.state.startDate}'}<br />
+              {'onChange={this.handleChange}'}<br />
+              <strong>{'disabledNavigation />'}</strong><br />
+              {'placeholderText="This has disabled navigation"'}
+        </code>
+      </pre>
+      <div className="column">
+        <DatePicker
+            selected={this.state.startDate}
+            onChange={this.handleChange}
+            disabledNavigation
+            placeholderText="This has disabled navigation" />
+      </div>
+    </div>
+  }
+})

--- a/docs/datepicker.md
+++ b/docs/datepicker.md
@@ -43,6 +43,12 @@ type: `bool`
 defaultValue: `false`
 
 
+### `disabledNavigation`
+
+type: `bool`
+defaultValue: `false`
+
+
 ### `dropdownMode` (required)
 
 type: `enum('scroll'|'select')`
@@ -267,4 +273,3 @@ type: `string`
 
 type: `number`
 defaultValue: `moment.utc().utcOffset()`
-

--- a/docs/datepicker.md
+++ b/docs/datepicker.md
@@ -43,12 +43,6 @@ type: `bool`
 defaultValue: `false`
 
 
-### `disabledNavigation`
-
-type: `bool`
-defaultValue: `false`
-
-
 ### `dropdownMode` (required)
 
 type: `enum('scroll'|'select')`

--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -30,6 +30,7 @@ var DatePicker = React.createClass({
     ]),
     dateFormatCalendar: React.PropTypes.string,
     disabled: React.PropTypes.bool,
+    disabledNavigation: React.PropTypes.bool,
     dropdownMode: React.PropTypes.oneOf(['scroll', 'select']).isRequired,
     endDate: React.PropTypes.object,
     excludeDates: React.PropTypes.array,
@@ -79,6 +80,7 @@ var DatePicker = React.createClass({
       dateFormatCalendar: 'MMMM YYYY',
       onChange () {},
       disabled: false,
+      disabledNavigation: false,
       dropdownMode: 'scroll',
       onFocus () {},
       onBlur () {},
@@ -184,30 +186,33 @@ var DatePicker = React.createClass({
       this.setOpen(false)
     } else if (event.key === 'Tab') {
       this.setOpen(false)
-    } else if (event.key === 'ArrowLeft') {
-      event.preventDefault()
-      this.setSelected(copy.subtract(1, 'days'))
-    } else if (event.key === 'ArrowRight') {
-      event.preventDefault()
-      this.setSelected(copy.add(1, 'days'))
-    } else if (event.key === 'ArrowUp') {
-      event.preventDefault()
-      this.setSelected(copy.subtract(1, 'weeks'))
-    } else if (event.key === 'ArrowDown') {
-      event.preventDefault()
-      this.setSelected(copy.add(1, 'weeks'))
-    } else if (event.key === 'PageUp') {
-      event.preventDefault()
-      this.setSelected(copy.subtract(1, 'months'))
-    } else if (event.key === 'PageDown') {
-      event.preventDefault()
-      this.setSelected(copy.add(1, 'months'))
-    } else if (event.key === 'Home') {
-      event.preventDefault()
-      this.setSelected(copy.subtract(1, 'years'))
-    } else if (event.key === 'End') {
-      event.preventDefault()
-      this.setSelected(copy.add(1, 'years'))
+    }
+    if (!this.props.disabledNavigation) {
+      if (event.key === 'ArrowLeft') {
+        event.preventDefault()
+        this.setSelected(copy.subtract(1, 'days'))
+      } else if (event.key === 'ArrowRight') {
+        event.preventDefault()
+        this.setSelected(copy.add(1, 'days'))
+      } else if (event.key === 'ArrowUp') {
+        event.preventDefault()
+        this.setSelected(copy.subtract(1, 'weeks'))
+      } else if (event.key === 'ArrowDown') {
+        event.preventDefault()
+        this.setSelected(copy.add(1, 'weeks'))
+      } else if (event.key === 'PageUp') {
+        event.preventDefault()
+        this.setSelected(copy.subtract(1, 'months'))
+      } else if (event.key === 'PageDown') {
+        event.preventDefault()
+        this.setSelected(copy.add(1, 'months'))
+      } else if (event.key === 'Home') {
+        event.preventDefault()
+        this.setSelected(copy.subtract(1, 'years'))
+      } else if (event.key === 'End') {
+        event.preventDefault()
+        this.setSelected(copy.add(1, 'years'))
+      }
     }
   },
 

--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -30,7 +30,7 @@ var DatePicker = React.createClass({
     ]),
     dateFormatCalendar: React.PropTypes.string,
     disabled: React.PropTypes.bool,
-    disabledNavigation: React.PropTypes.bool,
+    disabledKeyboardNavigation: React.PropTypes.bool,
     dropdownMode: React.PropTypes.oneOf(['scroll', 'select']).isRequired,
     endDate: React.PropTypes.object,
     excludeDates: React.PropTypes.array,
@@ -80,7 +80,7 @@ var DatePicker = React.createClass({
       dateFormatCalendar: 'MMMM YYYY',
       onChange () {},
       disabled: false,
-      disabledNavigation: false,
+      disabledKeyboardNavigation: false,
       dropdownMode: 'scroll',
       onFocus () {},
       onBlur () {},
@@ -187,7 +187,7 @@ var DatePicker = React.createClass({
     } else if (event.key === 'Tab') {
       this.setOpen(false)
     }
-    if (!this.props.disabledNavigation) {
+    if (!this.props.disabledKeyboardNavigation) {
       if (event.key === 'ArrowLeft') {
         event.preventDefault()
         this.setSelected(copy.subtract(1, 'days'))

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -330,6 +330,62 @@ describe('DatePicker', () => {
     expect(div.querySelector('input')).to.equal(document.activeElement)
   })
 
+  function getOnInputKeyDownDisabledKeyboardNavigationStuff () {
+    var m = moment()
+    var copyM = moment(m)
+    var testFormat = 'YYYY-MM-DD'
+    var callback = sinon.spy()
+    var datePicker = TestUtils.renderIntoDocument(
+      <DatePicker selected={m} onChange={callback} disabledKeyboardNavigation/>
+    )
+    var dateInput = datePicker.refs.input
+    var nodeInput = ReactDOM.findDOMNode(dateInput)
+    TestUtils.Simulate.focus(nodeInput)
+    return {
+      m, copyM, testFormat, callback, datePicker, dateInput, nodeInput
+    }
+  }
+  it('should not handle onInputKeyDown ArrowLeft', () => {
+    var data = getOnInputKeyDownDisabledKeyboardNavigationStuff()
+    TestUtils.Simulate.keyDown(data.nodeInput, {key: 'ArrowLeft', keyCode: 37, which: 37})
+    expect(data.callback.called).to.be.false
+  })
+  it('should not handle onInputKeyDown ArrowRight', () => {
+    var data = getOnInputKeyDownDisabledKeyboardNavigationStuff()
+    TestUtils.Simulate.keyDown(data.nodeInput, {key: 'ArrowRight', keyCode: 39, which: 39})
+    expect(data.callback.called).to.be.false
+  })
+  it('should not handle onInputKeyDown ArrowUp', () => {
+    var data = getOnInputKeyDownDisabledKeyboardNavigationStuff()
+    TestUtils.Simulate.keyDown(data.nodeInput, {key: 'ArrowUp', keyCode: 38, which: 38})
+    expect(data.callback.called).to.be.false
+  })
+  it('should not handle onInputKeyDown ArrowDown', () => {
+    var data = getOnInputKeyDownDisabledKeyboardNavigationStuff()
+    TestUtils.Simulate.keyDown(data.nodeInput, {key: 'ArrowDown', keyCode: 40, which: 40})
+    expect(data.callback.called).to.be.false
+  })
+  it('should not handle onInputKeyDown PageUp', () => {
+    var data = getOnInputKeyDownDisabledKeyboardNavigationStuff()
+    TestUtils.Simulate.keyDown(data.nodeInput, {key: 'PageUp', keyCode: 33, which: 33})
+    expect(data.callback.called).to.be.false
+  })
+  it('should not handle onInputKeyDown PageDown', () => {
+    var data = getOnInputKeyDownDisabledKeyboardNavigationStuff()
+    TestUtils.Simulate.keyDown(data.nodeInput, {key: 'PageDown', keyCode: 34, which: 34})
+    expect(data.callback.called).to.be.false
+  })
+  it('should not handle onInputKeyDown Home', () => {
+    var data = getOnInputKeyDownDisabledKeyboardNavigationStuff()
+    TestUtils.Simulate.keyDown(data.nodeInput, {key: 'Home', keyCode: 36, which: 36})
+    expect(data.callback.called).to.be.false
+  })
+  it('should not handle onInputKeyDown End', () => {
+    var data = getOnInputKeyDownDisabledKeyboardNavigationStuff()
+    TestUtils.Simulate.keyDown(data.nodeInput, {key: 'End', keyCode: 35, which: 35})
+    expect(data.callback.called).to.be.false
+  })
+
   it('should correctly clear date with empty input string', () => {
     var cleared = false
     function handleChange (d) {


### PR DESCRIPTION
Optionally disables arrows, page up/down, home and end keys

While I think it is nice to have the keyboard interaction available, it is also good to be able to turn it off.

The motivation for this is that we found that users in equal part either wanted to edit the date as text with keyboard functions (e.g. arrow keys) or wanted to click a date. So in our case, disabling the navigation only allows the former without affecting the latter. This PR makes that possible.