### PR TITLE
Adding error emitter for user input error

### DIFF
--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -14,6 +14,8 @@ const WrappedCalendar = onClickOutside(Calendar)
  * General datepicker component.
  */
 
+const INPUT_ERR_1 = 'Date input not valid.'
+
 export default class DatePicker extends React.Component {
   static propTypes = {
     allowSameDay: PropTypes.bool,
@@ -56,6 +58,7 @@ export default class DatePicker extends React.Component {
     onFocus: PropTypes.func,
     onKeyDown: PropTypes.func,
     onMonthChange: PropTypes.func,
+    onInputError: PropTypes.func,
     openToDate: PropTypes.object,
     peekNextMonth: PropTypes.bool,
     placeholderText: PropTypes.string,
@@ -99,6 +102,7 @@ export default class DatePicker extends React.Component {
       onSelect () {},
       onClickOutside () {},
       onMonthChange () {},
+      onInputError () {},
       utcOffset: moment().utcOffset(),
       monthsShown: 1,
       withPortal: false
@@ -280,18 +284,26 @@ export default class DatePicker extends React.Component {
       return
     }
     const copy = moment(this.state.preSelection)
+    const inputOk = moment.isMoment(this.state.preSelection) || moment.isDate(this.state.preSelection)
     if (eventKey === 'Enter') {
       event.preventDefault()
-      if (moment.isMoment(this.state.preSelection) || moment.isDate(this.state.preSelection)) {
+      if (inputOk) {
         this.handleSelect(copy, event)
       } else {
         this.setOpen(false)
+        this.props.onInputError({ code: 1, msg: INPUT_ERR_1 })
       }
     } else if (eventKey === 'Escape') {
       event.preventDefault()
       this.setOpen(false)
+      if (!inputOk) {
+        this.props.onInputError({ code: 1, msg: INPUT_ERR_1 })
+      }
     } else if (eventKey === 'Tab') {
       this.setOpen(false)
+      if (!inputOk) {
+        this.props.onInputError({ code: 1, msg: INPUT_ERR_1 })
+      }
     }
     if (!this.props.disabledKeyboardNavigation) {
       let newSelection

--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -162,6 +162,9 @@ export default class DatePicker extends React.Component {
     })
   }
 
+  inputOk = () =>
+    moment.isMoment(this.state.preSelection) || moment.isDate(this.state.preSelection)
+
   handleFocus = (event) => {
     if (!this.state.preventFocus) {
       this.props.onFocus(event)
@@ -188,6 +191,9 @@ export default class DatePicker extends React.Component {
       this.deferFocusInput()
     } else {
       this.props.onBlur(event)
+      if (!this.inputOk()) {
+        this.props.onInputError({ code: 1, msg: INPUT_ERR_1 })
+      }
     }
   }
 
@@ -284,10 +290,9 @@ export default class DatePicker extends React.Component {
       return
     }
     const copy = moment(this.state.preSelection)
-    const inputOk = moment.isMoment(this.state.preSelection) || moment.isDate(this.state.preSelection)
     if (eventKey === 'Enter') {
       event.preventDefault()
-      if (inputOk) {
+      if (this.inputOk()) {
         this.handleSelect(copy, event)
       } else {
         this.setOpen(false)
@@ -296,14 +301,11 @@ export default class DatePicker extends React.Component {
     } else if (eventKey === 'Escape') {
       event.preventDefault()
       this.setOpen(false)
-      if (!inputOk) {
+      if (!this.inputOk()) {
         this.props.onInputError({ code: 1, msg: INPUT_ERR_1 })
       }
     } else if (eventKey === 'Tab') {
       this.setOpen(false)
-      if (!inputOk) {
-        this.props.onInputError({ code: 1, msg: INPUT_ERR_1 })
-      }
     }
     if (!this.props.disabledKeyboardNavigation) {
       let newSelection

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -284,7 +284,7 @@ describe('DatePicker', () => {
     var nodeInput = ReactDOM.findDOMNode(dateInput)
     TestUtils.Simulate.focus(nodeInput)
     return {
-      m, copyM, testFormat, callback, datePicker, dateInput, nodeInput
+      m, copyM, testFormat, callback, inputErrorCallback, datePicker, dateInput, nodeInput
     }
   }
   it('should handle onInputKeyDown ArrowLeft', () => {

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -269,9 +269,11 @@ describe('DatePicker', () => {
     var copyM = moment(m)
     var testFormat = 'YYYY-MM-DD'
     var callback = sandbox.spy()
+    var inputErrorCallback = sandbox.spy()
     var datePicker = TestUtils.renderIntoDocument(
       <DatePicker selected={m}
           onChange={callback}
+          onInputError={inputErrorCallback}
           inline={opts.inline}
           excludeDates={opts.excludeDates}
           filterDate={opts.filterDate}
@@ -361,6 +363,7 @@ describe('DatePicker', () => {
       TestUtils.Simulate.keyDown(data.nodeInput, {key: 'Backspace', keyCode: 8, which: 8})
       TestUtils.Simulate.keyDown(data.nodeInput, {key: 'Enter', keyCode: 13, which: 13})
       expect(data.callback.calledOnce).to.be.false
+      expect(data.inputErrorCallback.calledOnce).to.be.true
     })
     it('should not select excludeDates', () => {
       var data = getOnInputKeyDownStuff({ excludeDates: [moment().subtract(1, 'days')] })
@@ -373,6 +376,26 @@ describe('DatePicker', () => {
       TestUtils.Simulate.keyDown(data.nodeInput, {key: 'ArrowLeft', keyCode: 37, which: 37})
       TestUtils.Simulate.keyDown(data.nodeInput, {key: 'Enter', keyCode: 13, which: 13})
       expect(data.callback.calledOnce).to.be.false
+    })
+  })
+  describe('onInputKeyDown Tab', () => {
+    it('should not update the selected date if the date input manually it has something wrong', () => {
+      var data = getOnInputKeyDownStuff()
+      TestUtils.Simulate.keyDown(data.nodeInput, {key: 'ArrowDown', keyCode: 40, which: 40})
+      TestUtils.Simulate.keyDown(data.nodeInput, {key: 'Backspace', keyCode: 8, which: 8})
+      TestUtils.Simulate.keyDown(data.nodeInput, {key: 'Tab', keyCode: 9, which: 9})
+      expect(data.callback.calledOnce).to.be.false
+      expect(data.inputErrorCallback.calledOnce).to.be.true
+    })
+  })
+  describe('onInputKeyDown Escape', () => {
+    it('should not update the selected date if the date input manually it has something wrong', () => {
+      var data = getOnInputKeyDownStuff()
+      TestUtils.Simulate.keyDown(data.nodeInput, {key: 'ArrowDown', keyCode: 40, which: 40})
+      TestUtils.Simulate.keyDown(data.nodeInput, {key: 'Backspace', keyCode: 8, which: 8})
+      TestUtils.Simulate.keyDown(data.nodeInput, {key: 'Escape', keyCode: 27, which: 27})
+      expect(data.callback.calledOnce).to.be.false
+      expect(data.inputErrorCallback.calledOnce).to.be.true
     })
   })
   it('should reset the keyboard selection when closed', () => {

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -378,16 +378,6 @@ describe('DatePicker', () => {
       expect(data.callback.calledOnce).to.be.false
     })
   })
-  describe('onInputKeyDown Tab', () => {
-    it('should not update the selected date if the date input manually it has something wrong', () => {
-      var data = getOnInputKeyDownStuff()
-      TestUtils.Simulate.keyDown(data.nodeInput, {key: 'ArrowDown', keyCode: 40, which: 40})
-      TestUtils.Simulate.keyDown(data.nodeInput, {key: 'Backspace', keyCode: 8, which: 8})
-      TestUtils.Simulate.keyDown(data.nodeInput, {key: 'Tab', keyCode: 9, which: 9})
-      expect(data.callback.calledOnce).to.be.false
-      expect(data.inputErrorCallback.calledOnce).to.be.true
-    })
-  })
   describe('onInputKeyDown Escape', () => {
     it('should not update the selected date if the date input manually it has something wrong', () => {
       var data = getOnInputKeyDownStuff()


### PR DESCRIPTION
This pull request is to address the needs to manage keyboard input error outside date picker component by emitting validation error when Enter, Tab, or Esc is pressed.