### PR TITLE
updating doc to show all props in a table form

### DIFF
--- a/docs/datepicker.md
+++ b/docs/datepicker.md
@@ -1,315 +1,61 @@
-`datepicker` (component)
-========================
-
-General datepicker component.
-
-Props
------
-
-### `autoComplete`
-
-type: `string`
-
-
-### `autoFocus`
-
-type: `bool`
-
-
-### `calendarClassName`
-
-type: `string`
-
-
-### `children`
-
-type: `node`
-
-
-### `className`
-
-type: `string`
-
-
-### `customInput`
-
-type: `element`
-
-
-### `dateFormat`
-
-type: `union(string|array)`
-defaultValue: `'L'`
-
-
-### `dateFormatCalendar`
-
-type: `string`
-defaultValue: `'MMMM YYYY'`
-
-
-### `disabled`
-
-type: `bool`
-defaultValue: `false`
-
-
-### `disabledKeyboardNavigation`
-
-type: `bool`
-defaultValue: `false`
-
-
-### `dropdownMode` (required)
-
-type: `enum('scroll'|'select')`
-defaultValue: `'scroll'`
-
-
-### `endDate`
-
-type: `object`
-
-
-### `excludeDates`
-
-type: `array`
-
-
-### `filterDate`
-
-type: `func`
-
-
-### `fixedHeight`
-
-type: `bool`
-
-
-### `forceShowMonthNavigation`
-
-type: `bool`
-
-
-### `highlightDates`
-
-type: `array`
-
-
-### `id`
-
-type: `string`
-
-
-### `includeDates`
-
-type: `array`
-
-
-### `inline`
-
-type: `bool`
-
-
-### `isClearable`
-
-type: `bool`
-
-
-### `locale`
-
-type: `string`
-
-
-### `maxDate`
-
-type: `object`
-
-
-### `minDate`
-
-type: `object`
-
-
-### `monthsShown`
-
-type: `number`
-defaultValue: `1`
-
-
-### `name`
-
-type: `string`
-
-
-### `onBlur`
-
-type: `func`
-defaultValue: `function() {}`
-
-
-### `onChange` (required)
-
-type: `func`
-defaultValue: `function() {}`
-
-
-### `onChangeRaw`
-
-type: `func`
-
-
-### `onClickOutside`
-
-type: `func`
-defaultValue: `function() {}`
-
-
-### `onFocus`
-
-type: `func`
-defaultValue: `function() {}`
-
-
-### `onMonthChange`
-
-type: `func`
-defaultValue: `function() {}`
-
-
-### `onSelect`
-
-type: `func`
-defaultValue: `function() {}`
-
-
-### `openToDate`
-
-type: `object`
-
-
-### `peekNextMonth`
-
-type: `bool`
-
-
-### `placeholderText`
-
-type: `string`
-
-
-### `popoverAttachment`
-
-type: `string`
-defaultValue: `'top left'`
-
-
-### `popoverTargetAttachment`
-
-type: `string`
-defaultValue: `'bottom left'`
-
-
-### `popoverTargetOffset`
-
-type: `string`
-defaultValue: `'10px 0'`
-
-
-### `readOnly`
-
-type: `bool`
-
-
-### `renderCalendarTo`
-
-type: `any`
-
-
-### `required`
-
-type: `bool`
-
-
-### `scrollableYearDropdown`
-
-type: `bool`
-
-
-### `selected`
-
-type: `object`
-
-
-### `selectsEnd`
-
-type: `bool`
-
-
-### `selectsStart`
-
-type: `bool`
-
-
-### `showMonthDropdown`
-
-type: `bool`
-
-
-### `showWeekNumbers`
-
-type: `bool`
-
-
-### `showYearDropdown`
-
-type: `bool`
-
-
-### `startDate`
-
-type: `object`
-
-
-### `tabIndex`
-
-type: `number`
-
-
-### `tetherConstraints`
-
-type: `array`
-defaultValue: `[
-  {
-    to: 'window',
-    attachment: 'together'
-  }
-]`
-
-
-### `title`
-
-type: `string`
-
-
-### `todayButton`
-
-type: `string`
-
-
-### `utcOffset`
-
-type: `number`
-defaultValue: `moment().utcOffset()`
-
-
-### `value`
-
-type: `string`
-
-
-### `withPortal`
-
-type: `bool`
-defaultValue: `false`
-
+### General `datepicker` component props.
+
+| name  | type  | default value  | description  |
+|---|---|---|---|
+| `dropdownMode` (required)  | `enum('scroll'|'select')`  |  `'scroll'` |   |
+| `onChange` (required)  |`func`   |`function() {}`   |   |
+| `autoComplete`  | `string`  |   |   |
+| `autoFocus` | `bool`  |   |   |
+| `calendarClassName`  | `string`  |   |   |
+| `children`  | `node`  |   |   |
+| `className`  | `string`  |   |   |
+| `customInput`  |`element`   |   |   |
+| `dateFormat`  | `union(string|array)`  | `'L'`  |   |
+|`dateFormatCalendar`   | `string`  | `'MMMM YYYY'`  |   |
+| `disabled`  | `bool`  | `false`  |   |
+|`disabledKeyboardNavigation`   | `bool`  | `false`  |   |
+| `endDate`  |`object`   |   |   |
+|`excludeDates`   | `array`  |   |   |
+| `filterDate`  |`func`   |   |   |
+| `fixedHeight`  |`bool`   |   |   |
+| `forceShowMonthNavigation`  | `bool`  |   |   |
+|`highlightDates`   | `array`  |   |   |
+| `id`  | `string`  |   |   |
+| `includeDates`  |`array`   |   |   |
+|`inline`   |`bool`   |   |   |
+|`isClearable`   |`bool`   |   |   |
+| `locale`  |`string`   |   |   |
+|`maxDate`   |`object`   |   |   |
+| `minDate`  | `object`  |   |   |
+|`monthsShown`   | `number`  | `1`  |   |
+| `name`  | `string`  |   |   |
+| `onBlur`  |`func`   |`function() {}`   |   |
+|`onChangeRaw`   | `func`  |   |   |
+| `onClickOutside`  |`func`   |  `function() {}` |   |
+|`onFocus`   | `func`  | `function() {}`  |   |
+| `onMonthChange`  |`func`   |`function() {}`   |   |
+|`onSelect`   |`func`   |`function() {}`   |   |
+| `openToDate`  |`object`   |   |   |
+| `peekNextMonth`  | `bool`  |   |   |
+|`placeholderText`   | `string`  |   |   |
+| `popoverAttachment`  |`string`   | `'top left'`  |   |
+|`popoverTargetAttachment`   |`string`   |`'bottom left'`   |   |
+| `popoverTargetOffset`   | `string`  |`'10px 0'`   |   |
+|`readOnly`   |`bool`   | `false`  |   |
+| `renderCalendarTo`  | any |   |   |
+|`required`   |`bool`   | `false`  |   |
+| `scrollableYearDropdown`  | `bool`  |   |   |
+|`selected`   | `object`  |   |   |
+|`selectsEnd`   | `bool`  |   |   |
+| `selectsStart`  |`bool`   |   |   |
+| `showMonthDropdown`  | `bool`  |   |   |
+| `showWeekNumbers`  |`bool`   |   |   |
+|`showYearDropdown`   |`bool`   |   |   |
+|`startDate`   |`object`   |   |   |
+|`tabIndex`   |`number`   |   |   |
+| `tetherConstraints`  |`array`   | `[{ to: 'window', attachment: 'together'}]`  |   |
+| `title`  |`string`   |   |   |
+| `todayButton`  | `string`  |   |   |
+|`utcOffset`   | `number`  |`moment().utcOffset()`   |   |
+|`value`   |  `string`  |   |   |
+|`withPortal`   | `bool`  |`false`   |   |


### PR DESCRIPTION
fixes #880 

below is how the updated doc page will looks. _(image does not capture all props....but the docs has them)_

![screen shot 2017-06-09 at 4 13 59 pm](https://user-images.githubusercontent.com/2084833/26997461-b30b730a-4d2e-11e7-9e07-33a0233d7160.png)

