### PR TITLE
Only call props.onChange handler if new date exists.

### DIFF
--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -232,8 +232,8 @@ export default class DatePicker extends React.Component {
         this.setState({
           preSelection: changedDate
         })
+        this.props.onChange(changedDate, event)
       }
-      this.props.onChange(changedDate, event)
     }
 
     this.props.onSelect(changedDate, event)


### PR DESCRIPTION
Fixes issue #947 - more detailed information can be found in the issue.