### PR TITLE
fixed calendar withPortal closing

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -274,7 +274,7 @@ export default class DatePicker extends React.Component {
   };
 
   handleBlur = event => {
-    if (this.state.open) {
+    if (this.state.open && !this.props.withPortal) {
       this.deferFocusInput();
     } else {
       this.props.onBlur(event);


### PR DESCRIPTION
Calendar in withPortal mode doesn't close on mobile devices when timeSelect added.
