### PR TITLE
Change close icon link href from # to javascript:void(0)

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -557,7 +557,7 @@ export default class DatePicker extends React.Component {
       return (
         <a
           className="react-datepicker__close-icon"
-          href="#"
+          href="javascript:void(0)"
           onClick={this.onClearClick}/>
       );
     } else {


### PR DESCRIPTION
Hello ReactDatepicker maintainers,
Kudos for this library,

I use the `Datepicker` component with `isCleareable={true}`, but whenever I try to clear the datepicker, it messes with my urls, and the browser tries to go to "#" and navigates me to the home page of my app

I couldn't do anything with event.preventDefault() but changing to `javascript:void(0)` in my sources solves it. 

Would you consider merging this PR ?
Thanks,

Nassim