### PR TITLE
Move z-index from style props into CSS rule-set (#952)

### DIFF
--- a/src/popper_component.jsx
+++ b/src/popper_component.jsx
@@ -60,10 +60,9 @@ export default class PopperComponent extends React.Component {
         {
           !hidePopper &&
           <Popper
-              style={{zIndex: 1}}
+              className="react-datepicker-popper"
               modifiers={popperModifiers}
-              placement={popperPlacement}
-              className="popper">
+              placement={popperPlacement}>
             {popperComponent}
           </Popper>
         }

--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -21,33 +21,41 @@
   left: 50px;
 }
 
-.popper[data-placement^="bottom"] {
-  margin-top: $datepicker__triangle-size + 2px;
-  .react-datepicker__triangle {
-    @extend %triangle-arrow-up;
-  }
-}
+.react-datepicker-popper {
+  z-index: 1;
 
-.popper[data-placement^="top"] {
-  margin-bottom: $datepicker__triangle-size - 2px;
-  .react-datepicker__triangle {
-    @extend %triangle-arrow-down;
-  }
-}
+  &[data-placement^="bottom"] {
+    margin-top: $datepicker__triangle-size + 2px;
 
-.popper[data-placement^="right"] {
-  margin-left: $datepicker__triangle-size;
-  .react-datepicker__triangle {
-    left: auto;
-    right: 42px;
+    .react-datepicker__triangle {
+      @extend %triangle-arrow-up;
+    }
   }
-}
 
-.popper[data-placement^="left"] {
-  margin-right: $datepicker__triangle-size;
-  .react-datepicker__triangle {
-    left: 42px;
-    right: auto;
+  &[data-placement^="top"] {
+    margin-bottom: $datepicker__triangle-size - 2px;
+
+    .react-datepicker__triangle {
+      @extend %triangle-arrow-down;
+    }
+  }
+
+  &[data-placement^="right"] {
+    margin-left: $datepicker__triangle-size;
+
+    .react-datepicker__triangle {
+      left: auto;
+      right: 42px;
+    }
+  }
+
+  &[data-placement^="left"] {
+    margin-right: $datepicker__triangle-size;
+
+    .react-datepicker__triangle {
+      left: 42px;
+      right: auto;
+    }
   }
 }
 


### PR DESCRIPTION
This is a PR to fix the issue highlighted in #952.

Since hardcoding values into component style props isn't considered a good practice, the `<Popper />`'s `z-index` attribute is now applied via the `.react-datepicker-popper` CSS class to allow users to overwrite it without having to use `!important` rule.

```JSX
// src/popper_component.jsx (new-implementation)
<Popper
  className="react-datepicker-popper"
  modifiers={popperModifiers}
  placement={popperPlacement}>
  {popperComponent}
</Popper>

// src/popper_component.jsx (old-implementation)
<Popper
  style={{zIndex: 1}}
  modifiers={popperModifiers}
  placement={popperPlacement}
  className="popper">
  {popperComponent}
</Popper>
```