### PR TITLE
Fixing the arrows in rtl languages

### DIFF
--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -32,6 +32,8 @@ import {
   getEffectiveMaxDate
 } from "./date_utils";
 
+import { isLocaleRtl } from "./locale_utils";
+
 const DROPDOWN_FOCUS_CLASSNAMES = [
   "react-datepicker__year-select",
   "react-datepicker__month-select",
@@ -304,7 +306,7 @@ export default class Calendar extends React.Component {
     ];
 
     let clickHandler;
-	if(this.props.locale === 'he' || this.props.locale === 'ar') {
+	if(isLocaleRtl(this.props.locale)) {
 		clickHandler = this.increaseMonth;
 	} else {
 		clickHandler = this.decreaseMonth;
@@ -346,7 +348,7 @@ export default class Calendar extends React.Component {
     }
 	
 	let clickHandler;
-	if(this.props.locale === 'he' || this.props.locale === 'ar') {
+	if(isLocaleRtl(this.props.locale)) {
 		clickHandler = this.decreaseMonth;
 	} else {
 		clickHandler = this.increaseMonth;

--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -286,7 +286,7 @@ export default class Calendar extends React.Component {
     );
   };
 
-  renderPreviousMonthButton = () => {
+  renderLeftArrowButton = () => {
 
     const allPrevDaysDisabled = allDaysDisabledBefore(this.state.date, "month", this.props);
 
@@ -303,7 +303,12 @@ export default class Calendar extends React.Component {
       "react-datepicker__navigation--previous"
     ];
 
-    let clickHandler = this.decreaseMonth;
+    let clickHandler;
+	if(this.props.locale === 'he' || this.props.locale === 'ar') {
+		clickHandler = this.increaseMonth;
+	} else {
+		clickHandler = this.decreaseMonth;
+	}
 
     if (allPrevDaysDisabled && this.props.showDisabledMonthNavigation) {
       classes.push("react-datepicker__navigation--previous--disabled");
@@ -317,7 +322,7 @@ export default class Calendar extends React.Component {
     );
   };
 
-  renderNextMonthButton = () => {
+  renderRightArrowButton = () => {
 
     const allNextDaysDisabled = allDaysDisabledAfter(this.state.date, "month", this.props);
 
@@ -339,8 +344,13 @@ export default class Calendar extends React.Component {
     if (this.props.todayButton) {
       classes.push("react-datepicker__navigation--next--with-today-button");
     }
-
-    let clickHandler = this.increaseMonth;
+	
+	let clickHandler;
+	if(this.props.locale === 'he' || this.props.locale === 'ar') {
+		clickHandler = this.decreaseMonth;
+	} else {
+		clickHandler = this.increaseMonth;
+	}
 
     if (allNextDaysDisabled && this.props.showDisabledMonthNavigation) {
         classes.push("react-datepicker__navigation--next--disabled");
@@ -523,8 +533,8 @@ export default class Calendar extends React.Component {
     return (
       <div className={classnames("react-datepicker", this.props.className)}>
         <div className="react-datepicker__triangle" />
-        {this.renderPreviousMonthButton()}
-        {this.renderNextMonthButton()}
+        {this.renderLeftArrowButton()}
+        {this.renderRightArrowButton()}
         {this.renderMonths()}
         {this.renderTodayButton()}
         {this.renderTimeSection()}

--- a/src/locale_utils.js
+++ b/src/locale_utils.js
@@ -1,0 +1,25 @@
+const rtlLocales = [
+    'ae',	/* Avestan */
+    'ar',   /* 'العربية', Arabic */
+    'arc',  /* Aramaic */
+    'bcc',  /* 'بلوچی مکرانی', Southern Balochi */
+    'bqi',  /* 'بختياري', Bakthiari */
+    'ckb',  /* 'Soranî / کوردی', Sorani */
+    'dv',   /* Dhivehi */
+    'fa',   /* 'فارسی', Persian */
+    'glk',  /* 'گیلکی', Gilaki */
+    'he',   /* 'עברית', Hebrew */
+    'ku',   /* 'Kurdî / كوردی', Kurdish */
+    'mzn',  /* 'مازِرونی', Mazanderani */
+    'nqo',  /* N'Ko */
+    'pnb',  /* 'پنجابی', Western Punjabi */
+    'ps',   /* 'پښتو', Pashto, */
+    'sd',   /* 'سنڌي', Sindhi */
+    'ug',   /* 'Uyghurche / ئۇيغۇرچە', Uyghur */
+    'ur',   /* 'اردو', Urdu */
+    'yi'    /* 'ייִדיש', Yiddish */
+];
+
+export function isLocaleRtl(locale) {
+    return rtlLocales.indexOf(locale.split('-')[0]) !== -1;
+}


### PR DESCRIPTION
When using this datepicker component with rtl languages the two arrows for moving from month to month are inverted
so I've just added a little check to check if the locale is an rtl language (hope I've included all of them feel free to add more if you know more rtl languages) and then decide if the arrow shall increase the month or decrease it.
I've also changed the functions names since each function is rendering the right/left arrow and not the prev/next month.
see my comment on this issue: https://github.com/Hacker0x01/react-datepicker/issues/1271