### PR TITLE
Change todayButton to PropTypes.node.

### DIFF
--- a/docs/datepicker.md
+++ b/docs/datepicker.md
@@ -74,7 +74,7 @@ General datepicker component.
 | `timeFormat`                 | `string`                       |                 |                                            |
 | `timeIntervals`              | `number`                       | `30`            |                                            |
 | `title`                      | `string`                       |                 |                                            |
-| `todayButton`                | `string`                       |                 |                                            |
+| `todayButton`                | `node`                         |                 |                                            |
 | `useWeekdaysShort`           | `bool`                         |                 |                                            |
 | `utcOffset`                  | `number`                       |                 |                                            |
 | `value`                      | `string`                       |                 |                                            |

--- a/docs/index.md
+++ b/docs/index.md
@@ -85,7 +85,7 @@ General datepicker component.
 | `timeFormat`                  | `string`                       |                    |             |
 | `timeIntervals`               | `number`                       | `30`               |             |
 | `title`                       | `string`                       |                    |             |
-| `todayButton`                 | `string`                       |                    |             |
+| `todayButton`                 | `node`                         |                    |             |
 | `useShortMonthInDropdown`     | `bool`                         |                    |             |
 | `useWeekdaysShort`            | `bool`                         |                    |             |
 | `utcOffset`                   | `number`                       |                    |             |

--- a/docs/time.md
+++ b/docs/time.md
@@ -14,4 +14,4 @@
 | `onTimeChange` |          | `() => {}`    |             |
 | `selected`     | `object` |               |             |
 | `timeCaption`  | `string` | `"Time"`      |             |
-| `todayButton`  | `string` | `null`        |             |
+| `todayButton`  | `node`   | `null`        |             |

--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -101,7 +101,7 @@ export default class Calendar extends React.Component {
     showWeekNumbers: PropTypes.bool,
     showYearDropdown: PropTypes.bool,
     startDate: PropTypes.object,
-    todayButton: PropTypes.string,
+    todayButton: PropTypes.node,
     useWeekdaysShort: PropTypes.bool,
     formatWeekDay: PropTypes.func,
     withPortal: PropTypes.bool,

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -137,7 +137,7 @@ export default class DatePicker extends React.Component {
     tabIndex: PropTypes.number,
     timeCaption: PropTypes.string,
     title: PropTypes.string,
-    todayButton: PropTypes.string,
+    todayButton: PropTypes.node,
     useWeekdaysShort: PropTypes.bool,
     formatWeekDay: PropTypes.func,
     utcOffset: PropTypes.number,

--- a/src/time.jsx
+++ b/src/time.jsx
@@ -20,7 +20,7 @@ export default class Time extends React.Component {
     intervals: PropTypes.number,
     selected: PropTypes.object,
     onChange: PropTypes.func,
-    todayButton: PropTypes.string,
+    todayButton: PropTypes.node,
     minTime: PropTypes.object,
     maxTime: PropTypes.object,
     excludeTimes: PropTypes.array,


### PR DESCRIPTION
```
type ReactNode = ReactChild | ReactFragment | ReactPortal | string | number | boolean | null | undefined;
```
PropTypes.node is more appropriate for this prop.

related change to DefinitelyTyped: https://github.com/skvale/DefinitelyTyped/commit/894260b8e7fd107c7f372f4623ff4c962c1229c8