### PR TITLE
Added public function for programatically clearing the input

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -444,10 +444,18 @@ export default class DatePicker extends React.Component {
   };
 
   onClearClick = event => {
-    event.preventDefault();
-    this.props.onChange(null, event);
-    this.setState({ inputValue: null });
+  	if (event) {
+  		if (event.preventDefault) {
+  			event.preventDefault()
+  		}
+  	}
+  	this.props.onChange(null, event)
+  	this.setState({ inputValue: null })
   };
+
+  clear = () => {
+    this.onClearClick()
+  }
 
   renderCalendar = () => {
     if (!this.props.inline && (!this.state.open || this.props.disabled)) {

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -895,4 +895,11 @@ describe("DatePicker", () => {
     );
     expect(datePicker.state.open).to.be.false;
   });
+  it("should clear the input when clear() member function is called", () => {
+    const datePicker = TestUtils.renderIntoDocument(
+      <DatePicker selected={utils.newDate("2015-12-15")} />
+    );
+    datePicker.clear();
+    expect(datePicker.state.inputValue).to.be.null;
+  });
 });


### PR DESCRIPTION
First of all, thank you so much for all the hard work that's gone into `react-datepicker`. It's been invaluable to our company to have such a well-made react date picker available. 

I ran into a small issue where after a date is selected, passing `null` to the `selected` prop wouldn't actually clear out the input. After looking through the code I realized I could call `onClearClick` manually to clear the input without needing to display the clear button. This works in my case but it does currently require that an event object be passed to the `onClearClick` function or it crashes. This pull request makes a small change to not require that event object. It also adds a new `clear` function that could be included in the docs as part of the public API. 

If this all looks acceptable I would be happy to make another pull request to include this method in the docs. 

Thanks again for this excellent package! It has seriously saved me so much time!

_Edit:_ I should mention, this PR at least partially addresses several open issues including: 
#1142 
#888 
#754 
  