### PR TITLE
Created two different builds for production and development enviroments.

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,8 @@
     "codecov":
       "cat coverage/*/lcov.info | ./node_modules/codecov.io/bin/codecov.io.js",
     "prebuild": "rimraf es lib dist",
-    "build": "run-p build:** && run-p css:**",
+    "build": "NODE_ENV=production run-p build:** && run-p css:**",
+    "build-dev": "NODE_ENV=development run-p build:** && run-p css:**",
     "css:prod":
       "node-sass --output-style compressed src/stylesheets/datepicker.scss > dist/react-datepicker.min.css",
     "css:modules:prod":
@@ -119,10 +120,10 @@
       "cross-env BABEL_ENV=es rollup -c -i src/index.jsx -o es/index.js",
     "build:cjs":
       "cross-env BABEL_ENV=cjs rollup -c -i src/index.jsx -o lib/index.js",
-    "build:umd:prod":
-      "cross-env BABEL_ENV=es NODE_ENV=production rollup -c rollup.umd.config.js -i src/index.jsx -o dist/react-datepicker.min.js",
     "build:umd:dev":
-      "cross-env BABEL_ENV=es NODE_ENV=development rollup -c rollup.umd.config.js -i src/index.jsx -o dist/react-datepicker.js",
+      "cross-env BABEL_ENV=es rollup -c rollup.umd.config.js -i src/index.jsx -o dist/react-datepicker.js",
+    "build:umd:prod":
+      "cross-env BABEL_ENV=es rollup -c rollup.umd.config.js -i src/index.jsx -o dist/react-datepicker.min.js",
     "build:docs":
       "cross-env MODULES=false webpack --config webpack.docs.config.js"
   },


### PR DESCRIPTION
There was a problem in the build script because it launched build:umd:dev and build:umd:prod.

build:umd:dev was setting NODE_ENV to 'development' so .babelrc.js was adding react-transform-hmr in the compiled file.

I changed package.json creating build-dev for development env and left build for production only.

FIXES: Local build issue #460