### PR TITLE
Allow passing ref via custom props

### DIFF
--- a/docs/datepicker.md
+++ b/docs/datepicker.md
@@ -12,6 +12,7 @@ General datepicker component.
 |`children`|`node`|||
 |`className`|`string`|||
 |`customInput`|`element`|||
+|`customInputRef`|`string`|`'ref'`|The property used to pass the ref callback|
 |`dateFormat`|`union(string\|array)`|`'L'`||
 |`dateFormatCalendar`|`string`|`'MMMM YYYY'`||
 |`dayClassName`|`func`|||

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -51,6 +51,7 @@ export default class DatePicker extends React.Component {
     children: PropTypes.node,
     className: PropTypes.string,
     customInput: PropTypes.element,
+    customInputRef: PropTypes.string,
     dateFormat: PropTypes.oneOfType([ // eslint-disable-line react/no-unused-prop-types
       PropTypes.string,
       PropTypes.array
@@ -461,13 +462,14 @@ export default class DatePicker extends React.Component {
     })
 
     const customInput = this.props.customInput || <input type="text" />
+    const customInputRef = this.props.customInputRef || 'ref'
     const inputValue =
       typeof this.props.value === 'string' ? this.props.value
         : typeof this.state.inputValue === 'string' ? this.state.inputValue
           : safeDateFormat(this.props.selected, this.props)
 
     return React.cloneElement(customInput, {
-      ref: (input) => { this.input = input },
+      [customInputRef]: (input) => { this.input = input },
       value: inputValue,
       onBlur: this.handleBlur,
       onChange: this.handleChange,


### PR DESCRIPTION
When using react-datepicker with material-ui's `TextField`, you get an error because `TextField` is a stateless fn component and you can't pass `ref` to it. It however accepts `inputRef`. Allow users to define how the ref is passed to the custom input.