### PR TITLE
add shouldCloseOnSelect prop to allow the calendar to remain open on …

### DIFF
--- a/docs-site/src/example_components.jsx
+++ b/docs-site/src/example_components.jsx
@@ -38,6 +38,7 @@ import Children from './examples/children'
 import Portal from './examples/portal'
 import InlinePortal from './examples/inline_portal'
 import RawChange from './examples/raw_change'
+import DontCloseOnSelect from './examples/dont_close_onSelect'
 
 import 'react-datepicker/dist/react-datepicker.css'
 import './style.scss'
@@ -190,6 +191,10 @@ export default class exampleComponents extends React.Component {
   {
     title: 'Get raw input value on change',
     component: <RawChange/>
+  },
+  {
+    title: 'Don\'t hide calendar on date selection',
+    component: <DontCloseOnSelect/>
   }]
 
   renderExamples = () =>

--- a/docs-site/src/examples/dont_close_onSelect.jsx
+++ b/docs-site/src/examples/dont_close_onSelect.jsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import DatePicker from 'react-datepicker'
+import moment from 'moment'
+
+export default class DontCloseOnSelect extends React.Component {
+  constructor (props) {
+    super(props)
+    this.state = {
+      startDate: moment()
+    }
+  }
+
+  handleChange = (date) => {
+    this.setState({
+      startDate: date
+    })
+  }
+
+  render () {
+    return <div className="row">
+      <pre className="column example__code">
+        <code className="jsx">{`
+<DatePicker
+    selected={this.state.startDate}
+    onChange={this.handleChange}
+    shouldCloseOnSelect={false}
+/>
+`}
+        </code>
+      </pre>
+      <div className="column">
+        <DatePicker
+            selected={this.state.startDate}
+            onChange={this.handleChange}
+            shouldCloseOnSelect={false} />
+      </div>
+    </div>
+  }
+}

--- a/docs/datepicker.md
+++ b/docs/datepicker.md
@@ -68,3 +68,4 @@ General datepicker component.
 |`weekLabel`|`string`|||
 |`withPortal`|`bool`|`false`||
 |`yearDropdownItemNumber`|`number`|||
+|`shouldCloseOnSelect`|`bool`|`true`|should the calendar close on day selection|

--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -81,7 +81,8 @@ export default class DatePicker extends React.Component {
     value: PropTypes.string,
     weekLabel: PropTypes.string,
     withPortal: PropTypes.bool,
-    yearDropdownItemNumber: PropTypes.number
+    yearDropdownItemNumber: PropTypes.number,
+    shouldCloseOnSelect: PropTypes.bool
   }
 
   static get defaultProps () {
@@ -101,7 +102,8 @@ export default class DatePicker extends React.Component {
       onMonthChange () {},
       utcOffset: moment().utcOffset(),
       monthsShown: 1,
-      withPortal: false
+      withPortal: false,
+      shouldCloseOnSelect: true
     }
   }
 
@@ -221,7 +223,9 @@ export default class DatePicker extends React.Component {
       }
     )
     this.setSelected(date, event)
-    if (!this.props.inline) {
+    if (!this.props.shouldCloseOnSelect) {
+      this.setPreSelection(date)
+    } else if (!this.props.inline) {
       this.setOpen(false)
     }
   }
