### PR TITLE
Added `react-input-fixer` to fix Safari 10/11 MacOS phantom events fr…

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "eslint-plugin-react": "^7.4.0",
     "eslint-plugin-standard": "^3.0.1",
     "express": "^4.16.2",
-    "extract-text-webpack-plugin": "^3.0.2",
+    "extract-text-webpack-plugin": "^1.0.1",
     "highlight.js": "^9.12.0",
     "isparta-loader": "^2.0.0",
     "karma": "^1.7.1",
@@ -101,6 +101,7 @@
     "classnames": "^2.2.5",
     "moment": "^2.19.1",
     "prop-types": "^15.6.0",
+    "react-input-fixer": "^1.0.3",
     "react-onclickoutside": "^6.6.3",
     "react-popper": "^0.7.4"
   },

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -34,6 +34,7 @@ import {
   safeDateFormat
 } from './date_utils'
 import onClickOutside from 'react-onclickoutside'
+import FixedInput from 'react-input-fixer'
 
 const outsideClickIgnoreClass = 'react-datepicker-ignore-onclickoutside'
 const WrappedCalendar = onClickOutside(Calendar)
@@ -191,7 +192,7 @@ export default class DatePicker extends React.Component {
   }
 
   setFocus = () => {
-    this.input.focus()
+    this.input && this.input.focus && this.input.focus()
   }
 
   setOpen = (open) => {
@@ -460,7 +461,7 @@ export default class DatePicker extends React.Component {
       [outsideClickIgnoreClass]: this.state.open
     })
 
-    const customInput = this.props.customInput || <input type="text" />
+    const customInput = this.props.customInput || <FixedInput type="text" />
     const inputValue =
       typeof this.props.value === 'string' ? this.props.value
         : typeof this.state.inputValue === 'string' ? this.state.inputValue
@@ -508,18 +509,16 @@ export default class DatePicker extends React.Component {
         <div>
           {
             !this.props.inline
-              ? <div className="react-datepicker__input-container">
+              && <div className="react-datepicker__input-container">
                 {this.renderDateInput()}
                 {this.renderClearButton()}
               </div>
-              : null
           }
           {
             this.state.open || this.props.inline
-              ? <div className="react-datepicker__portal">
+              && <div className="react-datepicker__portal">
                 {calendar}
               </div>
-              : null
           }
         </div>
       )

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -509,16 +509,18 @@ export default class DatePicker extends React.Component {
         <div>
           {
             !this.props.inline
-              && <div className="react-datepicker__input-container">
+              ? <div className="react-datepicker__input-container">
                 {this.renderDateInput()}
                 {this.renderClearButton()}
               </div>
+              : null
           }
           {
             this.state.open || this.props.inline
-              && <div className="react-datepicker__portal">
+              ? <div className="react-datepicker__portal">
                 {calendar}
               </div>
+              : null
           }
         </div>
       )

--- a/yarn.lock
+++ b/yarn.lock
@@ -306,7 +306,7 @@ async-foreach@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/async-foreach/-/async-foreach-0.1.3.tgz#36121f845c0578172de419a97dbeb1d16ec34542"
 
-async@1.x, async@^1.3.0, async@^1.4.0:
+async@1.x, async@^1.3.0, async@^1.4.0, async@^1.5.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
@@ -314,7 +314,7 @@ async@^0.9.0, async@~0.9.0:
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
 
-async@^2.1.4, async@^2.1.5, async@^2.4.1:
+async@^2.1.4, async@^2.1.5:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.0.tgz#61a29abb6fcc026fea77e56d1c6ec53a795951f4"
   dependencies:
@@ -2608,14 +2608,13 @@ extglob@^0.3.1:
   dependencies:
     is-extglob "^1.0.0"
 
-extract-text-webpack-plugin@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/extract-text-webpack-plugin/-/extract-text-webpack-plugin-3.0.2.tgz#5f043eaa02f9750a9258b78c0a6e0dc1408fb2f7"
+extract-text-webpack-plugin@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/extract-text-webpack-plugin/-/extract-text-webpack-plugin-1.0.1.tgz#c95bf3cbaac49dc96f1dc6e072549fbb654ccd2c"
   dependencies:
-    async "^2.4.1"
-    loader-utils "^1.1.0"
-    schema-utils "^0.3.0"
-    webpack-sources "^1.0.1"
+    async "^1.5.0"
+    loader-utils "^0.2.3"
+    webpack-sources "^0.1.0"
 
 extsprintf@1.3.0, extsprintf@^1.2.0:
   version "1.3.0"
@@ -3858,7 +3857,7 @@ load-json-file@^4.0.0:
     pify "^3.0.0"
     strip-bom "^3.0.0"
 
-loader-utils@^0.2.11, loader-utils@^0.2.16, loader-utils@^0.2.5:
+loader-utils@^0.2.11, loader-utils@^0.2.16, loader-utils@^0.2.3, loader-utils@^0.2.5:
   version "0.2.17"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-0.2.17.tgz#f86e6374d43205a6e6c60e9196f17c0299bfb348"
   dependencies:
@@ -3867,7 +3866,7 @@ loader-utils@^0.2.11, loader-utils@^0.2.16, loader-utils@^0.2.5:
     json5 "^0.5.0"
     object-assign "^4.0.1"
 
-loader-utils@^1.0.1, loader-utils@^1.0.2, loader-utils@^1.1.0:
+loader-utils@^1.0.1, loader-utils@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.1.0.tgz#c98aef488bcceda2ffb5e2de646d6a754429f5cd"
   dependencies:
@@ -5169,6 +5168,10 @@ react-dom@^16.1.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
+react-input-fixer@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/react-input-fixer/-/react-input-fixer-1.0.3.tgz#1140829c7810c6a1f8cb64a52212d903fdd92a4a"
+
 react-onclickoutside@^6.6.3:
   version "6.6.3"
   resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.6.3.tgz#f3b9226f4541039d6d5a4a6120c4dfffcf7de60c"
@@ -5930,7 +5933,7 @@ source-map@^0.4.2, source-map@^0.4.4, source-map@~0.4.1:
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@^0.5.0, source-map@^0.5.1, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1, source-map@~0.5.6:
+source-map@^0.5.0, source-map@^0.5.1, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1, source-map@~0.5.3, source-map@~0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
@@ -6544,12 +6547,12 @@ webpack-hot-middleware@^2.20.0:
     querystring "^0.2.0"
     strip-ansi "^3.0.0"
 
-webpack-sources@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.0.2.tgz#d0148ec083b3b5ccef1035a6b3ec16442983b27a"
+webpack-sources@^0.1.0:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-0.1.5.tgz#aa1f3abf0f0d74db7111c40e500b84f966640750"
   dependencies:
-    source-list-map "^2.0.0"
-    source-map "~0.6.1"
+    source-list-map "~0.1.7"
+    source-map "~0.5.3"
 
 webpack@^1.13.0:
   version "1.15.0"


### PR DESCRIPTION
…om firing. Addressing the bug raised in #1077 

Fixed `setFocus()` to handle instances where the input isn't correctly set.
Tidied up a couple of inline `if` statements.
Rolled `extract-text-webpack-plugin` back to 1.0.1 for compatibility with `webpack` 1.13.0 which is currently used in the project.