### PR TITLE
Change selected date on input + enter

### DIFF
--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -131,6 +131,12 @@ export default class DatePicker extends React.Component {
     }
   }
 
+  componentWillUpdate (nextProps, nextState) {
+    if (nextProps.selected !== this.props.selected) {
+      this.setPreSelection(nextProps.selected)
+    }
+  }
+
   componentWillUnmount () {
     this.clearPreventFocusTimeout()
   }
@@ -262,9 +268,7 @@ export default class DatePicker extends React.Component {
 
   onInputKeyDown = (event) => {
     if (!this.state.open && !this.props.inline) {
-      if (/^Arrow/.test(event.key)) {
-        this.onInputClick()
-      }
+      this.onInputClick()
       return
     }
     const copy = moment(this.state.preSelection)

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -362,6 +362,13 @@ describe('DatePicker', () => {
       var result = data.callback.args[0][0]
       expect(result.format(data.testFormat)).to.equal(data.copyM.format(data.testFormat))
     })
+    it('should update the selected date on manual input', () => {
+      var data = getOnInputKeyDownStuff()
+      TestUtils.Simulate.change(data.nodeInput, {target: {value: '02/02/2017'}})
+      TestUtils.Simulate.keyDown(data.nodeInput, {key: 'Enter', keyCode: 13, which: 13})
+      data.copyM = moment('02/02/2017')
+      expect(data.callback.args[0][0].format(data.testFormat)).to.equal(data.copyM.format(data.testFormat))
+    })
     it('should not select excludeDates', () => {
       var data = getOnInputKeyDownStuff({ excludeDates: [moment().subtract(1, 'days')] })
       TestUtils.Simulate.keyDown(data.nodeInput, {key: 'ArrowLeft', keyCode: 37, which: 37})


### PR DESCRIPTION
possible fix for #848 

I couldn't see any reason why we don't want the calendar to open on every InputKey event or change the preSelection on change of the selected input property.

Did I miss something?
