### PR TITLE
Added a way to open / close the calendar outside of the datepicker component

### DIFF
--- a/docs-site/src/example_components.jsx
+++ b/docs-site/src/example_components.jsx
@@ -42,6 +42,7 @@ import ShowTime from './examples/show_time'
 import ExcludeTimes from './examples/exclude_times'
 import ExcludeTimePeriod from './examples/exclude_time_period'
 import DontCloseOnSelect from './examples/dont_close_onSelect'
+import SetOpen from './examples/set_open'
 
 import 'react-datepicker/dist/react-datepicker.css'
 import './style.scss'
@@ -210,6 +211,10 @@ export default class exampleComponents extends React.Component {
   {
     title: 'Don\'t hide calendar on date selection',
     component: <DontCloseOnSelect />
+  },
+  {
+    title: 'Manually open calendar from outside the component',
+    component: <SetOpen />
   }]
 
   renderExamples = () =>

--- a/docs-site/src/examples/set_open.jsx
+++ b/docs-site/src/examples/set_open.jsx
@@ -1,0 +1,80 @@
+import React from 'react'
+import DatePicker from 'react-datepicker'
+import moment from 'moment'
+
+export default class SetOpen extends React.Component {
+
+  constructor (props) {
+    super(props)
+    this.state = {
+      startDate: moment(),
+      isCalendarOpened: false
+    }
+  }
+
+  handleChange = (date) => {
+    this.setState({
+      startDate: date
+    })
+  }
+
+  handleInputChange = (event) => {
+    const target = event.target
+    const value = target.type === 'checkbox' ? target.checked : target.value
+    this.setState({
+      isCalendarOpened: value
+    })
+  }
+
+  openCalendar = (open) => {
+    this.setState({
+      isCalendarOpened: open
+    })
+  }
+
+  render () {
+    return <div className="row">
+      <pre className="column example__code">
+        <code className="jsx">{`
+class ExampleSetOpen extends React.Component {
+  ...
+  handleInputChange = (event) => {
+    this.setState({
+      isCalendarOpened: event.target.value
+    })
+  }
+  openCalendar = (open) => {
+    this.setState({
+      isCalendarOpened: open
+    })
+  }
+  ...
+}
+  <DatePicker
+      isOpen={this.state.isCalendarOpened}
+      setOpen={this.openCalendar} />
+  <input
+      type="checkbox"
+      onChange={this.handleInputChange}
+      checked={this.state.isCalendarOpened} />
+  <label>check to open calendar</label>
+
+          `}
+        </code>
+      </pre>
+      <div className="row">
+        <DatePicker
+            selected={this.state.startDate}
+            onChange={this.handleChange}
+            isOpen={this.state.isCalendarOpened}
+            setOpen={this.openCalendar} />
+        <input
+            type="checkbox"
+            onChange={this.handleInputChange}
+            checked={this.state.isCalendarOpened} />
+        <label>check to open calendar</label>
+      </div>
+    </div>
+  }
+
+}

--- a/docs/datepicker.md
+++ b/docs/datepicker.md
@@ -74,3 +74,5 @@ General datepicker component.
 |`weekLabel`|`string`|||
 |`withPortal`|`bool`|`false`||
 |`yearDropdownItemNumber`|`number`|||
+|`isOpen`|`boolean`|`false`|||
+|`setOpen`|`func`|||

--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -88,7 +88,9 @@ export default class DatePicker extends React.Component {
     timeIntervals: PropTypes.number,
     minTime: PropTypes.object,
     maxTime: PropTypes.object,
-    excludeTimes: PropTypes.array
+    excludeTimes: PropTypes.array,
+    isOpen: PropTypes.bool,
+    setOpen: PropTypes.func
   }
 
   static get defaultProps () {
@@ -111,7 +113,8 @@ export default class DatePicker extends React.Component {
       withPortal: false,
       shouldCloseOnSelect: true,
       showTimeSelect: false,
-      timeIntervals: 30
+      timeIntervals: 30,
+      isOpen: false
     }
   }
 
@@ -125,6 +128,9 @@ export default class DatePicker extends React.Component {
     const nextMonth = nextProps.selected && nextProps.selected.month()
     if (this.props.inline && currentMonth !== nextMonth) {
       this.setPreSelection(nextProps.selected)
+    }
+    if (this.state.open !== nextProps.isOpen) {
+      this.setOpen(nextProps.isOpen)
     }
   }
 
@@ -150,7 +156,7 @@ export default class DatePicker extends React.Component {
       : defaultPreSelection
 
     return {
-      open: false,
+      open: this.props.isOpen,
       preventFocus: false,
       preSelection: this.props.selected ? moment(this.props.selected) : boundedPreSelection
     }
@@ -171,6 +177,9 @@ export default class DatePicker extends React.Component {
       open: open,
       preSelection: open && this.state.open ? this.state.preSelection : this.calcInitialState().preSelection
     })
+    if (this.props.setOpen) {
+      this.props.setOpen(open)
+    }
   }
 
   handleFocus = (event) => {

--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -113,8 +113,7 @@ export default class DatePicker extends React.Component {
       withPortal: false,
       shouldCloseOnSelect: true,
       showTimeSelect: false,
-      timeIntervals: 30,
-      isOpen: false
+      timeIntervals: 30
     }
   }
 
