### PR TITLE
Allow Re-Selecting the same day

### DIFF
--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -16,6 +16,7 @@ const WrappedCalendar = onClickOutside(Calendar)
 
 export default class DatePicker extends React.Component {
   static propTypes = {
+    allowSameDay: PropTypes.bool,
     autoComplete: PropTypes.string,
     autoFocus: PropTypes.bool,
     calendarClassName: PropTypes.string,
@@ -80,6 +81,7 @@ export default class DatePicker extends React.Component {
 
   static get defaultProps () {
     return {
+      allowSameDay: false,
       dateFormat: 'L',
       dateFormatCalendar: 'MMMM YYYY',
       onChange () {},
@@ -221,7 +223,7 @@ export default class DatePicker extends React.Component {
       return
     }
 
-    if (!isSameDay(this.props.selected, changedDate)) {
+    if (!isSameDay(this.props.selected, changedDate) || this.props.allowSameDay) {
       if (changedDate !== null) {
         if (this.props.selected) {
           changedDate = moment(changedDate).set({


### PR DESCRIPTION
This adds a boolean prop that allows a user to click on the same day again. It is turned off by default.

I added this option because we created an inline calendar where the user can select a start date and end date from the same calendar, and a use case exists for selecting the same day for both.