### PR TITLE
Adding option to use MomentJS's weekdaysShort instead of weekdaysMin.

### DIFF
--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -54,6 +54,7 @@ export default class Calendar extends React.Component {
     showYearDropdown: PropTypes.bool,
     startDate: PropTypes.object,
     todayButton: PropTypes.string,
+    useWeekdaysShort: PropTypes.bool,
     utcOffset: PropTypes.number
   }
 
@@ -164,9 +165,12 @@ export default class Calendar extends React.Component {
     }
     return dayNames.concat([0, 1, 2, 3, 4, 5, 6].map(offset => {
       const day = startOfWeek.clone().add(offset, 'days')
+      const weekDayName = this.props.useWeekdaysShort
+          ? day.localeData().weekdaysShort(day)
+          : day.localeData().weekdaysMin(day)
       return (
         <div key={offset} className="react-datepicker__day-name">
-          {day.localeData().weekdaysMin(day)}
+          {weekDayName}
         </div>
       )
     }))

--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -74,6 +74,7 @@ export default class DatePicker extends React.Component {
     tetherConstraints: PropTypes.array,
     title: PropTypes.string,
     todayButton: PropTypes.string,
+    useWeekdaysShort: PropTypes.bool,
     utcOffset: PropTypes.number,
     value: PropTypes.string,
     withPortal: PropTypes.bool
@@ -325,6 +326,7 @@ export default class DatePicker extends React.Component {
         ref="calendar"
         locale={this.props.locale}
         dateFormat={this.props.dateFormatCalendar}
+        useWeekdaysShort={this.props.useWeekdaysShort}
         dropdownMode={this.props.dropdownMode}
         selected={this.props.selected}
         preSelection={this.state.preSelection}

--- a/test/calendar_test.js
+++ b/test/calendar_test.js
@@ -213,6 +213,29 @@ describe('Calendar', function () {
     expect(month.prop('selectingDate')).not.to.exist
   })
 
+  it('uses MomentJS\'s weekdaysShort instead of weekdaysMin provided useWeekdaysShort prop is present', () => {
+    moment.defineLocale('weekDaysLocale', {
+      parentLocale: 'en',
+      weekdaysMin: 'AA_BB_CC_DD_EE_FF_GG'.split('_'),
+      weekdaysShort: 'AAA_BBB_CCC_DDD_EEE_FFF_GGG'.split('_')
+    })
+
+    const calendarShort = mount(
+      <Calendar locale="weekDaysLocale" useWeekdaysShort />
+    )
+    const calendarMin = mount(
+      <Calendar locale="weekDaysLocale" />
+    )
+
+    const daysNamesShort = calendarShort.find('.react-datepicker__day-name')
+    expect(daysNamesShort.at(0).text()).to.equal('AAA')
+    expect(daysNamesShort.at(6).text()).to.equal('GGG')
+
+    const daysNamesMin = calendarMin.find('.react-datepicker__day-name')
+    expect(daysNamesMin.at(0).text()).to.equal('AA')
+    expect(daysNamesMin.at(6).text()).to.equal('GG')
+  })
+
   describe('onMonthChange', () => {
     let onMonthChangeSpy = sinon.spy()
     let calendar


### PR DESCRIPTION
Example of code:

    <DatePicker
      autoFocus
      useWeekdaysShort
      selected={this.state.startDate}
      onChange={this.handleChange}
    />