### PR TITLE
Fix #1049 nested css calc function

### DIFF
--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -178,7 +178,7 @@
       ul.react-datepicker__time-list {
         list-style: none;
         margin: 0;
-        height: calc(195px + calc(#{$datepicker__item-size} / 2));
+        height: calc(195px + (#{$datepicker__item-size} / 2));
         overflow-y: scroll;
         padding-right: 30px;
         width: 100%;


### PR DESCRIPTION
Address unnecessary nested 'calc' function which crashes webpack