### PR TITLE
Show only one month and month-year dropdown when showing multiple months

### DIFF
--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -387,7 +387,7 @@ export default class Calendar extends React.Component {
   };
 
   renderMonthDropdown = (overrideHide = false) => {
-    if (!this.props.showMonthDropdown) {
+    if (!this.props.showMonthDropdown || overrideHide) {
       return;
     }
     return (
@@ -402,7 +402,7 @@ export default class Calendar extends React.Component {
   };
 
   renderMonthYearDropdown = (overrideHide = false) => {
-    if (!this.props.showMonthYearDropdown) {
+    if (!this.props.showMonthYearDropdown || overrideHide) {
       return;
     }
     return (

--- a/test/calendar_test.js
+++ b/test/calendar_test.js
@@ -159,6 +159,13 @@ describe("Calendar", function() {
     expect(yearReadView).to.have.length(1);
   });
 
+
+  it("should show only one year dropdown menu if toggled on and multiple month mode on", function() {
+    const calendar = getCalendar({ showYearDropdown: true, monthsShown: 2 });
+    const monthReadView = calendar.find(YearDropdown);
+    expect(monthReadView).to.have.length(1);
+  });
+
   it("should show month navigation if toggled on", function() {
     const calendar = getCalendar({
       includeDates: [utils.newDate()],
@@ -299,6 +306,12 @@ describe("Calendar", function() {
     expect(monthReadView).to.have.length(1);
   });
 
+  it("should show only one month dropdown menu if toggled on and multiple month mode on", function() {
+    const calendar = getCalendar({ showMonthDropdown: true, monthsShown: 2 });
+    const monthReadView = calendar.find(MonthDropdown);
+    expect(monthReadView).to.have.length(1);
+  });
+
   it("should not show the month-year dropdown menu by default", function() {
     const calendar = getCalendar();
     const monthYearReadView = calendar.find(MonthYearDropdown);
@@ -312,6 +325,17 @@ describe("Calendar", function() {
     const monthYearReadView = calendar.find(MonthYearDropdown);
     expect(monthYearReadView).to.have.length(1);
   });
+
+
+  it("should show only one month-year dropdown menu if toggled on and multiple month mode on", function() {
+    const calendar = getCalendar({ showMonthYearDropdown: true,
+                                   minDate: utils.subtractYears(utils.newDate(), 1),
+                                   maxDate: utils.addYears(utils.newDate(), 1),
+                                   monthsShown: 2 });
+    const monthReadView = calendar.find(MonthYearDropdown);
+    expect(monthReadView).to.have.length(1);
+  });
+
 
   it("should not show the today button by default", function() {
     const calendar = getCalendar();


### PR DESCRIPTION
This makes month and month-year dropdown work with same logic as year-dropdown. 

Before this PR, month dropdown was duplicated as show in the image below:

![image](https://user-images.githubusercontent.com/3878821/35218126-1c78555c-ff76-11e7-9bf3-64e78e1b25a9.png)