@@ -129,7 +128,7 @@ export default class DatePicker extends React.Component {
     if (this.props.inline && currentMonth !== nextMonth) {
       this.setPreSelection(nextProps.selected)
     }
-    if (this.state.open !== nextProps.isOpen) {
+    if (typeof nextProps.isOpen !== 'undefined' && this.state.open !== nextProps.isOpen) {
       this.setOpen(nextProps.isOpen)
     }
   }

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -44,7 +44,7 @@ describe('DatePicker', () => {
     )
     var dateInput = datePicker.input
     TestUtils.Simulate.click(ReactDOM.findDOMNode(dateInput))
-    expect(datePicker.state.open).to.be.false
+    expect(typeof datePicker.state.open).to.equal('undefined')
   })
 
   it('should keep the calendar shown when blurring the date input', (done) => {
@@ -106,7 +106,7 @@ describe('DatePicker', () => {
     )
     var dateInput = datePicker.input
     TestUtils.Simulate.click(ReactDOM.findDOMNode(dateInput))
-    expect(datePicker.state.open).to.be.false
+    expect(typeof datePicker.state.open).to.equal('undefined')
   })
 
   it('should hide the calendar when clicking a day on the calendar', () => {
@@ -181,11 +181,11 @@ describe('DatePicker', () => {
     expect(datePicker.state.open).to.be.false
   })
 
-  it('should init open as false when isOpen is not defined', () => {
+  it('should init open as undefined when isOpen is not defined', () => {
     const datePicker = TestUtils.renderIntoDocument(
       <DatePicker />
     )
-    expect(datePicker.state.open).to.be.false
+    expect(typeof datePicker.state.open).to.equal('undefined')
   })
 
   it('should not hide the calendar when clicking a day on the calendar and shouldCloseOnSelect prop is false', () => {

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -120,6 +120,74 @@ describe('DatePicker', () => {
     expect(datePicker.calendar).to.not.exist
   })
 
+  it('should call setOpen with isOpen prop value when its changed to true', () => {
+    const setOpen = sandbox.spy()
+    let datePicker = mount(
+      <DatePicker isOpen={false} setOpen={setOpen}/>
+    )
+    datePicker.setProps({isOpen: true})
+    expect(setOpen.calledWithExactly(true)).to.be.true
+  })
+
+  it('should call setOpen with isOpen prop value when its changed to false', () => {
+    const setOpen = sandbox.spy()
+    let datePicker = mount(
+      <DatePicker isOpen setOpen={setOpen}/>
+    )
+    datePicker.setProps({isOpen: false})
+    expect(setOpen.calledWithExactly(false)).to.be.true
+  })
+
+  it('should not call setOpen when isOpen stayed with the same value', () => {
+    const setOpen = sandbox.spy()
+    let datePicker = mount(
+      <DatePicker isOpen setOpen={setOpen}/>
+    )
+    datePicker.setProps({isOpen: true})
+    expect(setOpen.called).to.be.false
+  })
+
+  it('should call setOpen prop when its defined and setOpen triggered', () => {
+    const setOpenSpy = sandbox.spy()
+    const datePicker = TestUtils.renderIntoDocument(
+      <DatePicker setOpen={setOpenSpy} />
+    )
+    var dateInput = datePicker.input
+    TestUtils.Simulate.focus(ReactDOM.findDOMNode(dateInput))
+    expect(setOpenSpy.called).to.be.true
+  })
+
+  it('should not call setOpen prop when its not defined', () => {
+    const setOpenSpy = sandbox.spy()
+    const datePicker = TestUtils.renderIntoDocument(
+      <DatePicker />
+    )
+    const dateInput = datePicker.input
+    TestUtils.Simulate.focus(ReactDOM.findDOMNode(dateInput))
+    expect(setOpenSpy.called).to.be.false
+  })
+
+  it('should init open as as true when isOpen prop is true', () => {
+    const datePicker = TestUtils.renderIntoDocument(
+      <DatePicker isOpen/>
+    )
+    expect(datePicker.state.open).to.be.true
+  })
+
+  it('should init open as as false when isOpen prop is false', () => {
+    const datePicker = TestUtils.renderIntoDocument(
+      <DatePicker isOpen={false}/>
+    )
+    expect(datePicker.state.open).to.be.false
+  })
+
+  it('should init open as as false when isOpen is not defined', () => {
+    const datePicker = TestUtils.renderIntoDocument(
+      <DatePicker />
+    )
+    expect(datePicker.state.open).to.be.false
+  })
+
   it('should not hide the calendar when clicking a day on the calendar and shouldCloseOnSelect prop is false', () => {
     var datePicker = TestUtils.renderIntoDocument(
       <DatePicker shouldCloseOnSelect={false}/>

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -167,21 +167,21 @@ describe('DatePicker', () => {
     expect(setOpenSpy.called).to.be.false
   })
 
-  it('should init open as as true when isOpen prop is true', () => {
+  it('should init open as true when isOpen prop is true', () => {
     const datePicker = TestUtils.renderIntoDocument(
       <DatePicker isOpen/>
     )
     expect(datePicker.state.open).to.be.true
   })
 
-  it('should init open as as false when isOpen prop is false', () => {
+  it('should init open as false when isOpen prop is false', () => {
     const datePicker = TestUtils.renderIntoDocument(
       <DatePicker isOpen={false}/>
     )
     expect(datePicker.state.open).to.be.false
   })
 
-  it('should init open as as false when isOpen is not defined', () => {
+  it('should init open as false when isOpen is not defined', () => {
     const datePicker = TestUtils.renderIntoDocument(
       <DatePicker />
     )


### PR DESCRIPTION
Hi,
I work at Wix, and we needed a way to open / close the calendar outside of the component (for example, opening the calendar with an external button).

I've done that by adding 2 new props: "_isOpen_" (boolean) and "_setOpen_" (function).
This functionality will only work by adding these props, and **will not affect the object in any way if those props were not added**.

isOpen - will live alongside the internal ‘state.open’ in correlation.
setOpen - is a callback that will be called if the function is defined and the state has been changed.

I've also added a simple example that shows a connection between the calendar and a checkbox using this new feature.

Hope you will like it, have a nice week.
approved by @lbelinsk 