### PR TITLE
Added click blocking to portal

### DIFF
--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -147,6 +147,7 @@ var DatePicker = React.createClass({
 
   handleCalendarClickOutside (event) {
     this.setOpen(false)
+    if (this.props.withPortal) { event.preventDefault() }
   },
 
   handleSelect (date, event) {


### PR DESCRIPTION
This is a minor bug fix. The portal wasn't 'click blocking', meaning if you clicked the 'background' to close the calendar you would interact with any elements/links behind.