### PR TITLE
Add option to allow showing month navigation as disabled,…

### DIFF
--- a/docs-site/src/example_components.jsx
+++ b/docs-site/src/example_components.jsx
@@ -21,6 +21,7 @@ import ClearInput from './examples/clear_input'
 import OnBlurCallbacks from './examples/on_blur_callbacks'
 import ConfigurePopper from './examples/configurePopper'
 import DateRange from './examples/date_range'
+import DateRangeWithShowDisabledNavigation from './examples/date_range_with_show_disabled_navigation'
 import TabIndex from './examples/tab_index'
 import YearDropdown from './examples/year_dropdown'
 import MonthDropdown from './examples/month_dropdown'
@@ -100,6 +101,10 @@ export default class exampleComponents extends React.Component {
   {
     title: 'Specific date range',
     component: <SpecificDateRange />
+  },
+  {
+    title: 'Date Range with disabled navigation shown',
+    component: <DateRangeWithShowDisabledNavigation />
   },
   {
     title: 'Locale',

--- a/docs-site/src/examples/date_range_with_show_disabled_navigation.jsx
+++ b/docs-site/src/examples/date_range_with_show_disabled_navigation.jsx
@@ -23,7 +23,7 @@ export default class DateRangeWithShowDisabledNavigation extends React.Component
   onChange={this.handleChange}
   minDate={moment()}
   maxDate={moment().add(5, "months")}
-  showDisabledMonthNavigation={true} />
+  showDisabledMonthNavigation />
 </div>
 
 `}
@@ -35,7 +35,7 @@ export default class DateRangeWithShowDisabledNavigation extends React.Component
             onChange={this.handleChange}
             minDate={moment()}
             maxDate={moment().add(5, "months")}
-            showDisabledMonthNavigation={true} />
+            showDisabledMonthNavigation />
         </div>
       </div>
     );

--- a/docs-site/src/examples/date_range_with_show_disabled_navigation.jsx
+++ b/docs-site/src/examples/date_range_with_show_disabled_navigation.jsx
@@ -1,0 +1,43 @@
+import React from "react";
+import DatePicker from "react-datepicker";
+import moment from "moment";
+
+export default class DateRangeWithShowDisabledNavigation extends React.Component {
+  state = {
+    startDate: null
+  };
+
+  handleChange = date => {
+    this.setState({
+      startDate: date
+    });
+  };
+
+  render() {
+    return (
+      <div className="row">
+        <pre className="column example__code">
+          <code className="jsx">{`
+<DatePicker
+  selected={this.state.startDate}
+  onChange={this.handleChange}
+  minDate={moment()}
+  maxDate={moment().add(5, "months")}
+  showDisabledMonthNavigation={true} />
+</div>
+
+`}
+          </code>
+        </pre>
+        <div className="column">
+          <DatePicker
+            selected={this.state.startDate}
+            onChange={this.handleChange}
+            minDate={moment()}
+            maxDate={moment().add(5, "months")}
+            showDisabledMonthNavigation={true} />
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -96,7 +96,8 @@ export default class Calendar extends React.Component {
     weekLabel: PropTypes.string,
     yearDropdownItemNumber: PropTypes.number,
     setOpen: PropTypes.func,
-    useShortMonthInDropdown: PropTypes.bool
+    useShortMonthInDropdown: PropTypes.bool,
+    showDisabledMonthNavigation: PropTypes.bool,
   };
 
   static get defaultProps() {
@@ -265,28 +266,49 @@ export default class Calendar extends React.Component {
   };
 
   renderPreviousMonthButton = () => {
+
+    const allPrevDaysDisabled = allDaysDisabledBefore(this.state.date, "month", this.props);
+
     if (
       !this.props.forceShowMonthNavigation &&
-      allDaysDisabledBefore(this.state.date, "month", this.props)
+      !this.props.showDisabledMonthNavigation &&
+      allPrevDaysDisabled
     ) {
       return;
     }
+
+    const classes = [
+      "react-datepicker__navigation",
+      "react-datepicker__navigation--previous"
+    ];
+
+    let clickHandler = this.decreaseMonth;
+
+    if (allPrevDaysDisabled && this.props.showDisabledMonthNavigation) {
+      classes.push("react-datepicker__navigation--previous--disabled");
+      clickHandler = null;
+    }
+
     return (
       <a
-        className="react-datepicker__navigation react-datepicker__navigation--previous"
-        onClick={this.decreaseMonth}/>
+        className={classes.join(" ")}
+        onClick={clickHandler}/>
     );
   };
 
   renderNextMonthButton = () => {
+
+    const allNextDaysDisabled = allDaysDisabledAfter(this.state.date, "month", this.props);
+
     if (
       !this.props.forceShowMonthNavigation &&
-      allDaysDisabledAfter(this.state.date, "month", this.props)
+      !this.props.showDisabledMonthNavigation &&
+      allNextDaysDisabled
     ) {
       return;
     }
 
-    let classes = [
+    const classes = [
       "react-datepicker__navigation",
       "react-datepicker__navigation--next"
     ];
@@ -297,7 +319,14 @@ export default class Calendar extends React.Component {
       classes.push("react-datepicker__navigation--next--with-today-button");
     }
 
-    return <a className={classes.join(" ")} onClick={this.increaseMonth} />;
+    let clickHandler = this.increaseMonth;
+
+    if (allNextDaysDisabled && this.props.showDisabledMonthNavigation) {
+        classes.push("react-datepicker__navigation--next--disabled");
+        clickHandler = null;
+    }
+
+    return <a className={classes.join(" ")} onClick={clickHandler} />;
   };
 
   renderCurrentMonth = (date = this.state.date) => {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -105,6 +105,7 @@ export default class DatePicker extends React.Component {
     showWeekNumbers: PropTypes.bool,
     showYearDropdown: PropTypes.bool,
     forceShowMonthNavigation: PropTypes.bool,
+    showDisabledMonthNavigation: PropTypes.bool,
     startDate: PropTypes.object,
     startOpen: PropTypes.bool,
     tabIndex: PropTypes.number,
@@ -489,6 +490,7 @@ export default class DatePicker extends React.Component {
         showYearDropdown={this.props.showYearDropdown}
         withPortal={this.props.withPortal}
         forceShowMonthNavigation={this.props.forceShowMonthNavigation}
+        showDisabledMonthNavigation={this.props.showDisabledMonthNavigation}
         scrollableYearDropdown={this.props.scrollableYearDropdown}
         todayButton={this.props.todayButton}
         weekLabel={this.props.weekLabel}

--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -106,6 +106,12 @@
     &:hover {
       border-right-color: darken($datepicker__muted-color, 10%);
     }
+
+    &--disabled,
+    &--disabled:hover {
+      border-right-color: $datepicker__navigation-disabled-color;
+      cursor: default;
+    }
   }
 
   &--next {
@@ -117,6 +123,12 @@
 
     &:hover {
       border-left-color: darken($datepicker__muted-color, 10%);
+    }
+
+    &--disabled,
+    &--disabled:hover {
+      border-left-color: $datepicker__navigation-disabled-color;
+      cursor: default;
     }
   }
 
@@ -494,6 +506,12 @@
     &:hover {
       border-right-color: darken($datepicker__muted-color, 10%);
     }
+
+    &--disabled,
+    &--disabled:hover {
+      border-right-color: $datepicker__navigation-disabled-color;
+      cursor: default;
+    }
   }
 
   .react-datepicker__navigation--next {
@@ -502,5 +520,11 @@
     &:hover {
       border-left-color: darken($datepicker__muted-color, 10%);
     }
+
+    &--disabled,
+     &--disabled:hover {
+       border-left-color: $datepicker__navigation-disabled-color;
+       cursor: default;
+     }
   }
 }

--- a/src/stylesheets/variables.scss
+++ b/src/stylesheets/variables.scss
@@ -5,6 +5,7 @@ $datepicker__muted-color: #ccc !default;
 $datepicker__selected-color: #216ba5 !default;
 $datepicker__text-color: #000 !default;
 $datepicker__header-color: #000 !default;
+$datepicker__navigation-disabled-color: lighten($datepicker__muted-color, 10%) !default;
 
 $datepicker__border-radius: 0.3rem !default;
 $datepicker__day-margin: 0.166rem !default;

--- a/test/calendar_test.js
+++ b/test/calendar_test.js
@@ -169,6 +169,123 @@ describe("Calendar", function() {
     expect(nextNavigationButton).to.have.length(1);
   });
 
+  describe("when showDisabledMonthNavigation is enabled", () => {
+    let onMonthChangeSpy = sinon.spy();
+
+    beforeEach(() => {
+      onMonthChangeSpy = sinon.spy();
+    });
+
+    it("should show disabled previous month navigation", function() {
+      const calendar = getCalendar({
+        minDate: utils.newDate(),
+        maxDate: utils.addMonths(utils.newDate(), 3),
+        showDisabledMonthNavigation: true
+      });
+      const prevDisabledNavigationButton = calendar.find(
+        ".react-datepicker__navigation--previous--disabled"
+      );
+
+      const nextDisabledNavigationButton = calendar.find(
+        ".react-datepicker__navigation--next--disabled"
+      );
+      expect(prevDisabledNavigationButton).to.have.length(1);
+      expect(nextDisabledNavigationButton).to.have.length(0);
+    });
+
+    it("should show disabled next month navigation", function() {
+      const calendar = getCalendar({
+        minDate: utils.subtractMonths(utils.newDate(), 3),
+        maxDate: utils.newDate(),
+        showDisabledMonthNavigation: true
+      });
+      const prevDisabledNavigationButton = calendar.find(
+        ".react-datepicker__navigation--previous--disabled"
+      );
+
+      const nextDisabledNavigationButton = calendar.find(
+        ".react-datepicker__navigation--next--disabled"
+      );
+      expect(prevDisabledNavigationButton).to.have.length(0);
+      expect(nextDisabledNavigationButton).to.have.length(1);
+    });
+
+    it("should not show disabled previous/next month navigation when next/previous month available", function() {
+      const calendar = getCalendar({
+        minDate: utils.subtractMonths(utils.newDate(), 3),
+        maxDate: utils.addMonths(utils.newDate(), 3),
+        showDisabledMonthNavigation: true
+      });
+      const prevDisabledNavigationButton = calendar.find(
+        ".react-datepicker__navigation--previous--disabled"
+      );
+
+      const nextDisabledNavigationButton = calendar.find(
+        ".react-datepicker__navigation--next--disabled"
+      );
+      expect(prevDisabledNavigationButton).to.have.length(0);
+      expect(nextDisabledNavigationButton).to.have.length(0);
+    });
+
+    it("when clicking disabled month navigation, should not change month", function() {
+
+      const calendar = getCalendar({
+        minDate: utils.newDate(),
+        maxDate: utils.newDate(),
+        showDisabledMonthNavigation: true,
+        onMonthChange: onMonthChangeSpy
+      });
+      const prevNavigationButton = calendar.find(
+        ".react-datepicker__navigation--previous"
+      );
+
+      const nextNavigationButton = calendar.find(
+        ".react-datepicker__navigation--next"
+      );
+
+      prevNavigationButton.simulate("click");
+
+      assert(
+        onMonthChangeSpy.called === false,
+        "onMonthChange should not be called"
+      );
+
+      nextNavigationButton.simulate("click");
+
+      assert(
+        onMonthChangeSpy.called === false,
+        "onMonthChange should not be called"
+      );
+    });
+
+    it("when clicking non-disabled month navigation, should change month", function() {
+
+      const calendar = getCalendar({
+        selected: utils.newDate(),
+        minDate: utils.subtractMonths(utils.newDate(), 3),
+        maxDate: utils.addMonths(utils.newDate(), 3),
+        showDisabledMonthNavigation: true,
+        onMonthChange: onMonthChangeSpy
+      });
+      const prevNavigationButton = calendar.find(
+        ".react-datepicker__navigation--previous"
+      );
+
+      const nextNavigationButton = calendar.find(
+        ".react-datepicker__navigation--next"
+      );
+
+      prevNavigationButton.simulate("click");
+      nextNavigationButton.simulate("click");
+
+      assert(
+        onMonthChangeSpy.callCount === 2,
+        "onMonthChange should be called 2 times"
+      );
+    });
+  });
+
+
   it("should not show the month dropdown menu by default", function() {
     const calendar = getCalendar();
     const monthReadView = calendar.find(MonthDropdown);


### PR DESCRIPTION
… when no next/previous months are available.

When showDisabledMonthNavigation is set true, the month navigation buttons are always shown, but buttons disabled (non-clickable) when there is no previous/next month available. Also --disabled classname is added to buttons in disabled state allowing them to be styled.

This is bit different from forceShowMonthNavigation, which does not disable month changing.