### PR TITLE
Remove isRequired prop from dropdownMode property

### DIFF
--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -53,7 +53,7 @@ export default class Calendar extends React.Component {
     dateFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.array])
       .isRequired,
     dayClassName: PropTypes.func,
-    dropdownMode: PropTypes.oneOf(["scroll", "select"]).isRequired,
+    dropdownMode: PropTypes.oneOf(["scroll", "select"]),
     endDate: PropTypes.object,
     excludeDates: PropTypes.array,
     filterDate: PropTypes.func,


### PR DESCRIPTION
According to https://github.com/Hacker0x01/react-datepicker/issues/1188, isRequired prop has removed from dropdownMode property. 
Indeed, you have not to set this prop.