### PR TITLE
Fix timezone example in docs

### DIFF
--- a/docs-site/src/examples/timezone_date.jsx
+++ b/docs-site/src/examples/timezone_date.jsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import moment from 'moment'
 
 import DatePicker from 'react-datepicker'
 

--- a/docs-site/src/examples/timezone_date.jsx
+++ b/docs-site/src/examples/timezone_date.jsx
@@ -58,12 +58,11 @@ export default class TimeZoneDate extends React.Component {
       </pre>
       <div className="column">
         <DatePicker
-            utcOffset={this.state.utcOffset}
+            utcOffset={this.state.utcOffset * 60}
             dateFormat="DD-MMM YYYY HH:mm"
+            showTimeSelect
             todayButton={todayTxt}
             selected={selected}
-            minDate={moment('2016-11-05T00:00:00+00:00').utcOffset(this.state.utcOffset)}
-            maxDate={moment('2016-12-04T00:00:00-04:00').utcOffset(this.state.utcOffset)}
             onChange={this.handleChange} />
         <br/>
         <label className="example__timezone-label">


### PR DESCRIPTION
Should fix https://github.com/Hacker0x01/react-datepicker/issues/1054, see my answer there for details.