### PR TITLE
Remove lodash and replace with inbuilt native functionality

### DIFF
--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -1,5 +1,4 @@
 import moment from 'moment'
-import find from 'lodash/find'
 import YearDropdown from './year_dropdown'
 import MonthDropdown from './month_dropdown'
 import Month from './month'
@@ -14,9 +13,7 @@ const DROPDOWN_FOCUS_CLASSNAMES = [
 
 const isDropdownSelect = (element = {}) => {
   const classNames = (element.className || '').split(/\s+/)
-  return !!find(DROPDOWN_FOCUS_CLASSNAMES, (testClassname) => {
-    return classNames.indexOf(testClassname) >= 0
-  })
+  return DROPDOWN_FOCUS_CLASSNAMES.some(testClassname => classNames.indexOf(testClassname) >= 0)
 }
 
 var Calendar = React.createClass({

--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -1,7 +1,6 @@
 import DateInput from './date_input'
 import Calendar from './calendar'
 import React from 'react'
-import defer from 'lodash/defer'
 import TetherComponent from './tether_component'
 import classnames from 'classnames'
 import {isSameDay, isDayDisabled, isDayInRange} from './date_utils'
@@ -146,7 +145,7 @@ var DatePicker = React.createClass({
 
   deferFocusInput () {
     this.cancelFocusInput()
-    this.inputFocusTimeout = defer(() => this.setFocus())
+    this.inputFocusTimeout = window.setTimeout(() => this.setFocus(), 1)
   },
 
   handleDropdownFocus () {

--- a/src/month_dropdown.jsx
+++ b/src/month_dropdown.jsx
@@ -2,7 +2,6 @@ import React from 'react'
 import MonthDropdownOptions from './month_dropdown_options'
 import onClickOutside from 'react-onclickoutside'
 import moment from 'moment'
-import range from 'lodash/range'
 
 var WrappedMonthDropdownOptions = onClickOutside(MonthDropdownOptions)
 
@@ -81,7 +80,9 @@ var MonthDropdown = React.createClass({
 
   render () {
     const localeData = moment.localeData(this.props.locale)
-    const monthNames = range(0, 12).map((M) => localeData.months(moment({M})))
+    const monthNames = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11].map(
+      (M) => localeData.months(moment({M}))
+    )
 
     let renderedDropdown
     switch (this.props.dropdownMode) {


### PR DESCRIPTION
As discussed in Issue #749, this removes Lodash from the datepicker.
Takes file size from 77kb to 57kb.

Lodash is still in dev deps because it uses in some of the tests.

Before:
![image](https://cloud.githubusercontent.com/assets/9244507/23566088/7f3b0eae-00a4-11e7-92f7-db428f0b5f63.png)


After:
![image](https://cloud.githubusercontent.com/assets/9244507/23566071/7129bf9a-00a4-11e7-9932-f67f9c4b6ed0.png)
