### PR TITLE
Only open the calendar for ArrowUp and ArrowDown

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -415,13 +415,7 @@ export default class DatePicker extends React.Component {
       !this.props.inline &&
       !this.props.preventOpenOnFocus
     ) {
-      if (
-        eventKey !== "Enter" &&
-        eventKey !== "Escape" &&
-        eventKey !== "Tab" &&
-        eventKey !== "ArrowLeft" &&
-        eventKey !== "ArrowRight"
-      ) {
+      if (eventKey === "ArrowDown" || eventKey === "ArrowUp") {
         this.onInputClick();
       }
       return;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -415,7 +415,13 @@ export default class DatePicker extends React.Component {
       !this.props.inline &&
       !this.props.preventOpenOnFocus
     ) {
-      if (eventKey !== "Enter" && eventKey !== "Escape" && eventKey !== "Tab") {
+      if (
+        eventKey !== "Enter" &&
+        eventKey !== "Escape" &&
+        eventKey !== "Tab" &&
+        eventKey !== "ArrowLeft" &&
+        eventKey !== "ArrowRight"
+      ) {
         this.onInputClick();
       }
       return;

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -631,12 +631,19 @@ describe("DatePicker", () => {
       utils.formatDate(data.datePicker.state.preSelection, data.testFormat)
     ).to.equal(utils.formatDate(data.copyM, data.testFormat));
   });
-  it("should open the calendar when an arrow key is pressed", () => {
+  it("should open the calendar when the down arrow key is pressed", () => {
+    var data = getOnInputKeyDownStuff();
+    data.datePicker.setOpen(false);
+    expect(data.datePicker.state.open).to.be.false;
+    TestUtils.Simulate.keyDown(data.nodeInput, getKey("ArrowDown"));
+    expect(data.datePicker.state.open).to.be.true;
+  });
+  it("should not open the calendar when the left arrow key is pressed", () => {
     var data = getOnInputKeyDownStuff();
     data.datePicker.setOpen(false);
     expect(data.datePicker.state.open).to.be.false;
     TestUtils.Simulate.keyDown(data.nodeInput, getKey("ArrowLeft"));
-    expect(data.datePicker.state.open).to.be.true;
+    expect(data.datePicker.state.open).to.be.false;
   });
   it("should default to the current day on Enter", () => {
     const data = getOnInputKeyDownStuff({ selected: null });


### PR DESCRIPTION
Some users prefer editing dates without using the calendar. However, whenever you press a key, the calendar automatically pops up. Even worse, left and right arrows are double booked: they navigate the cursor in the input control but also move to another day in the calendar.

This PR changes the behavior such that the calendar is only opened if you press the up or down arrow and not for all keys except tab, escape and Enter. That way, you can close the calendar with Escape and edit the date in place and the calendar you just closed doesn't suddenly pop up again with each key press.
