### PR TITLE
Add .scss extensions

### DIFF
--- a/src/stylesheets/datepicker-cssmodules.scss
+++ b/src/stylesheets/datepicker-cssmodules.scss
@@ -1,3 +1,3 @@
 :global {
-  @import "datepicker";
+  @import "datepicker.scss";
 }

--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -1,5 +1,5 @@
-@import "variables";
-@import "mixins";
+@import "variables.scss";
+@import "mixins.scss";
 
 .react-datepicker-wrapper {
   display: inline-block;


### PR DESCRIPTION
I use [node-sass-chokidar](https://github.com/michaelwayman/node-sass-chokidar), it transforms *.scss files to *.css and keeps them near *.scss origins.
So, during the first build everything is ok, but during the next, it fails because it sees 2 files (e.g `variables.scss` & `variables.css`) and can't decide which file should be included.

Here is my output:
```
{
  "status": 1,
  "file": "./node_modules/react-datepicker/src/stylesheets/datepicker.scss",
  "line": 1,
  "column": 1,
  "message": "It's not clear which file to import for '@import \"variables\"'.\nCandidates:\n  variables.scss\n  variables.css\nPlease delete or rename all but one of these files.\n",
  "formatted": "Error: It's not clear which file to import for '@import \"variables\"'.\n       Candidates:\n         variables.scss\n         variables.css\n       Please delete or rename all but one of these files.\n        on line 1 of node_modules/react-datepicker/src/stylesheets/datepicker.scss\n>> @import \"variables\";\n   ^\n"
}
```