### PR TITLE
added box-sizing to time-list

### DIFF
--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -210,6 +210,7 @@
         overflow-y: scroll;
         padding-right: 30px;
         width: 100%;
+        box-sizing: content-box;
 
         li.react-datepicker__time-list-item {
           padding: 5px 10px;


### PR DESCRIPTION
Enforce the time-list to have a default box-sizing, which is content-box.