### PR TITLE
Time selector close

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -192,7 +192,7 @@ export default class DatePicker extends React.Component {
 
   setFocus = () => {
     if (this.input.focus) {
-      this.input.focus();
+      this.input.focus()
     }
   }
 
@@ -264,7 +264,7 @@ export default class DatePicker extends React.Component {
       }
     )
     this.setSelected(date, event)
-    if (!this.props.shouldCloseOnSelect) {
+    if (!this.props.shouldCloseOnSelect || this.props.showTimeSelect) {
       this.setPreSelection(date)
     } else if (!this.props.inline) {
       this.setOpen(false)
@@ -323,6 +323,7 @@ export default class DatePicker extends React.Component {
     })
 
     this.props.onChange(changedDate)
+    this.setOpen(false)
   }
 
   onInputClick = () => {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -191,7 +191,9 @@ export default class DatePicker extends React.Component {
   }
 
   setFocus = () => {
-    this.input.focus()
+    if (this.input.focus) {
+      this.input.focus();
+    }
   }
 
   setOpen = (open) => {


### PR DESCRIPTION
When the time selector is displayed, only close the picker when a time is selected (issue described in #1149)

Also, when passing in a custom input element, don't try and call a non existent `focus()` function #636 