### PR TITLE
Implemented popperClassName prop

### DIFF
--- a/docs-site/src/examples/configurePopper.jsx
+++ b/docs-site/src/examples/configurePopper.jsx
@@ -23,6 +23,7 @@ export default class ConfigurePopper extends React.Component {
 <DatePicker
     selected={this.state.startDate}
     onChange={this.handleChange}
+    popperClassName="some-custom-class"
     popperPlacement="top-end"
     popperModifiers={{
       offset: {
@@ -43,6 +44,7 @@ export default class ConfigurePopper extends React.Component {
         <DatePicker
             selected={this.state.startDate}
             onChange={this.handleChange}
+            popperClassName="some-custom-class"
             popperPlacement="top-end"
             popperModifiers={{
               offset: {

--- a/src/popper_component.jsx
+++ b/src/popper_component.jsx
@@ -1,3 +1,4 @@
+import classnames from 'classnames'
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Manager, Target, Popper } from 'react-popper'
@@ -22,6 +23,7 @@ export const popperPlacementPositions = [
 
 export default class PopperComponent extends React.Component {
   static propTypes = {
+    className: PropTypes.string,
     hidePopper: PropTypes.bool,
     popperComponent: PropTypes.element,
     popperModifiers: PropTypes.object, // <datepicker/> props
@@ -46,6 +48,7 @@ export default class PopperComponent extends React.Component {
 
   render () {
     const {
+      className,
       hidePopper,
       popperComponent,
       popperModifiers,
@@ -56,9 +59,10 @@ export default class PopperComponent extends React.Component {
     let popper
 
     if (!hidePopper) {
+      const classes = classnames('react-datepicker-popper', className)
       popper = (
         <Popper
-            className="react-datepicker-popper"
+            className={classes}
             modifiers={popperModifiers}
             placement={popperPlacement}>
           {popperComponent}

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -60,6 +60,19 @@ describe('DatePicker', () => {
     expect(datePicker.instance().calendar).to.exist
   })
 
+  it('should pass a custom class to the popper container', () => {
+    var datePicker = TestUtils.renderIntoDocument(
+      <DatePicker popperClassName="some-class-name" />
+    )
+    var dateInput = datePicker.input
+    TestUtils.Simulate.focus(ReactDOM.findDOMNode(dateInput))
+
+    const element = ReactDOM.findDOMNode(datePicker)
+    const popper = element.querySelector('.react-datepicker-popper')
+    expect(popper).to.exist
+    expect(popper.className).to.contain('some-class-name')
+  })
+
   it('should show the calendar when clicking on the date input', () => {
     var datePicker = TestUtils.renderIntoDocument(
       <DatePicker />


### PR DESCRIPTION
The prop `popperClassName` is passed into the `PopperComponent`, however, it is ignored and never actually makes it to the `Popper` component.

Fixes #1019 