### PR TITLE
Add type="button" to navigation buttons to avoid them to submit form …

### DIFF
--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -308,7 +308,7 @@ export default class Calendar extends React.Component {
     }
 
     return (
-      <button
+      <button type="button"
         className={classes.join(" ")}
         onClick={clickHandler}/>
     );
@@ -344,7 +344,7 @@ export default class Calendar extends React.Component {
         clickHandler = null;
     }
 
-    return <button className={classes.join(" ")} onClick={clickHandler} />;
+    return <button type="button" className={classes.join(" ")} onClick={clickHandler} />;
   };
 
   renderCurrentMonth = (date = this.state.date) => {


### PR DESCRIPTION
…(when datepicker is used inside form).

So this fixes form being submitted when datepicker's next/prev-month buttons are clicked.  