### PR TITLE
Fix package entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "version": "0.58.0",
   "license": "MIT",
   "homepage": "https://github.com/Hacker0x01/react-datepicker",
-  "main": "dist/react-datepicker.min.js",
+  "main": "lib/datepicker",
+  "unpkg": "dist/react-datepicker.min.js",
   "style": "dist/react-datepicker.min.css",
   "files": [
     "*.md",


### PR DESCRIPTION
It is not a good practice in general to use UMD bundles as entry points.

Bundlers should get access to files specifying imports/exports so they can follow dependency graph on their own (and possibly tree shake it too). I.e. by default consumer's bundler when bundling `react-datepicker` as dep should recognize it uses `react-onclickoutside` and just load it too. If you give the bundlers UMD bundles with externals most bundlers just wont recognize this pattern and wont load this such dep correctly.

Also for better performance you should also setup a parallel build with es modules left intact and specify `"module"` entry point in the `package.json`