### PR TITLE
Use cross-env for build scripts to fix Windows usage.

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,8 +106,8 @@
     "codecov":
       "cat coverage/*/lcov.info | ./node_modules/codecov.io/bin/codecov.io.js",
     "prebuild": "rimraf es lib dist",
-    "build": "NODE_ENV=production run-p build:** && run-p css:**",
-    "build-dev": "NODE_ENV=development run-p build:** && run-p css:**",
+    "build": "cross-env NODE_ENV=production run-p build:** && run-p css:**",
+    "build-dev": "cross-env NODE_ENV=development run-p build:** && run-p css:**",
     "css:prod":
       "node-sass --output-style compressed src/stylesheets/datepicker.scss > dist/react-datepicker.min.css",
     "css:modules:prod":


### PR DESCRIPTION
I encountered an issue while trying to install this package as part of our Azure deployment. The error was in the `build` script:

> 'NODE_ENV' is not recognized as an internal or external command

I noticed that the `build` and `build-dev` scripts are the only 2 which don't use `cross-env` to set the Node environment variable(s) necessary for the script to run. Is this intentional?

Adding `cross-env` to the scripts fixed the deployment for us as our Azure service is a Windows environment.