### PR TITLE
Optionally wrap the popper element with a user-supplied container

### DIFF
--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -87,6 +87,7 @@ export default class DatePicker extends React.Component {
     openToDate: PropTypes.object,
     peekNextMonth: PropTypes.bool,
     placeholderText: PropTypes.string,
+    popperContainer: PropTypes.func,
     popperClassName: PropTypes.string, // <PopperComponent/> props
     popperModifiers: PropTypes.object, // <PopperComponent/> props
     popperPlacement: PropTypes.oneOf(popperPlacementPositions), // <PopperComponent/> props
@@ -534,6 +535,7 @@ export default class DatePicker extends React.Component {
               {this.renderClearButton()}
             </div>
           }
+          popperContainer={this.props.popperContainer}
           popperComponent={calendar}
           popperPlacement={this.props.popperPlacement}/>
     )

--- a/src/popper_component.jsx
+++ b/src/popper_component.jsx
@@ -26,6 +26,7 @@ export default class PopperComponent extends React.Component {
     popperComponent: PropTypes.element,
     popperModifiers: PropTypes.object, // <datepicker/> props
     popperPlacement: PropTypes.oneOf(popperPlacementPositions), // <datepicker/> props
+    popperContainer: PropTypes.func,
     targetComponent: PropTypes.element
   }
 
@@ -52,20 +53,29 @@ export default class PopperComponent extends React.Component {
       targetComponent
     } = this.props
 
+    let popper
+
+    if (!hidePopper) {
+      popper = (
+        <Popper
+            className="react-datepicker-popper"
+            modifiers={popperModifiers}
+            placement={popperPlacement}>
+          {popperComponent}
+        </Popper>
+      )
+    }
+
+    if (this.props.popperContainer) {
+      popper = React.createElement(this.props.popperContainer, {}, popper)
+    }
+
     return (
       <Manager>
         <Target className="react-datepicker-wrapper">
           {targetComponent}
         </Target>
-        {
-          !hidePopper &&
-          <Popper
-              className="react-datepicker-popper"
-              modifiers={popperModifiers}
-              placement={popperPlacement}>
-            {popperComponent}
-          </Popper>
-        }
+        { popper }
       </Manager>
     )
   }

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -5,6 +5,7 @@ import { mount, ReactWrapper } from 'enzyme'
 import defer from 'lodash/defer'
 import DatePicker from '../src/datepicker.jsx'
 import Day from '../src/day'
+import TestWrapper from './test_wrapper.jsx'
 import PopperComponent from '../src/popper_component.jsx'
 import TimezoneDatePicker from './timezone_date_picker.jsx'
 import * as utils from '../src/date_utils'
@@ -45,6 +46,18 @@ describe('DatePicker', () => {
     var dateInput = datePicker.input
     TestUtils.Simulate.focus(ReactDOM.findDOMNode(dateInput))
     expect(datePicker.calendar).to.exist
+  })
+
+  it('should allow the user to supply a wrapper component for the popper', () => {
+    var datePicker = mount(
+      <DatePicker popperContainer={TestWrapper} />
+    )
+
+    const dateInput = datePicker.instance().input
+    TestUtils.Simulate.focus(ReactDOM.findDOMNode(dateInput))
+
+    expect(datePicker.find('.test-wrapper').length).to.equal(1)
+    expect(datePicker.instance().calendar).to.exist
   })
 
   it('should show the calendar when clicking on the date input', () => {

--- a/test/test_wrapper.jsx
+++ b/test/test_wrapper.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+var TestWrapper = ({ children }) => (<div className="test-wrapper">{children}</div>)
+
+TestWrapper.propTypes = {
+  children: PropTypes.node
+}
+
+export default TestWrapper


### PR DESCRIPTION
react-popper will place the popover in the same constraints as the
parent div. For cases where the parent div is somehow constrained -- a
scrollable div -- the popper will appear inside the div and will be
constrained by it to.

There are cases where you want the popover to be unconstrained it's
parent. To do this, you must place the popover in a container outside of
the constrained container.

demo: https://codesandbox.io/s/1ozy5ol5vl

Adding a popperContainer would allow a user to implement the following

  function CalendarContainer (props) {
    const containerId = document.getElementById('container-outside-root')

    return (
      <Portal container={containerId}>
        {props.children}
      </Portal>
    )
  }

  // somewhere else

  <DatePicker ... popperContainer={CalendarContainer} />

Which will then permit rendering the control inside the div and the
calendar outside the div (which the popper library will connect through
the magic of javascript)