### PR TITLE
Move '}' for js code markdown.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ You can use `onSelect` event handler which fires each time some calendar date ha
 
 ```js
 <DatePicker selected={this.state.date}
-  onSelect={this.handleSelect //when day is clicked}
-  onChange={this.handleChange //only when value has changed}
+  onSelect={this.handleSelect} //when day is clicked
+  onChange={this.handleChange} //only when value has changed
 />
 ```
 


### PR DESCRIPTION
 It's fine, but I want to fix it.

before the change:
```js
 <DatePicker selected={this.state.date}
  onSelect={this.handleSelect //when day is clicked}
  onChange={this.handleChange //only when value has changed}
 />
```

after the change:
```js
 <DatePicker selected={this.state.date}
  onSelect={this.handleSelect} //when day is clicked
  onChange={this.handleChange} //only when value has changed
 />
```