### PR TITLE
Improvements to injectTimes

### DIFF
--- a/docs-site/src/examples/inject_times.jsx
+++ b/docs-site/src/examples/inject_times.jsx
@@ -27,7 +27,11 @@ export default class InjectTimes extends React.Component {
             <br />
             <strong>{`    showTimeSelect
     timeFormat="HH:mm"
-    injectTimes={[moment().hours(0).minutes(1), moment().hours(12).minutes(5), moment().hours(23).minutes(59)]}
+    injectTimes={[
+      moment().hours(0).minutes(1),
+      moment().hours(12).minutes(5),
+      moment().hours(23).minutes(59)
+    ]}
     dateFormat="LLL"
 />
 `}</strong>

--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -504,9 +504,6 @@ export function timesToInjectAfter(
 ) {
   const l = injectedTimes.length;
   const times = [];
-  injectedTimes.sort(function(a, b) {
-    return a - b;
-  });
   for (let i = 0; i < l; i++) {
     const injectedTime = addMinutes(
       addHours(cloneDate(startOfDay), getHour(injectedTimes[i])),

--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -495,7 +495,7 @@ export function getHightLightDaysMap(
   return dateClasses;
 }
 
-export function timeToInjectAfter(
+export function timesToInjectAfter(
   startOfDay,
   currentTime,
   currentMultiplier,
@@ -503,6 +503,10 @@ export function timeToInjectAfter(
   injectedTimes
 ) {
   const l = injectedTimes.length;
+  const times = [];
+  injectedTimes.sort(function(a, b) {
+    return a - b;
+  });
   for (let i = 0; i < l; i++) {
     const injectedTime = addMinutes(
       addHours(cloneDate(startOfDay), getHour(injectedTimes[i])),
@@ -514,9 +518,9 @@ export function timeToInjectAfter(
     );
 
     if (injectedTime.isBetween(currentTime, nextTime)) {
-      return injectedTimes[i];
+      times.push(injectedTimes[i]);
     }
   }
 
-  return false;
+  return times;
 }

--- a/src/time.jsx
+++ b/src/time.jsx
@@ -97,17 +97,22 @@ export default class Time extends React.Component {
     const currM = getMinute(activeTime);
     let base = getStartOfDay(newDate());
     const multiplier = 1440 / intervals;
+    const sortedInjectTimes =
+      this.props.injectTimes &&
+      this.props.injectTimes.sort(function(a, b) {
+        return a - b;
+      });
     for (let i = 0; i < multiplier; i++) {
       const currentTime = addMinutes(cloneDate(base), i * intervals);
       times.push(currentTime);
 
-      if (this.props.injectTimes) {
+      if (sortedInjectTimes) {
         const timesToInject = timesToInjectAfter(
           base,
           currentTime,
           i,
           intervals,
-          this.props.injectTimes
+          sortedInjectTimes
         );
         times = times.concat(timesToInject);
       }

--- a/src/time.jsx
+++ b/src/time.jsx
@@ -10,7 +10,7 @@ import {
   formatDate,
   isTimeInDisabledRange,
   isTimeDisabled,
-  timeToInjectAfter
+  timesToInjectAfter
 } from "./date_utils";
 
 export default class Time extends React.Component {
@@ -102,16 +102,14 @@ export default class Time extends React.Component {
       times.push(currentTime);
 
       if (this.props.injectTimes) {
-        const timeToInject = timeToInjectAfter(
+        const timesToInject = timesToInjectAfter(
           base,
           currentTime,
           i,
           intervals,
           this.props.injectTimes
         );
-        if (timeToInject) {
-          times.push(timeToInject);
-        }
+        times = times.concat(timesToInject);
       }
     }
 

--- a/test/inject_times_test.js
+++ b/test/inject_times_test.js
@@ -31,10 +31,10 @@ describe("TimeComponent", () => {
       />
     );
 
-    const disabledItems = timeComponent.find(
+    const injectedItems = timeComponent.find(
       ".react-datepicker__time-list-item--injected"
     );
-    expect(disabledItems).to.have.length(3);
+    expect(injectedItems).to.have.length(3);
   });
 
   it("should not affect existing time intervals", () => {
@@ -50,9 +50,51 @@ describe("TimeComponent", () => {
       />
     );
 
-    const disabledItems = timeComponent.find(
+    const injectedItems = timeComponent.find(
       ".react-datepicker__time-list-item--injected"
     );
-    expect(disabledItems).to.have.length(0);
+    expect(injectedItems).to.have.length(0);
+  });
+
+  it("should allow multiple injected times per interval", () => {
+    const today = utils.getStartOfDay(utils.newDate());
+    const timeComponent = mount(
+      <TimeComponent
+        timeIntervals={60}
+        injectTimes={[
+          utils.addMinutes(cloneDate(today), 1),
+          utils.addMinutes(cloneDate(today), 2),
+          utils.addMinutes(cloneDate(today), 3)
+        ]}
+      />
+    );
+
+    const injectedItems = timeComponent.find(
+      ".react-datepicker__time-list-item--injected"
+    );
+    expect(injectedItems).to.have.length(3);
+  });
+
+  it("should sort injected times automatically", () => {
+    const today = utils.getStartOfDay(utils.newDate());
+    const timeComponent = mount(
+      <TimeComponent
+        timeIntervals={60}
+        injectTimes={[
+          utils.addMinutes(cloneDate(today), 3),
+          utils.addMinutes(cloneDate(today), 1),
+          utils.addMinutes(cloneDate(today), 2)
+        ]}
+      />
+    );
+
+    const injectedItems = timeComponent.find(
+      ".react-datepicker__time-list-item--injected"
+    );
+    expect(injectedItems.map(node => node.text())).eql([
+      "12:01 AM",
+      "12:02 AM",
+      "12:03 AM"
+    ]);
   });
 });


### PR DESCRIPTION
Following up on https://github.com/Hacker0x01/react-datepicker/pull/1329
Feature proposed at https://github.com/Hacker0x01/react-datepicker/issues/1328

Added ability to :-
- Insert multiple times in between each interval. Previously only one injected time allowed per interval.
<img width="302" alt="screen shot 2018-03-27 at 13 46 25" src="https://user-images.githubusercontent.com/377774/37949007-47cccc7a-31c5-11e8-98c8-ab04c667a53a.png">

- Auto sort injected times so that they appear chronologically
<img width="748" alt="screen shot 2018-03-27 at 13 49 02" src="https://user-images.githubusercontent.com/377774/37949071-a357333c-31c5-11e8-9f23-2d7dee6f0336.png">

