### PR TITLE
fix for mismatch of global context

### DIFF
--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -158,7 +158,7 @@ export default class DatePicker extends React.Component {
 
   deferFocusInput = () => {
     this.cancelFocusInput()
-    this.inputFocusTimeout = window.setTimeout(() => this.setFocus(), 1)
+    this.inputFocusTimeout = setTimeout(() => this.setFocus(), 1)
   }
 
   handleDropdownFocus = () => {


### PR DESCRIPTION
While testing in node.js environment unmounting the component with enzyme didn't clear the timeout which lead to setting the state after component is unmounted. clearTimeout had `global` context, but setting timeout had `window`. it must be the same.