### PR TITLE
Ignore Enter when disabledKeyboardNavigation #754

### DIFF
--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -286,7 +286,7 @@ export default class DatePicker extends React.Component {
       return
     }
     const copy = moment(this.state.preSelection)
-    if (eventKey === 'Enter') {
+    if (eventKey === 'Enter' && !this.props.disabledKeyboardNavigation) {
       event.preventDefault()
       if (moment.isMoment(this.state.preSelection) || moment.isDate(this.state.preSelection)) {
         this.handleSelect(copy, event)


### PR DESCRIPTION
Make possible submit forms with manually typed or programmatically set/cleared value.
Do not insert "today" date when pressing Enter when using `disabledKeyboardNavigation`.

This is a workaround for #754, proper fix might be to set input `value` to whatever is `selected` + `setOpen(false)`...?

Might also help with #966