### PR TITLE
Selected time scrolltop fix (#1396)

### DIFF
--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -235,6 +235,7 @@
         box-sizing: content-box;
 
         li.react-datepicker__time-list-item {
+          height: 30px;
           padding: 5px 10px;
           &:hover {
             cursor: pointer;


### PR DESCRIPTION
The scroll top of a list of times is calculated assuming a height of 30px for each list item in` time.jsx`:

`this.list.scrollTop = 30 * (multiplier * currH);`
 
However, the actual height of the time-list-item is 31px, so the scroll top is often inaccurate.

This change ensures the selected time-list-item will be scrolled into view.

fixes #1396