### PR TITLE
Avoid crash when inline and selected is null

### DIFF
--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -111,7 +111,9 @@ export default class DatePicker extends React.Component {
   }
 
   componentWillReceiveProps (nextProps) {
-    if (this.props.inline && !this.props.selected.isSame(nextProps.selected, 'month')) {
+    const currentMonth = this.props.selected && this.props.selected.month()
+    const nextMonth = nextProps.selected && nextProps.selected.month()
+    if (this.props.inline && currentMonth !== nextMonth) {
       this.setPreSelection(nextProps.selected)
     }
   }

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -601,6 +601,11 @@ describe('DatePicker', () => {
     )
     expect(datePicker.state('preSelection').format('YYYY-MM-DD')).to.equal(moment().format('YYYY-MM-DD'))
   })
+  it('should support an initial null `selected` value in inline mode', () => {
+    const datePicker = mount(<DatePicker inline selected={null} />)
+
+    expect(() => datePicker.setProps({ selected: moment() })).to.not.throw()
+  })
   it('should switch month in inline mode immediately', () => {
     const selected = moment()
     const future = moment().add(100, 'day')


### PR DESCRIPTION
This addresses a problem introduced in #960 (not yet part of a release version) where if a date picker is `inline` then it will crash when `selected` is null, due to the check added in #960 assuming that it will not be null.