### PR TITLE
PreventFocus timeout is now cleared when datepicker is unmounted #731

### DIFF
--- a/docs-site/bundle.js
+++ b/docs-site/bundle.js
@@ -36923,6 +36923,11 @@
 	      preSelection: this.props.selected ? (0, _moment2.default)(this.props.selected) : (0, _moment2.default)()
 	    };
 	  },
+	  componentWillUnmount: function componentWillUnmount() {
+	    if (this.preventFocusTimeout) {
+	      clearTimeout(this.preventFocusTimeout);
+	    }
+	  },
 	  setFocus: function setFocus() {
 	    this.refs.input.focus();
 	  },
@@ -36972,9 +36977,10 @@
 	    // Preventing onFocus event to fix issue
 	    // https://github.com/Hacker0x01/react-datepicker/issues/628
 	    this.setState({ preventFocus: true }, function () {
-	      return setTimeout(function () {
+	      _this2.preventFocusTimeout = setTimeout(function () {
 	        return _this2.setState({ preventFocus: false });
 	      }, 50);
+	      return _this2.preventFocusTimeout;
 	    });
 	    this.setSelected(date, event);
 	    this.setOpen(false);
@@ -37257,7 +37263,7 @@
 	  },
 	  handleChangeDate: function handleChangeDate(value) {
 	    if (this.props.onChangeDate) {
-	      var date = (0, _moment2.default)(value, this.props.dateFormat, this.props.locale || _moment2.default.locale(), true);
+	      var date = (0, _moment2.default)(value.trim(), this.props.dateFormat, this.props.locale || _moment2.default.locale(), true);
 	      if (date.isValid() && !(0, _date_utils.isDayDisabled)(date, this.props)) {
 	        this.props.onChangeDate(date);
 	      } else if (value === '') {
@@ -56851,8 +56857,8 @@
 
 	function generateYears(year, noOfYear) {
 	  var list = [];
-	  for (var i = 0; i < noOfYear; i++) {
-	    list.push(year - i);
+	  for (var i = 0; i < 2 * noOfYear; i++) {
+	    list.push(year + noOfYear - i);
 	  }
 	  return list;
 	}
@@ -56869,7 +56875,7 @@
 
 	  getInitialState: function getInitialState() {
 	    return {
-	      yearsList: this.props.scrollableYearDropdown ? generateYears(this.props.year, 50) : generateYears(this.props.year, 5)
+	      yearsList: this.props.scrollableYearDropdown ? generateYears(this.props.year, 10) : generateYears(this.props.year, 5)
 	    };
 	  },
 	  renderOptions: function renderOptions() {

--- a/docs-site/bundle.js
+++ b/docs-site/bundle.js
@@ -36924,6 +36924,9 @@
 	    };
 	  },
 	  componentWillUnmount: function componentWillUnmount() {
+	    this.clearPreventFocusTimeout();
+	  },
+	  clearPreventFocusTimeout: function clearPreventFocusTimeout() {
 	    if (this.preventFocusTimeout) {
 	      clearTimeout(this.preventFocusTimeout);
 	    }

--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -110,6 +110,12 @@ var DatePicker = React.createClass({
     }
   },
 
+  componentWillUnmount () {
+    if (this.preventFocusTimeout) {
+      clearTimeout(this.preventFocusTimeout)
+    }
+  },
+
   setFocus () {
     this.refs.input.focus()
   },
@@ -159,7 +165,10 @@ var DatePicker = React.createClass({
     // Preventing onFocus event to fix issue
     // https://github.com/Hacker0x01/react-datepicker/issues/628
     this.setState({ preventFocus: true },
-      () => setTimeout(() => this.setState({ preventFocus: false }), 50)
+      () => {
+        this.preventFocusTimeout = setTimeout(() => this.setState({ preventFocus: false }), 50)
+        return this.preventFocusTimeout
+      }
     )
     this.setSelected(date, event)
     this.setOpen(false)

--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -111,6 +111,10 @@ var DatePicker = React.createClass({
   },
 
   componentWillUnmount () {
+    this.clearPreventFocusTimeout()
+  },
+
+  clearPreventFocusTimeout () {
     if (this.preventFocusTimeout) {
       clearTimeout(this.preventFocusTimeout)
     }

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -382,6 +382,14 @@ describe('DatePicker', () => {
     datePicker.setFocus()
     expect(div.querySelector('input')).to.equal(document.activeElement)
   })
+  it('should clear preventFocus timeout id when component is unmounted', () => {
+    var div = document.createElement('div')
+    document.body.appendChild(div)
+    var datePicker = ReactDOM.render(<DatePicker inline />, div)
+    datePicker.clearPreventFocusTimeout = sinon.spy()
+    ReactDOM.unmountComponentAtNode(div)
+    assert(datePicker.clearPreventFocusTimeout.calledOnce, 'should call clearPreventFocusTimeout')
+  })
 
   function getOnInputKeyDownDisabledKeyboardNavigationStuff () {
     var m = moment()


### PR DESCRIPTION
This PR fixes [issue](https://github.com/Hacker0x01/react-datepicker/issues/731) with datepicker trying to set state after being already unmounted thus resulting in React warning.

Things that were done:
- timeout id is now stored inside datepicker component,
- whenever component wants to unmount, timeout is cleared if it's created