### PR TITLE
className prop should always be applied to the outermost element, old className prop renamed to inputClassName

### DIFF
--- a/docs-site/src/example_components.jsx
+++ b/docs-site/src/example_components.jsx
@@ -4,7 +4,7 @@ import Default from './examples/default'
 import CodeExampleComponent from './code_example_component'
 
 import CustomDateFormat from './examples/custom_date_format'
-import CustomClassName from './examples/custom_class_name'
+import CustomInputClassName from './examples/custom_input_class_name'
 import CustomCalendarClassName from './examples/custom_calendar_class_name'
 import PlaceholderText from './examples/placeholder_text'
 import SpecificDateRange from './examples/specific_date_range'
@@ -56,8 +56,8 @@ export default React.createClass({
       component: <CustomDateFormat />
     },
     {
-      title: 'Custom class name',
-      component: <CustomClassName />
+      title: 'Custom input class name',
+      component: <CustomInputClassName />
     },
     {
       title: 'Custom calendar class name',

--- a/docs-site/src/examples/custom_input_class_name.jsx
+++ b/docs-site/src/examples/custom_input_class_name.jsx
@@ -3,7 +3,7 @@ import DatePicker from 'react-datepicker'
 import moment from 'moment'
 
 export default React.createClass({
-  displayName: 'CustomClassName',
+  displayName: 'CustomInputClassName',
 
   getInitialState () {
     return {
@@ -24,14 +24,14 @@ export default React.createClass({
           {'<DatePicker'}<br />
               {'selected={this.state.startDate}'}<br />
               {'onChange={this.handleChange}'} <br />
-              {'className="red-border" />'}
+              {'inputClassName="red-border" />'}
         </code>
       </pre>
       <div className="column">
         <DatePicker
             selected={this.state.startDate}
             onChange={this.handleChange}
-            className="red-border" />
+            inputClassName="red-border" />
       </div>
     </div>
   }

--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -41,6 +41,7 @@ var DatePicker = React.createClass({
     id: React.PropTypes.string,
     includeDates: React.PropTypes.array,
     inline: React.PropTypes.bool,
+    inputClassName: React.PropTypes.string,
     isClearable: React.PropTypes.bool,
     locale: React.PropTypes.string,
     maxDate: React.PropTypes.object,
@@ -325,7 +326,7 @@ var DatePicker = React.createClass({
   },
 
   renderDateInput () {
-    var className = classnames(this.props.className, {
+    var className = classnames(this.props.inputClassName, {
       [outsideClickIgnoreClass]: this.state.open
     })
     return <DateInput
@@ -375,7 +376,7 @@ var DatePicker = React.createClass({
 
     if (this.props.withPortal) {
       return (
-        <div>
+        <div className={this.props.className}>
           <div className="react-datepicker__input-container">
             {this.renderDateInput()}
             {this.renderClearButton()}
@@ -399,7 +400,7 @@ var DatePicker = React.createClass({
           targetOffset={this.props.popoverTargetOffset}
           renderElementTo={this.props.renderCalendarTo}
           constraints={this.props.tetherConstraints}>
-        <div className="react-datepicker__input-container">
+        <div className={classnames('react-datepicker__input-container', this.props.className)}>
           {this.renderDateInput()}
           {this.renderClearButton()}
         </div>


### PR DESCRIPTION
When I pass the `className` prop, intuitively I always expect it to be applied to the outermost element rendered, not some element deep inside. For example your DatePicker is in a `flex` element, you need to control the `order` or `flex-grow` of it, you cannot achieve the same effect when apply the styles into the input. Or when you need the component to be full width, setting `width: 100%` on the input is pointless if the outer `div` is `inline-block` and cannot be changed (it currently is).

This pull request changes the way `className` prop works, making it always be applied to the outermost element rendered, and the old `className` prop is renamed to `inputClassName` to be exact. Example docs site is modified accordingly.