### PR TITLE
updating doc generation script to create props as table

### DIFF
--- a/scripts/generateMarkdown.sh
+++ b/scripts/generateMarkdown.sh
@@ -22,7 +22,9 @@ function generateTitle(name) {
 }
 
 function generateDesciption(description) {
-  return description + '\n';
+  if (description) return description + '\n';
+
+  return '';
 }
 
 function generatePropType(type) {
@@ -37,31 +39,26 @@ function generatePropType(type) {
     values = type.value;
   }
 
-  return 'type: `' + type.name + (values ? values: '') + '`\n';
+  return '`' + type.name + (values ? values: '') + '`';
 }
 
 function generatePropDefaultValue(value) {
-  return 'defaultValue: `' + value.value + '`\n';
+  return '`' + value.value + '`';
 }
 
 function generateProp(propName, prop) {
   return (
-    '### `' + propName + '`' + (prop.required ? ' (required)' : '') + '\n' +
-    '\n' +
-    (prop.description ? prop.description + '\n\n' : '') +
-    (prop.type ? generatePropType(prop.type) : '') +
-    (prop.defaultValue ? generatePropDefaultValue(prop.defaultValue) : '') +
-    '\n'
+    '|`' + propName + '`' + (prop.required ? ' (required)' : '')  +
+    '|' + (prop.type ? generatePropType(prop.type) : '') +
+    '|' + (prop.defaultValue ? generatePropDefaultValue(prop.defaultValue) : '') +
+    '|' + (prop.description ? prop.description + '\n\n' : '') + '|'
   );
 }
 
 function generateProps(props) {
-  var title = 'Props';
-
   return (
-    title + '\n' +
-    stringOfLength('-', title.length) + '\n' +
-    '\n' +
+    '| name  | type  | default value  | description  |' + '\n' +
+    '|---|---|---|---|' + '\n' +
     Object.keys(props).sort().map(function(propName) {
       return generateProp(propName, props[propName]);
     }).join('\n')

--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -96,12 +96,7 @@ export default class DatePicker extends React.Component {
       popoverAttachment: 'top left',
       popoverTargetAttachment: 'bottom left',
       popoverTargetOffset: '10px 0',
-      tetherConstraints: [
-        {
-          to: 'window',
-          attachment: 'together'
-        }
-      ],
+      tetherConstraints: [{ to: 'window', attachment: 'together' }],
       utcOffset: moment().utcOffset(),
       monthsShown: 1,
       withPortal: false


### PR DESCRIPTION
fixes #880 

Currently the `generateMarkdown.sh` creates a name-value pair for the props. This is not very readable since the page can get long. eg: https://github.com/Hacker0x01/react-datepicker/blob/master/docs/datepicker.md

updating the script, changes it to a table layout which makes the props docs more readable. eg: https://github.com/hozefaj/react-datepicker/blob/generate-docs/docs/datepicker.md

I have not generated the new docs, since this will done during the release process. 