### PR TITLE
Fix potential exception after unmounting

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -220,7 +220,7 @@ export default class DatePicker extends React.Component {
   };
 
   setFocus = () => {
-    if (this.input.focus) {
+    if (this.input && this.input.focus) {
       this.input.focus();
     }
   };


### PR DESCRIPTION
`handleBlur()` calls `deferFocusInput()` if the date picker is open. `deferFocusInput()` schedules a later `setFocus()` call, which didn't make sure the input element is still mounted before focusing it, yielding an unhandled exception.

I'm getting this exception with a DatePicker component embedded in a react-tippy tooltip, when leaving the tooltip with an opened date picker.