### PR TITLE
Upgrade react-onclickoutside to 6.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "prop-types": "^15.6.0",
-    "react-onclickoutside": "^6.6.3",
+    "react-onclickoutside": "^6.7.1",
     "react-popper": "^0.7.4"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5428,9 +5428,9 @@ react-dom@^16.1.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react-onclickoutside@^6.6.3:
-  version "6.6.3"
-  resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.6.3.tgz#f3b9226f4541039d6d5a4a6120c4dfffcf7de60c"
+react-onclickoutside@^6.7.1:
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.7.1.tgz#6a5b5b8b4eae6b776259712c89c8a2b36b17be93"
 
 react-popper@^0.7.4:
   version "0.7.4"


### PR DESCRIPTION
Upgrades react-onclickoutside to fix production `findDOMNode was called on an unmounted component.` bug.

Fixes #1213 

<img width="810" alt="screen shot 2018-01-16 at 2 30 37 pm" src="https://user-images.githubusercontent.com/399068/35013642-42ef8304-facb-11e7-9f19-716e986e9b15.png">
