### PR TITLE
Added check on utcOffset to see if it was passed with a zero value

### DIFF
--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -116,7 +116,7 @@ export default class DatePicker extends React.Component {
       this.props.openToDate ? moment(this.props.openToDate)
       : this.props.selectsEnd && this.props.startDate ? moment(this.props.startDate)
       : this.props.selectsStart && this.props.endDate ? moment(this.props.endDate)
-      : (this.props.utcOffset || this.props.utcOffset === 0) ? moment.utc().utcOffset(this.props.utcOffset)
+      : (typeof this.props.utcOffset !== 'undefined') ? moment.utc().utcOffset(this.props.utcOffset)
       : moment()
     const minDate = getEffectiveMinDate(this.props)
     const maxDate = getEffectiveMaxDate(this.props)

--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -116,7 +116,7 @@ export default class DatePicker extends React.Component {
       this.props.openToDate ? moment(this.props.openToDate)
       : this.props.selectsEnd && this.props.startDate ? moment(this.props.startDate)
       : this.props.selectsStart && this.props.endDate ? moment(this.props.endDate)
-      : this.props.utcOffset ? moment.utc().utcOffset(this.props.utcOffset)
+      : (this.props.utcOffset || this.props.utcOffset === 0) ? moment.utc().utcOffset(this.props.utcOffset)
       : moment()
     const minDate = getEffectiveMinDate(this.props)
     const maxDate = getEffectiveMaxDate(this.props)


### PR DESCRIPTION
During a previous pull request (#921), I added a check for `utcOffset` when computing the `defaultPreSelection`.  This _almost_ worked.  As it turns out, it works for any non-zero `utcOffset`, however, if the `utcOffset` is passed as `0` (GMT), the check returns falsey and does not evaluate properly.  This change also checks for a value of `0`.

Fixes #920 