### PR TITLE
Improve default pre selection

### DIFF
--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -3,7 +3,7 @@ import Calendar from './calendar'
 import React from 'react'
 import TetherComponent from './tether_component'
 import classnames from 'classnames'
-import {isSameDay, isDayDisabled, isDayInRange} from './date_utils'
+import {isSameDay, isDayDisabled, isDayInRange, getEffectiveMinDate, getEffectiveMaxDate} from './date_utils'
 import moment from 'moment'
 import onClickOutside from 'react-onclickoutside'
 
@@ -103,11 +103,22 @@ var DatePicker = React.createClass({
   },
 
   getInitialState () {
-    const defaultPreSelection = this.props.openToDate ? moment(this.props.openToDate) : moment()
+    const defaultPreSelection =
+      this.props.openToDate ? moment(this.props.openToDate)
+      : this.props.selectsEnd && this.props.startDate ? moment(this.props.startDate)
+      : this.props.selectsStart && this.props.endDate ? moment(this.props.endDate)
+      : moment()
+    const minDate = getEffectiveMinDate(this.props)
+    const maxDate = getEffectiveMaxDate(this.props)
+    const boundedPreSelection =
+      minDate && defaultPreSelection.isBefore(minDate) ? minDate
+      : maxDate && defaultPreSelection.isAfter(maxDate) ? maxDate
+      : defaultPreSelection
+
     return {
       open: false,
       preventFocus: false,
-      preSelection: this.props.selected ? moment(this.props.selected) : defaultPreSelection
+      preSelection: this.props.selected ? moment(this.props.selected) : boundedPreSelection
     }
   },
 

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -526,4 +526,46 @@ describe('DatePicker', () => {
     expect(openSpy.calledOnce).to.be.true
     expect(openSpy.calledWithExactly(false)).to.be.true
   })
+  it('should default to the currently selected date', () => {
+    const datePicker = mount(
+      <DatePicker selected={moment('1988-12-30')} />
+    )
+    expect(datePicker.state('preSelection').format('YYYY-MM-DD')).to.equal('1988-12-30')
+  })
+  it('should default to the start date when selecting an end date', () => {
+    const datePicker = mount(
+      <DatePicker startDate={moment('1988-11-30')} selectsEnd />
+    )
+    expect(datePicker.state('preSelection').format('YYYY-MM-DD')).to.equal('1988-11-30')
+  })
+  it('should default to the end date when selecting a start date', () => {
+    const datePicker = mount(
+      <DatePicker endDate={moment('1988-12-31')} selectsStart />
+    )
+    expect(datePicker.state('preSelection').format('YYYY-MM-DD')).to.equal('1988-12-31')
+  })
+  it('should default to a date <= maxDate', () => {
+    const datePicker = mount(
+      <DatePicker maxDate={moment('1982-01-01')} />
+    )
+    expect(datePicker.state('preSelection').format('YYYY-MM-DD')).to.equal('1982-01-01')
+  })
+  it('should default to a date >= minDate', () => {
+    const datePicker = mount(
+      <DatePicker minDate={moment('2063-04-05')} />
+    )
+    expect(datePicker.state('preSelection').format('YYYY-MM-DD')).to.equal('2063-04-05')
+  })
+  it('should default to the openToDate if there is one', () => {
+    const datePicker = mount(
+      <DatePicker openToDate={moment('2020-01-23')} />
+    )
+    expect(datePicker.state('preSelection').format('YYYY-MM-DD')).to.equal('2020-01-23')
+  })
+  it('should otherwise default to the current date', () => {
+    const datePicker = mount(
+      <DatePicker/>
+    )
+    expect(datePicker.state('preSelection').format('YYYY-MM-DD')).to.equal(moment().format('YYYY-MM-DD'))
+  })
 })


### PR DESCRIPTION
This fixes the regression where the default was no longer
within the selectable calendar dates. (Mentioned in #736)