### PR TITLE
Fix the spacing on the time picker

### DIFF
--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -230,7 +230,8 @@
         margin: 0;
         height: calc(195px + (#{$datepicker__item-size} / 2));
         overflow-y: scroll;
-        padding-right: 30px;
+        padding-right: 0px;
+        padding-left: 0px;
         width: 100%;
         box-sizing: content-box;
 


### PR DESCRIPTION
An extra 70px of padding is turning up on the time picker in the latest versions of Firefox, Chrome and Safari, this is forcing hte time select to be clipped and not displayed properly. This is related to issue #1489 https://github.com/Hacker0x01/react-datepicker/issues/1489