### PR TITLE
Add z-index 1 to month/year dropdown

### DIFF
--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -241,6 +241,7 @@
   width: 50%;
   left: 25%;
   top: 30px;
+  z-index: 1;
   text-align: center;
   border-radius: $datepicker__border-radius;
   border: 1px solid $datepicker__border-color;


### PR DESCRIPTION
Fix #845

- Add z-index 1 to month and year dropdown to prevent the year dropdown to shine through month dropdown in scroll mode