### PR TITLE
#1248 - update calendar position on month and year change

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "classnames": "^2.2.5",
     "prop-types": "^15.6.0",
     "react-onclickoutside": "^6.7.1",
-    "react-popper": "^0.7.4"
+    "react-popper": "^0.8.0"
   },
   "scripts": {
     "eslint": "eslint {src,test,docs-site/src}/**/*.{js,jsx} *.js",

--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -103,13 +103,15 @@ export default class Calendar extends React.Component {
     setOpen: PropTypes.func,
     useShortMonthInDropdown: PropTypes.bool,
     showDisabledMonthNavigation: PropTypes.bool,
+    scheduleUpdate: PropTypes.func,
   };
 
   static get defaultProps() {
     return {
       onDropdownFocus: () => {},
       monthsShown: 1,
-      forceShowMonthNavigation: false
+      forceShowMonthNavigation: false,
+      scheduleUpdate: () => {},
     };
   }
 
@@ -210,6 +212,8 @@ export default class Calendar extends React.Component {
     if (this.props.onYearChange) {
       this.props.onYearChange(date);
     }
+
+    this.props.scheduleUpdate();
   };
 
   handleMonthChange = date => {
@@ -224,6 +228,8 @@ export default class Calendar extends React.Component {
         this.props.setOpen(true);
       }
     }
+
+    this.props.scheduleUpdate();
   };
 
   handleMonthYearChange = date => {

--- a/src/popper_component.jsx
+++ b/src/popper_component.jsx
@@ -46,11 +46,29 @@ export default class PopperComponent extends React.Component {
     };
   }
 
