### PR TITLE
Limit month list by minDate and maxDate

### DIFF
--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -238,9 +238,29 @@ export default class Calendar extends React.Component {
   };
 
   changeYear = year => {
+    let newDate = setYear(cloneDate(this.state.date), year);
+    const newDateMonth = getMonth(newDate);
+    const newDateYear = getYear(newDate);
+
+    if (
+      this.props.minDate &&
+      getYear(this.props.minDate) === newDateYear &&
+      getMonth(this.props.minDate) > newDateMonth
+    ) {
+      newDate = setMonth(cloneDate(newDate), getMonth(this.props.minDate));
+    }
+
+    if (
+      this.props.maxDate &&
+      getYear(this.props.maxDate) === newDateYear &&
+      getMonth(this.props.maxDate) < newDateMonth
+    ) {
+      newDate = setMonth(cloneDate(newDate), getMonth(this.props.maxDate));
+    }
+
     this.setState(
       {
-        date: setYear(cloneDate(this.state.date), year)
+        date: newDate
       },
       () => this.handleYearChange(this.state.date)
     );
@@ -293,12 +313,16 @@ export default class Calendar extends React.Component {
   };
 
   formatWeekday = (localeData, day) => {
-      if (this.props.formatWeekDay) {
-          return getFormattedWeekdayInLocale(localeData, day, this.props.formatWeekDay);
-      }
-      return this.props.useWeekdaysShort
-          ? getWeekdayShortInLocale(localeData, day)
-          : getWeekdayMinInLocale(localeData, day);
+    if (this.props.formatWeekDay) {
+      return getFormattedWeekdayInLocale(
+        localeData,
+        day,
+        this.props.formatWeekDay
+      );
+    }
+    return this.props.useWeekdaysShort
+      ? getWeekdayShortInLocale(localeData, day)
+      : getWeekdayMinInLocale(localeData, day);
   };
 
   renderPreviousMonthButton = () => {
@@ -431,7 +455,10 @@ export default class Calendar extends React.Component {
         locale={this.props.locale}
         dateFormat={this.props.dateFormat}
         onChange={this.changeMonth}
+        minDate={this.props.minDate}
+        maxDate={this.props.maxDate}
         month={getMonth(this.state.date)}
+        year={getYear(this.state.date)}
         useShortMonthInDropdown={this.props.useShortMonthInDropdown}
       />
     );

--- a/src/month_dropdown.jsx
+++ b/src/month_dropdown.jsx
@@ -11,6 +11,9 @@ export default class MonthDropdown extends React.Component {
     dropdownMode: PropTypes.oneOf(["scroll", "select"]).isRequired,
     locale: PropTypes.string,
     dateFormat: PropTypes.string.isRequired,
+    maxDate: PropTypes.object,
+    minDate: PropTypes.object,
+    year: PropTypes.number.isRequired,
     month: PropTypes.number.isRequired,
     onChange: PropTypes.func.isRequired,
     useShortMonthInDropdown: PropTypes.bool
@@ -20,12 +23,44 @@ export default class MonthDropdown extends React.Component {
     dropdownVisible: false
   };
 
-  renderSelectOptions = monthNames =>
-    monthNames.map((M, i) => (
-      <option key={i} value={i}>
-        {M}
-      </option>
-    ));
+  renderSelectOptions = monthNames => {
+    let minMonth = 0;
+    let maxMonth = 11;
+
+    if (this.props.minDate) {
+      const minYear = this.props.minDate
+        ? utils.getYear(this.props.minDate)
+        : 1900;
+      minMonth =
+        minYear < this.props.year
+          ? 0
+          : minYear === this.props.year
+            ? utils.getMonth(this.props.minDate)
+            : 12;
+    }
+
+    if (this.props.maxDate) {
+      const maxYear = this.props.maxDate
+        ? utils.getYear(this.props.maxDate)
+        : 2100;
+      maxMonth =
+        maxYear > this.props.year
+          ? 11
+          : maxYear === this.props.year
+            ? utils.getMonth(this.props.maxDate)
+            : -1;
+    }
+
+    const options = [];
+    for (let i = minMonth; i <= maxMonth; i++) {
+      options.push(
+        <option key={i} value={i}>
+          {monthNames[i]}
+        </option>
+      );
+    }
+    return options;
+  };
 
   renderSelectMode = monthNames => (
     <select
@@ -55,7 +90,10 @@ export default class MonthDropdown extends React.Component {
     <WrappedMonthDropdownOptions
       key="dropdown"
       ref="options"
+      minDate={this.props.minDate}
+      maxDate={this.props.maxDate}
       month={this.props.month}
+      year={this.props.year}
       monthNames={monthNames}
       onChange={this.onChange}
       onCancel={this.toggleDropdown}

--- a/src/month_dropdown_options.jsx
+++ b/src/month_dropdown_options.jsx
@@ -1,24 +1,64 @@
 import React from "react";
 import PropTypes from "prop-types";
 
+function generateMonths(year, minDate, maxDate) {
+  var list = [];
+  for (var i = 0; i < 12; i++) {
+    let isInRange = true;
+
+    if (minDate) {
+      isInRange =
+        minDate.year() < year ||
+        (minDate.year() === year && minDate.month() <= i);
+    }
+
+    if (maxDate && isInRange) {
+      isInRange =
+        maxDate.year() > year ||
+        (maxDate.year() === year && maxDate.month() >= i);
+    }
+
+    if (isInRange) {
+      list.push(i);
+    }
+  }
+
+  return list;
+}
+
 export default class MonthDropdownOptions extends React.Component {
   static propTypes = {
+    minDate: PropTypes.object,
+    maxDate: PropTypes.object,
     onCancel: PropTypes.func.isRequired,
     onChange: PropTypes.func.isRequired,
+    year: PropTypes.number.isRequired,
     month: PropTypes.number.isRequired,
     monthNames: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired
   };
 
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      monthsList: generateMonths(
+        this.props.year,
+        this.props.minDate,
+        this.props.maxDate
+      )
+    };
+  }
+
   renderOptions = () => {
-    return this.props.monthNames.map((month, i) => (
+    return this.state.monthsList.map(i => (
       <div
         className={
           this.props.month === i
             ? "react-datepicker__month-option --selected_month"
             : "react-datepicker__month-option"
         }
-        key={month}
-        ref={month}
+        key={i}
+        ref={i}
         onClick={this.onChange.bind(this, i)}
       >
         {this.props.month === i ? (
@@ -26,7 +66,7 @@ export default class MonthDropdownOptions extends React.Component {
         ) : (
           ""
         )}
-        {month}
+        {this.props.monthNames[i]}
       </div>
     ));
   };

--- a/test/month_dropdown_test.js
+++ b/test/month_dropdown_test.js
@@ -23,6 +23,7 @@ describe("MonthDropdown", () => {
       <MonthDropdown
         dropdownMode="scroll"
         month={11}
+        year={2018}
         dateFormat={dateFormatCalendar}
         onChange={mockHandleChange}
         {...overrideProps}
@@ -77,6 +78,7 @@ describe("MonthDropdown", () => {
           onCancel={onCancelSpy}
           onChange={sandbox.spy()}
           month={11}
+          year={2018}
           monthNames={monthNames}
         />
       ).instance();


### PR DESCRIPTION
This PR:
- limits month list in select mode
- limits month list in scroll mode
- auto-changes month (by minDate and maxDate) when we change year
- updates tests for changed components

Issue: https://github.com/Hacker0x01/react-datepicker/issues/759