@@ -286,6 +290,7 @@ export default class DatePicker extends React.Component {
       event.preventDefault()
       if (moment.isMoment(this.state.preSelection) || moment.isDate(this.state.preSelection)) {
         this.handleSelect(copy, event)
+        !this.props.shouldCloseOnSelect && this.setPreSelection(copy)
       } else {
         this.setOpen(false)
       }
@@ -294,8 +299,7 @@ export default class DatePicker extends React.Component {
       this.setOpen(false)
     } else if (eventKey === 'Tab') {
       this.setOpen(false)
-    }
-    if (!this.props.disabledKeyboardNavigation) {
+    } else if (!this.props.disabledKeyboardNavigation) {
       let newSelection
       switch (eventKey) {
         case 'ArrowLeft':

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -117,7 +117,49 @@ describe('DatePicker', () => {
     expect(datePicker.refs.calendar).to.not.exist
   })
 
-  it('should hide the calendar when the pressing enter in the date input', () => {
+  it('should not hide the calendar when clicking a day on the calendar and shouldCloseOnSelect prop is false', () => {
+    var datePicker = TestUtils.renderIntoDocument(
+      <DatePicker shouldCloseOnSelect={false}/>
+    )
+    var dateInput = datePicker.refs.input
+    TestUtils.Simulate.focus(ReactDOM.findDOMNode(dateInput))
+    var day = TestUtils.scryRenderedComponentsWithType(datePicker.refs.calendar, Day)[0]
+    TestUtils.Simulate.click(ReactDOM.findDOMNode(day))
+    expect(datePicker.state.open).to.be.true
+  })
+
+  it('should not hide the calendar when selecting a day in the calendar with Enter press, and shouldCloseOnSelect prop is false', () => {
+    var data = getOnInputKeyDownStuff({shouldCloseOnSelect: false})
+    var dateInput = data.datePicker.refs.input
+
+    TestUtils.Simulate.keyDown(data.nodeInput, {key: 'ArrowUp', keyCode: 38, which: 38})
+    TestUtils.Simulate.keyDown(ReactDOM.findDOMNode(dateInput), { key: 'Enter' })
+    expect(data.datePicker.state.open).to.be.true
+  })
+
+  it('should update the preSelection state when a day is selected with Enter press', () => {
+    var data = getOnInputKeyDownStuff({shouldCloseOnSelect: false})
+    var dateInput = data.datePicker.refs.input
+    TestUtils.Simulate.keyDown(data.nodeInput, {key: 'ArrowDown', keyCode: 40, which: 40})
+    TestUtils.Simulate.keyDown(ReactDOM.findDOMNode(dateInput), { key: 'Enter' })
+    TestUtils.Simulate.keyDown(data.nodeInput, {key: 'ArrowDown', keyCode: 40, which: 40})
+    data.copyM.add(2, 'weeks')
+    expect(data.datePicker.state.preSelection.format(data.testFormat)).to.equal(data.copyM.format(data.testFormat))
+  })
+
+  it('should update the preSelection state when a day is selected with mouse click', () => {
+    var data = getOnInputKeyDownStuff({shouldCloseOnSelect: false})
+    var day = TestUtils.findRenderedDOMComponentWithClass(data.datePicker.refs.calendar, 'react-datepicker__day--today')
+    TestUtils.Simulate.keyDown(data.nodeInput, {key: 'ArrowLeft', keyCode: 37, which: 37})
+    TestUtils.Simulate.keyDown(data.nodeInput, {key: 'ArrowLeft', keyCode: 37, which: 37})
+    TestUtils.Simulate.click(ReactDOM.findDOMNode(day))
+
+    TestUtils.Simulate.keyDown(data.nodeInput, {key: 'ArrowDown', keyCode: 40, which: 40})
+    data.copyM.add(1, 'weeks')
+    expect(data.datePicker.state.preSelection.format(data.testFormat)).to.equal(data.copyM.format(data.testFormat))
+  })
+
+  it('should hide the calendar when pressing enter in the date input', () => {
     var datePicker = TestUtils.renderIntoDocument(
       <DatePicker />
     )
@@ -276,7 +318,8 @@ describe('DatePicker', () => {
           excludeDates={opts.excludeDates}
           filterDate={opts.filterDate}
           minDate={opts.minDate}
-          maxDate={opts.maxDate}/>
+          maxDate={opts.maxDate}
+          shouldCloseOnSelect={opts.shouldCloseOnSelect}/>
     )
     var dateInput = datePicker.refs.input
     var nodeInput = ReactDOM.findDOMNode(dateInput)


### PR DESCRIPTION
This pr will close #989 

What have changed:
1. When selecting a day with mouse click or Enter press the datePicker will remain open if a shouldCloseOnSelect prop will be provided with a false value.

2. When ```shouldCloseOnSelect = false``` after selecting a day, the calendar will remain open and then the state.preselection value date will be updated to allow the expected UX behaviour.
For example.