### PR TITLE
Race condition on time selection fixed

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -420,7 +420,9 @@ export default class DatePicker extends React.Component {
     });
 
     this.props.onChange(changedDate);
-    this.setOpen(false);
+    setTimeout(() => {
+      this.setOpen(false);
+    }, 60);
     this.setState({ inputValue: null });
   };
 


### PR DESCRIPTION
There was a race condition on time selection: `handleTimeChange` and `handleFocus` set `open` variable in the opposite way. If `handleFocus` ran last, calendar sometimes stayed opened.

### Before

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/18036578/42989660-ea2baa84-8bd6-11e8-9bb3-0a649a60a63f.gif)

### Now

![ezgif com-video-to-gif 1](https://user-images.githubusercontent.com/18036578/42989870-61b2bd68-8bd7-11e8-883c-a778480e094b.gif)

As we can not manage events order excecution, I add an imperceptible `timeout` in `handleTimeChange` to ensure that It sets `open` variable last.
