### PR TITLE
Fixed test which fails when today is at the start of the month

### DIFF
--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -252,10 +252,10 @@ describe("DatePicker", () => {
     TestUtils.Simulate.keyDown(data.nodeInput, getKey("ArrowLeft"));
     TestUtils.Simulate.keyDown(data.nodeInput, getKey("ArrowLeft"));
 
-    var day = TestUtils.findRenderedDOMComponentWithClass(
+    var day = TestUtils.scryRenderedDOMComponentsWithClass(
       data.datePicker.calendar,
       "react-datepicker__day--today"
-    );
+    )[0];
     TestUtils.Simulate.click(ReactDOM.findDOMNode(day));
 
     TestUtils.Simulate.keyDown(data.nodeInput, getKey("ArrowDown"));


### PR DESCRIPTION
The test 'should update the preSelection state when a day is selected with mouse click' was failing because today is at the start of the month. Hence today is rendered multiple times and findRenderedDOMComponentWithClass was throwing an error.

By switching to scryRenderedDOMComponentsWithClass and taking the first element the test passes when multiple months are rendered.