### PR TITLE
Handling wrong data in input when Enter is press

### DIFF
--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -270,7 +270,11 @@ export default class DatePicker extends React.Component {
     const copy = moment(this.state.preSelection)
     if (eventKey === 'Enter') {
       event.preventDefault()
-      this.handleSelect(copy, event)
+      if (moment.isMoment(this.state.preSelection) || moment.isDate(this.state.preSelection)) {
+        this.handleSelect(copy, event)
+      } else {
+        this.setOpen(false)
+      }
     } else if (eventKey === 'Escape') {
       event.preventDefault()
       this.setOpen(false)

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -339,7 +339,7 @@ describe('DatePicker', () => {
     expect(data.datePicker.state.preSelection.format(data.testFormat)).to.equal(moment().format(data.testFormat))
   })
   describe('onInputKeyDown Enter', () => {
-    it('should update the selected date', () => {
+    it('should update the selected date if the date format is valid', () => {
       var data = getOnInputKeyDownStuff()
       TestUtils.Simulate.keyDown(data.nodeInput, {key: 'ArrowLeft', keyCode: 37, which: 37})
       TestUtils.Simulate.keyDown(data.nodeInput, {key: 'Enter', keyCode: 13, which: 13})
@@ -347,6 +347,12 @@ describe('DatePicker', () => {
       expect(data.callback.calledOnce).to.be.true
       var result = data.callback.args[0][0]
       expect(result.format(data.testFormat)).to.equal(data.copyM.format(data.testFormat))
+    })
+    it('should not update the selected date if the date format is wrong', () => {
+      var data = getOnInputKeyDownStuff()
+      TestUtils.Simulate.change(data.nodeInput, {target: {value: '02/02/20177'}})
+      TestUtils.Simulate.keyDown(data.nodeInput, {key: 'Enter', keyCode: 13, which: 13})
+      expect(data.callback.calledOnce).to.be.false
     })
     it('should update the selected date on manual input', () => {
       var data = getOnInputKeyDownStuff()

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -339,7 +339,7 @@ describe('DatePicker', () => {
     expect(data.datePicker.state.preSelection.format(data.testFormat)).to.equal(moment().format(data.testFormat))
   })
   describe('onInputKeyDown Enter', () => {
-    it('should update the selected date if the date format is valid', () => {
+    it('should update the selected date', () => {
       var data = getOnInputKeyDownStuff()
       TestUtils.Simulate.keyDown(data.nodeInput, {key: 'ArrowLeft', keyCode: 37, which: 37})
       TestUtils.Simulate.keyDown(data.nodeInput, {key: 'Enter', keyCode: 13, which: 13})
@@ -348,18 +348,19 @@ describe('DatePicker', () => {
       var result = data.callback.args[0][0]
       expect(result.format(data.testFormat)).to.equal(data.copyM.format(data.testFormat))
     })
-    it('should not update the selected date if the date format is wrong', () => {
-      var data = getOnInputKeyDownStuff()
-      TestUtils.Simulate.change(data.nodeInput, {target: {value: '02/02/20177'}})
-      TestUtils.Simulate.keyDown(data.nodeInput, {key: 'Enter', keyCode: 13, which: 13})
-      expect(data.callback.calledOnce).to.be.false
-    })
     it('should update the selected date on manual input', () => {
       var data = getOnInputKeyDownStuff()
       TestUtils.Simulate.change(data.nodeInput, {target: {value: '02/02/2017'}})
       TestUtils.Simulate.keyDown(data.nodeInput, {key: 'Enter', keyCode: 13, which: 13})
       data.copyM = moment('02/02/2017')
       expect(data.callback.args[0][0].format(data.testFormat)).to.equal(data.copyM.format(data.testFormat))
+    })
+    it('should not update the selected date if the date input manually it has something wrong', () => {
+      var data = getOnInputKeyDownStuff()
+      TestUtils.Simulate.keyDown(data.nodeInput, {key: 'ArrowDown', keyCode: 40, which: 40})
+      TestUtils.Simulate.keyDown(data.nodeInput, {key: 'Backspace', keyCode: 8, which: 8})
+      TestUtils.Simulate.keyDown(data.nodeInput, {key: 'Enter', keyCode: 13, which: 13})
+      expect(data.callback.calledOnce).to.be.false
     })
     it('should not select excludeDates', () => {
       var data = getOnInputKeyDownStuff({ excludeDates: [moment().subtract(1, 'days')] })


### PR DESCRIPTION
Related to #945 I think the correct behaviour should be exactly as if you click outside when the data is wrong.
The input field keep the wrong data as it is and the implementer should handle the error if needed.

Let me know if you find this interesting and if there is anything else to do I can keep working on it.
![date-picker-pr](https://user-images.githubusercontent.com/2563196/28164306-ce801958-67c6-11e7-8c51-76f62e7405a3.gif)
