### PR TITLE
Default value for utcOffset props should be moment().utcOffset()

### DIFF
--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -92,7 +92,7 @@ var DatePicker = React.createClass({
           attachment: 'together'
         }
       ],
-      utcOffset: moment.utc().utcOffset(),
+      utcOffset: moment().utcOffset(),
       monthsShown: 1
     }
   },


### PR DESCRIPTION
According to issues  #679 and #498 date representation should be local or correct utcOffset must be used. Now `moment.utc().utcOffset()` as a default value for `utcOffset` is incorrect, because is 0. It must be `moment().utcOffset()`. Now when `utcOffset` is not set default value is user's local offset.