### PR TITLE
Fix duplicated defaultProps in Calendar

### DIFF
--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -121,7 +121,7 @@ export default class Calendar extends React.Component {
       forceShowMonthNavigation: false,
       timeCaption: "Time",
       previousMonthButtonLabel: "Previous Month",
-      previousMonthButtonLabel: "Next Month"
+      nextMonthButtonLabel: "Next Month"
     };
   }
 


### PR DESCRIPTION
I found out a duplicated default prop. There are two `previousMonthButtonLabel` definitions in `Calendar` component. This PR will fix one of the default props into `nextMonthButtonLabel`.