### PR TITLE
add props.popperReactPortal

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -124,6 +124,7 @@ export default class DatePicker extends React.Component {
     popperModifiers: PropTypes.object, // <PopperComponent/> props
     popperPlacement: PropTypes.oneOf(popperPlacementPositions), // <PopperComponent/> props
     popperProps: PropTypes.object,
+    popperReactPortal: PropTypes.bool,
     preventOpenOnFocus: PropTypes.bool,
     readOnly: PropTypes.bool,
     required: PropTypes.bool,
@@ -742,6 +743,7 @@ export default class DatePicker extends React.Component {
         className={this.props.popperClassName}
         hidePopper={!this.isCalendarOpen()}
         popperModifiers={this.props.popperModifiers}
+        popperReactPortal={this.props.popperReactPortal}
         targetComponent={
           <div className="react-datepicker__input-container">
             {this.renderDateInput()}

--- a/src/popper_component.jsx
+++ b/src/popper_component.jsx
@@ -1,5 +1,6 @@
 import classnames from "classnames";
 import React from "react";
+import ReactDOM from "react-dom";
 import PropTypes from "prop-types";
 import { Manager, Reference, Popper } from "react-popper";
 
@@ -24,6 +25,7 @@ export default class PopperComponent extends React.Component {
     hidePopper: PropTypes.bool,
     popperComponent: PropTypes.element,
     popperModifiers: PropTypes.object, // <datepicker/> props
+    popperReactPortal: PropTypes.bool,
     popperPlacement: PropTypes.oneOf(popperPlacementPositions), // <datepicker/> props
     popperContainer: PropTypes.func,
     popperProps: PropTypes.object,
@@ -81,6 +83,10 @@ export default class PopperComponent extends React.Component {
 
     if (this.props.popperContainer) {
       popper = React.createElement(this.props.popperContainer, {}, popper);
+    }
+    
+    if (this.props.popperReactPortal) {
+      popper = ReactDOM.createPortal(popper, window.document.body);
     }
 
     return (

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -506,6 +506,19 @@ describe("DatePicker", () => {
       nodeInput
     };
   }
+
+  it("should use React portal when popperReactPortal prop is set", () => {
+    var datePicker = TestUtils.renderIntoDocument(
+      <DatePicker popperReactPortal />
+    );
+    expect(function() {
+      TestUtils.findRenderedDOMComponentWithClass(
+        datePicker,
+        "body > react-datepicker__portal"
+      );
+    }).to.not.throw();
+  });
+
   it("should handle onInputKeyDown ArrowLeft", () => {
     var data = getOnInputKeyDownStuff();
     TestUtils.Simulate.keyDown(data.nodeInput, getKey("ArrowLeft"));

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -507,16 +507,18 @@ describe("DatePicker", () => {
     };
   }
 
-  it("should use React portal when popperReactPortal prop is set", () => {
-    var datePicker = TestUtils.renderIntoDocument(
-      <DatePicker popperReactPortal />
-    );
-    expect(function() {
-      TestUtils.findRenderedDOMComponentWithClass(
-        datePicker,
-        "body > react-datepicker__portal"
-      );
-    }).to.not.throw();
+  it.only("should use React portal when popperReactPortal prop is set", () => {
+    var div = document.createElement("div");
+    div.classList.add("pseudo-parent");
+    document.body.appendChild(div);
+    var datePicker = ReactDOM.render(<DatePicker popperReactPortal />, div);
+    console.log("find", ReactDOM.findDOMNode(datePicker));
+    console.log("parentNode", ReactDOM.findDOMNode(datePicker).parentNode);
+    console.log("children", div.children);
+
+    expect(ReactDOM.findDOMNode(datePicker).parentNode === document.body).to.be
+      .true;
+    expect(div.hasChildNodes(ReactDOM.findDOMNode(datePicker))).to.be.false;
   });
 
   it("should handle onInputKeyDown ArrowLeft", () => {


### PR DESCRIPTION
ReactDOM.createPortal allows avoid css `overflow: hidden` issues (popper's root will be appended to document.body). 

react-popper can work in the portal with no extra changes

**(not minimal) usage example**:<br/>
**my use-case**: DatePicker in the DropDown's Item with overflow: hidden on them

```jsx
    <DatePicker popperReactPortal // Enable ReactPortal
      popperClassName={ classes.datepickerPopper } // z-index
      customInput={ <Input/> }
      isAfter
      onChange={ @createDateChangeHandler(dropdownItem) }
      dateFormat="YYYY-MM-DD"
      placeholderText="LET'S TO..."
    />
```
