### PR TITLE
Better Popover Triangle Orientation

### DIFF
--- a/docs-site/src/examples/placement.jsx
+++ b/docs-site/src/examples/placement.jsx
@@ -23,8 +23,8 @@ export default class Placement extends React.Component {
 <DatePicker
     selected={this.state.startDate}
     onChange={this.handleChange}
-    popoverAttachment="bottom center"
-    popoverTargetAttachment="top center"
+    popoverAttachment="bottom right"
+    popoverTargetAttachment="top right"
     popoverTargetOffset="0px 0px"
 />
 `}
@@ -34,8 +34,8 @@ export default class Placement extends React.Component {
         <DatePicker
             selected={this.state.startDate}
             onChange={this.handleChange}
-            popoverAttachment="bottom center"
-            popoverTargetAttachment="top center"
+            popoverAttachment="bottom right"
+            popoverTargetAttachment="top right"
             popoverTargetOffset="0px 0px" />
       </div>
     </div>

--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -25,6 +25,11 @@
   @extend %triangle-arrow-down;
 }
 
+.react-datepicker__tether-element-attached-right .react-datepicker__triangle {
+  left: auto;
+  right: 50px;
+}
+
 .react-datepicker__tether-element-attached-bottom.react-datepicker__tether-element {
   margin-top: -20px;
 }

--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -27,7 +27,7 @@
 
 .react-datepicker__tether-element-attached-right .react-datepicker__triangle {
   left: auto;
-  right: 50px;
+  right: 42px;
 }
 
 .react-datepicker__tether-element-attached-bottom.react-datepicker__tether-element {


### PR DESCRIPTION
This allows the triangle to be positioned relative to the right side of the popover if the user passes `popoverAttachment="right"` as a prop.