### PR TITLE
Removed extra closing tag in example for onChangeRaw

### DIFF
--- a/docs-site/src/examples/raw_change.jsx
+++ b/docs-site/src/examples/raw_change.jsx
@@ -35,7 +35,7 @@ export default React.createClass({
           {'}'}<br />
           {'<DatePicker'}<br />
           {'    selected={this.state.startDate}'}<br />
-          {'    onChange={this.handleChange} />'}<br />
+          {'    onChange={this.handleChange}'}<br />
           {'    placeholderText="Enter tomorrow"'}<br />
           {'    onChangeRaw={(event) => '}<br />
           {'    this.handleChangeRaw(event.target.value)'}<br />


### PR DESCRIPTION
This example is showing incorrect syntax. Removed extra closing tag.