### PR TITLE
DateRange endDate doc bugfix

### DIFF
--- a/docs-site/src/examples/date_range.jsx
+++ b/docs-site/src/examples/date_range.jsx
@@ -16,9 +16,7 @@ export default class DateRange extends React.Component {
     endDate = endDate || this.state.endDate
 
     if (startDate.isAfter(endDate)) {
-      var temp = startDate
-      startDate = endDate
-      endDate = temp
+      endDate = startDate
     }
 
     this.setState({ startDate, endDate })


### PR DESCRIPTION
Fixes the issue on the site docs when you select a start date that is after the end date.