### PR TITLE
Added highlightDates2 and highlightDates3 ranges

### DIFF
--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -31,6 +31,8 @@ export default class Calendar extends React.Component {
     filterDate: PropTypes.func,
     fixedHeight: PropTypes.bool,
     highlightDates: PropTypes.array,
+    highlightDates2: PropTypes.array,
+    highlightDates3: PropTypes.array,
     includeDates: PropTypes.array,
     inline: PropTypes.bool,
     locale: PropTypes.string,
@@ -282,6 +284,8 @@ export default class Calendar extends React.Component {
                 maxDate={this.props.maxDate}
                 excludeDates={this.props.excludeDates}
                 highlightDates={this.props.highlightDates}
+                highlightDates2={this.props.highlightDates2}
+                highlightDates3={this.props.highlightDates3}
                 selectingDate={this.state.selectingDate}
                 includeDates={this.props.includeDates}
                 inline={this.props.inline}

--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -35,6 +35,8 @@ export default class DatePicker extends React.Component {
     filterDate: PropTypes.func,
     fixedHeight: PropTypes.bool,
     highlightDates: PropTypes.array,
+    highlightDates2: PropTypes.array,
+    highlightDates3: PropTypes.array,
     id: PropTypes.string,
     includeDates: PropTypes.array,
     inline: PropTypes.bool,
@@ -345,6 +347,8 @@ export default class DatePicker extends React.Component {
         filterDate={this.props.filterDate}
         onClickOutside={this.handleCalendarClickOutside}
         highlightDates={this.props.highlightDates}
+        highlightDates2={this.props.highlightDates2}
+        highlightDates3={this.props.highlightDates3}
         includeDates={this.props.includeDates}
         inline={this.props.inline}
         peekNextMonth={this.props.peekNextMonth}

--- a/src/day.jsx
+++ b/src/day.jsx
@@ -9,6 +9,8 @@ export default class Day extends React.Component {
     day: PropTypes.object.isRequired,
     endDate: PropTypes.object,
     highlightDates: PropTypes.array,
+    highlightDates2: PropTypes.array,
+    highlightDates3: PropTypes.array,
     inline: PropTypes.bool,
     month: PropTypes.number,
     onClick: PropTypes.func,
@@ -45,8 +47,8 @@ export default class Day extends React.Component {
 
   isDisabled = () => isDayDisabled(this.props.day, this.props)
 
-  isHighlighted = () => {
-    const { day, highlightDates } = this.props
+  isHighlighted = (highlightDates) => {
+    const { day } = this.props
     if (!highlightDates) {
       return false
     }
@@ -138,7 +140,9 @@ export default class Day extends React.Component {
       'react-datepicker__day--disabled': this.isDisabled(),
       'react-datepicker__day--selected': this.isSameDay(this.props.selected),
       'react-datepicker__day--keyboard-selected': this.isKeyboardSelected(),
-      'react-datepicker__day--highlighted': this.isHighlighted(),
+      'react-datepicker__day--highlighted': this.isHighlighted(this.props.highlightDates),
+      'react-datepicker__day--highlighted2': this.isHighlighted(this.props.highlightDates2),
+      'react-datepicker__day--highlighted3': this.isHighlighted(this.props.highlightDates3),
       'react-datepicker__day--range-start': this.isRangeStart(),
       'react-datepicker__day--range-end': this.isRangeEnd(),
       'react-datepicker__day--in-range': this.isInRange(),

--- a/src/month.jsx
+++ b/src/month.jsx
@@ -13,6 +13,8 @@ export default class Month extends React.Component {
     filterDate: PropTypes.func,
     fixedHeight: PropTypes.bool,
     highlightDates: PropTypes.array,
+    highlightDates2: PropTypes.array,
+    highlightDates3: PropTypes.array,
     includeDates: PropTypes.array,
     inline: PropTypes.bool,
     maxDate: PropTypes.object,
@@ -75,6 +77,8 @@ export default class Month extends React.Component {
           includeDates={this.props.includeDates}
           inline={this.props.inline}
           highlightDates={this.props.highlightDates}
+          highlightDates2={this.props.highlightDates2}
+          highlightDates3={this.props.highlightDates3}
           selectingDate={this.props.selectingDate}
           filterDate={this.props.filterDate}
           preSelection={this.props.preSelection}

--- a/src/week.jsx
+++ b/src/week.jsx
@@ -10,6 +10,8 @@ export default class Week extends React.Component {
     excludeDates: PropTypes.array,
     filterDate: PropTypes.func,
     highlightDates: PropTypes.array,
+    highlightDates2: PropTypes.array,
+    highlightDates3: PropTypes.array,
     includeDates: PropTypes.array,
     inline: PropTypes.bool,
     maxDate: PropTypes.object,
@@ -60,6 +62,8 @@ export default class Week extends React.Component {
             includeDates={this.props.includeDates}
             inline={this.props.inline}
             highlightDates={this.props.highlightDates}
+            highlightDates2={this.props.highlightDates2}
+            highlightDates3={this.props.highlightDates3}
             selectingDate={this.props.selectingDate}
             filterDate={this.props.filterDate}
             preSelection={this.props.preSelection}


### PR DESCRIPTION
Sometimes we need diffrent highlighted date ranges with diffrent styles. I added `highlightDates2` and `highlightDates2` props. It can be very useful to apply different styles.