### PR TITLE
'openToDate' prop is now take a precedence over 'selected' value

### DIFF
--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -101,24 +101,17 @@ export default class Calendar extends React.Component {
     const minDate = getEffectiveMinDate(this.props)
     const maxDate = getEffectiveMaxDate(this.props)
     const current = moment.utc().utcOffset(utcOffset)
-    const initialDate = preSelection || selected
+    const initialDate = openToDate || selected || preSelection
     if (initialDate) {
       return initialDate
-    } else if (minDate && maxDate && openToDate && openToDate.isBetween(minDate, maxDate)) {
-      return openToDate
-    } else if (minDate && openToDate && openToDate.isAfter(minDate)) {
-      return openToDate
-    } else if (minDate && minDate.isAfter(current)) {
-      return minDate
-    } else if (maxDate && openToDate && openToDate.isBefore(maxDate)) {
-      return openToDate
-    } else if (maxDate && maxDate.isBefore(current)) {
-      return maxDate
-    } else if (openToDate) {
-      return openToDate
     } else {
-      return current
+      if (minDate && current.isBefore(minDate)) {
+        return minDate
+      } else if (maxDate && current.isAfter(maxDate)) {
+        return maxDate
+      }
     }
+    return current
   }
 
   localizeMoment = date => date.clone().locale(this.props.locale || moment.locale())

--- a/test/calendar_test.js
+++ b/test/calendar_test.js
@@ -108,11 +108,11 @@ describe('Calendar', function () {
     assert(calendar.state().date.isSame(openToDate, 'day'))
   })
 
-  it('should open on selected date rather than openToDate when both are specified', function () {
-    const openToDate = moment('09/28/1993', 'MM/DD/YYYY')
-    const selected = moment('09/28/1995', 'MM/DD/YYYY')
-    const calendar = getCalendar({ openToDate, selected })
-    assert(calendar.state().date.isSame(selected, 'day'))
+  it('should open on openToDate date rather than selected date when both are specified', function () {
+    var openToDate = moment('09/28/1993', 'MM/DD/YYYY')
+    var selected = moment('09/28/1995', 'MM/DD/YYYY')
+    var calendar = getCalendar({ openToDate, selected })
+    assert(calendar.state().date.isSame(openToDate, 'day'))
   })
 
   it('should trigger date change when openToDate prop is set after calcInitialState()', () => {


### PR DESCRIPTION
I think that current behavior when `selected` and `openToDate` both specified and `selected ` take a precedence over `openToDate` is totally incorrect. Every time calendar is open it must be opened at `openToDate` if specified regardless of other values. It's should be treated as a constant value at which calendar will open every time. It's not a selection of any kind, it's just a page on which calendar will be opened.
See this issue #736 and my arguments for and some use cases. 