+  renderPopperComponent = ({
+    popperProps,
+    restProps,
+    scheduleUpdate,
+  }) => {
+    const wrapperPopperComponent =  React.cloneElement(this.props.popperComponent, {
+      scheduleUpdate,
+    });
+
+    return (
+      <div
+        {...popperProps}
+        {...restProps}
+        >
+        {wrapperPopperComponent}
+      </div>
+    );
+  };
+
   render() {
     const {
       className,
       hidePopper,
-      popperComponent,
       popperModifiers,
       popperPlacement,
       targetComponent
@@ -65,7 +83,7 @@ export default class PopperComponent extends React.Component {
           className={classes}
           modifiers={popperModifiers}
           placement={popperPlacement}>
-          {popperComponent}
+          {this.renderPopperComponent}
         </Popper>
       );
     }

--- a/test/calendar_test.js
+++ b/test/calendar_test.js
@@ -159,7 +159,6 @@ describe("Calendar", function() {
     expect(yearReadView).to.have.length(1);
   });
 
-
   it("should show only one year dropdown menu if toggled on and multiple month mode on", function() {
     const calendar = getCalendar({ showYearDropdown: true, monthsShown: 2 });
     const monthReadView = calendar.find(YearDropdown);
@@ -236,7 +235,6 @@ describe("Calendar", function() {
     });
 
     it("when clicking disabled month navigation, should not change month", function() {
-
       const calendar = getCalendar({
         minDate: utils.newDate(),
         maxDate: utils.newDate(),
@@ -267,7 +265,6 @@ describe("Calendar", function() {
     });
 
     it("when clicking non-disabled month navigation, should change month", function() {
-
       const calendar = getCalendar({
         selected: utils.newDate(),
         minDate: utils.subtractMonths(utils.newDate(), 3),
@@ -292,7 +289,6 @@ describe("Calendar", function() {
       );
     });
   });
-
 
   it("should not show the month dropdown menu by default", function() {
     const calendar = getCalendar();
@@ -319,23 +315,25 @@ describe("Calendar", function() {
   });
 
   it("should show the month-year dropdown menu if toggled on", function() {
-    const calendar = getCalendar({ showMonthYearDropdown: true,
-                                   minDate: utils.subtractYears(utils.newDate(), 1),
-                                   maxDate: utils.addYears(utils.newDate(), 1) });
+    const calendar = getCalendar({
+      showMonthYearDropdown: true,
+      minDate: utils.subtractYears(utils.newDate(), 1),
+      maxDate: utils.addYears(utils.newDate(), 1)
+    });
     const monthYearReadView = calendar.find(MonthYearDropdown);
     expect(monthYearReadView).to.have.length(1);
   });
 
-
   it("should show only one month-year dropdown menu if toggled on and multiple month mode on", function() {
-    const calendar = getCalendar({ showMonthYearDropdown: true,
-                                   minDate: utils.subtractYears(utils.newDate(), 1),
-                                   maxDate: utils.addYears(utils.newDate(), 1),
-                                   monthsShown: 2 });
+    const calendar = getCalendar({
+      showMonthYearDropdown: true,
+      minDate: utils.subtractYears(utils.newDate(), 1),
+      maxDate: utils.addYears(utils.newDate(), 1),
+      monthsShown: 2
+    });
     const monthReadView = calendar.find(MonthYearDropdown);
     expect(monthReadView).to.have.length(1);
   });
-
 
   it("should not show the today button by default", function() {
     const calendar = getCalendar();
@@ -514,10 +512,12 @@ describe("Calendar", function() {
 
   describe("onMonthChange", () => {
     let onMonthChangeSpy = sinon.spy();
+    let scheduleUpdateSpy = sinon.spy();
     let calendar;
 
     beforeEach(() => {
       onMonthChangeSpy = sinon.spy();
+      scheduleUpdateSpy = sinon.spy();
       calendar = mount(
         <Calendar
           dateFormat={dateFormat}
@@ -529,6 +529,7 @@ describe("Calendar", function() {
           showMonthDropdown
           forceShowMonthNavigation
           onMonthChange={onMonthChangeSpy}
+          scheduleUpdate={scheduleUpdateSpy}
         />
       );
     });
@@ -543,6 +544,16 @@ describe("Calendar", function() {
       );
     });
 
+    it("calls scheduleUpdate prop when previous month button clicked", () => {
+      const select = calendar.find(".react-datepicker__navigation--previous");
+      select.simulate("click");
+
+      assert(
+        scheduleUpdateSpy.called === true,
+        "scheduleUpdate should be called"
+      );
+    });
+
     it("calls onMonthChange prop when next month button clicked", () => {
       const select = calendar.find(".react-datepicker__navigation--next");
       select.simulate("click");
@@ -550,6 +561,16 @@ describe("Calendar", function() {
       assert(
         onMonthChangeSpy.called === true,
         "onMonthChange should be called"
+      );
+    });
+
+    it("calls scheduleUpdate prop when next month button clicked", () => {
+      const select = calendar.find(".react-datepicker__navigation--next");
+      select.simulate("click");
+
+      assert(
+        scheduleUpdateSpy.called === true,
+        "scheduleUpdate should be called"
       );
     });
 
@@ -562,14 +583,26 @@ describe("Calendar", function() {
         "onMonthChange should be called"
       );
     });
+
+    it("calls scheduleUpdate prop when month changed from month dropdown", () => {
+      const select = calendar.find(MonthDropdown).find("select");
+      select.simulate("change");
+
+      assert(
+        scheduleUpdateSpy.called === true,
+        "scheduleUpdate should be called"
+      );
+    });
   });
 
   describe("onYearChange", () => {
     let onYearChangeSpy = sinon.spy();
+    let scheduleUpdateSpy = sinon.spy();
     let calendar;
 
     beforeEach(() => {
       onYearChangeSpy = sinon.spy();
+      scheduleUpdateSpy = sinon.spy();
       calendar = mount(
         <Calendar
           dateFormat={dateFormat}
@@ -579,6 +612,7 @@ describe("Calendar", function() {
           dropdownMode="select"
           showYearDropdown
           onYearChange={onYearChangeSpy}
+          scheduleUpdate={scheduleUpdateSpy}
         />
       );
     });
@@ -588,6 +622,16 @@ describe("Calendar", function() {
       select.simulate("change");
 
       assert(onYearChangeSpy.called === true, "onYearChange should be called");
+    });
+
+    it("calls scheduleUpdate prop when year changed from year dropdown", () => {
+      const select = calendar.find(YearDropdown).find("select");
+      select.simulate("change");
+
+      assert(
+        scheduleUpdateSpy.called === true,
+        "scheduleUpdate should be called"
+      );
     });
   });
 
@@ -616,17 +660,28 @@ describe("Calendar", function() {
     });
 
     it("calls onYearChange prop when selection is changed from month-year dropdown", () => {
-      const option = calendar.find(MonthYearDropdown).find("select").find("option").at(3);
+      const option = calendar
+        .find(MonthYearDropdown)
+        .find("select")
+        .find("option")
+        .at(3);
       option.simulate("change");
 
       assert(onYearChangeSpy.called === true, "onYearChange should be called");
     });
 
     it("calls onMonthChange prop when selection is changed from month-year dropdown", () => {
-      const option = calendar.find(MonthYearDropdown).find("select").find("option").at(3);
+      const option = calendar
+        .find(MonthYearDropdown)
+        .find("select")
+        .find("option")
+        .at(3);
       option.simulate("change");
 
-      assert(onMonthChangeSpy.called === true, "onMonthChange should be called");
+      assert(
+        onMonthChangeSpy.called === true,
+        "onMonthChange should be called"
+      );
     });
   });
 

--- a/test/popper_component_test.js
+++ b/test/popper_component_test.js
@@ -1,0 +1,23 @@
+import React from "react";
+import { mount } from "enzyme";
+
+import PopperComponent from "../src/popper_component.jsx";
+
+describe("PopperComponent", () => {
+  it("should render child inside PopperComponent and provide scheduleUpdate prop", () => {
+    const ChildComponent = () => <div />;
+
+    const wrapper = mount(
+      <PopperComponent
+        hidePopper={false}
+        popperComponent={<ChildComponent testProperty="testValue" />}
+      />
+    );
+
+    const childNode = wrapper.find(ChildComponent);
+
+    expect(childNode.length).to.equal(1);
+    expect(childNode.prop("testProperty")).to.equal("testValue");
+    expect(typeof childNode.prop("scheduleUpdate")).to.equal("function");
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1392,6 +1392,10 @@ chai@^3.5.0:
     deep-eql "^0.1.3"
     type-detect "^1.0.0"
 
+chain-function@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/chain-function/-/chain-function-1.0.0.tgz#0d4ab37e7e18ead0bdc47b920764118ce58733dc"
+
 chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -2046,6 +2050,10 @@ doctrine@^2.0.2:
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.0.2.tgz#68f96ce8efc56cc42651f1faadb4f175273b0075"
   dependencies:
     esutils "^2.0.2"
+
+dom-helpers@^3.2.0:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.3.1.tgz#fc1a4e15ffdf60ddde03a480a9c0fece821dd4a6"
 
 dom-serialize@^2.2.0:
   version "2.2.1"
@@ -4974,9 +4982,9 @@ pluralize@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
 
-popper.js@^1.12.5:
-  version "1.12.6"
-  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.12.6.tgz#91e12a97b07815258b76915d64044e8ac053d426"
+popper.js@^1.12.9:
+  version "1.12.9"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.12.9.tgz#0dfbc2dff96c451bb332edcfcfaaf566d331d5b3"
 
 postcss-calc@^5.2.0:
   version "5.3.1"
@@ -5277,7 +5285,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10, prop-types@^15.6.0:
+prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
   dependencies:
@@ -5432,12 +5440,13 @@ react-onclickoutside@^6.7.1:
   version "6.7.1"
   resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.7.1.tgz#6a5b5b8b4eae6b776259712c89c8a2b36b17be93"
 
-react-popper@^0.7.4:
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-0.7.4.tgz#8649d539837e7c6f47bc9b24c9cf57a404e199a1"
+react-popper@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-0.8.0.tgz#e8d5a936e2d4ded439a704221f0a893eda8cf284"
   dependencies:
-    popper.js "^1.12.5"
+    popper.js "^1.12.9"
     prop-types "^15.5.10"
+    react-transition-group "^2.2.1"
 
 react-proxy@^1.1.7:
   version "1.1.8"
@@ -5460,6 +5469,17 @@ react-transform-hmr@^1.0.4:
   dependencies:
     global "^4.3.0"
     react-proxy "^1.1.7"
+
+react-transition-group@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.2.1.tgz#e9fb677b79e6455fd391b03823afe84849df4a10"
+  dependencies:
+    chain-function "^1.0.0"
+    classnames "^2.2.5"
+    dom-helpers "^3.2.0"
+    loose-envify "^1.3.1"
+    prop-types "^15.5.8"
+    warning "^3.0.0"
 
 react@^16.1.0:
   version "16.1.0"
@@ -6779,6 +6799,12 @@ vm-browserify@0.0.4:
 void-elements@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"
+
+warning@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
+  dependencies:
+    loose-envify "^1.0.0"
 
 watchpack@^0.2.1:
   version "0.2.9"


### PR DESCRIPTION
Fixed updating calendar position (#1248)

- Upgrade `react-popper` to `0.8.0`.
- Provided `scheduleUpdate` function from `react-popper` to child node of `PopperComponent`.
- Call `scheduleUpdate` from `Calendar` on every change of year or month.
