### PR TITLE
Allow utcOffset to be specified as a string

### DIFF
--- a/docs-site/bundle.js
+++ b/docs-site/bundle.js
@@ -35899,7 +35899,10 @@
         todayButton: _propTypes2.default.string,
         useWeekdaysShort: _propTypes2.default.bool,
         formatWeekDay: _propTypes2.default.func,
-        utcOffset: _propTypes2.default.number,
+        utcOffset: _propTypes2.default.oneOfType([
+          _propTypes2.default.number,
+          _propTypes2.default.string
+        ]),
         value: _propTypes2.default.string,
         weekLabel: _propTypes2.default.string,
         withPortal: _propTypes2.default.bool,
@@ -35929,6 +35932,21 @@
       "use strict";
 
       exports.__esModule = true;
+
+      var _extends =
+        Object.assign ||
+        function(target) {
+          for (var i = 1; i < arguments.length; i++) {
+            var source = arguments[i];
+            for (var key in source) {
+              if (Object.prototype.hasOwnProperty.call(source, key)) {
+                target[key] = source[key];
+              }
+            }
+          }
+          return target;
+        };
+
       exports.default = CalendarContainer;
 
       var _propTypes = __webpack_require__(525);
@@ -35945,21 +35963,25 @@
 
       function CalendarContainer(_ref) {
         var className = _ref.className,
-          children = _ref.children;
+          children = _ref.children,
+          _ref$arrowProps = _ref.arrowProps,
+          arrowProps = _ref$arrowProps === undefined ? {} : _ref$arrowProps;
 
         return _react2.default.createElement(
           "div",
           { className: className },
-          _react2.default.createElement("div", {
-            className: "react-datepicker__triangle"
-          }),
+          _react2.default.createElement(
+            "div",
+            _extends({ className: "react-datepicker__triangle" }, arrowProps)
+          ),
           children
         );
       }
 
       CalendarContainer.propTypes = {
         className: _propTypes2.default.string,
-        children: _propTypes2.default.node
+        children: _propTypes2.default.node,
+        arrowProps: _propTypes2.default.object // react-popper arrow props
       };
 
       /***/
@@ -36838,7 +36860,10 @@
         useWeekdaysShort: _propTypes2.default.bool,
         formatWeekDay: _propTypes2.default.func,
         withPortal: _propTypes2.default.bool,
-        utcOffset: _propTypes2.default.number,
+        utcOffset: _propTypes2.default.oneOfType([
+          _propTypes2.default.number,
+          _propTypes2.default.string
+        ]),
         weekLabel: _propTypes2.default.string,
         yearDropdownItemNumber: _propTypes2.default.number,
         setOpen: _propTypes2.default.func,
@@ -57827,7 +57852,10 @@
         selectsStart: _propTypes2.default.bool,
         showWeekNumbers: _propTypes2.default.bool,
         startDate: _propTypes2.default.object,
-        utcOffset: _propTypes2.default.number
+        utcOffset: _propTypes2.default.oneOfType([
+          _propTypes2.default.number,
+          _propTypes2.default.string
+        ])
       };
       exports.default = Month;
 
@@ -58049,7 +58077,10 @@
         selectsStart: _propTypes2.default.bool,
         showWeekNumber: _propTypes2.default.bool,
         startDate: _propTypes2.default.object,
-        utcOffset: _propTypes2.default.number
+        utcOffset: _propTypes2.default.oneOfType([
+          _propTypes2.default.number,
+          _propTypes2.default.string
+        ])
       };
       exports.default = Week;
 
@@ -58367,7 +58398,10 @@
         selectsEnd: _propTypes2.default.bool,
         selectsStart: _propTypes2.default.bool,
         startDate: _propTypes2.default.object,
-        utcOffset: _propTypes2.default.number
+        utcOffset: _propTypes2.default.oneOfType([
+          _propTypes2.default.number,
+          _propTypes2.default.string
+        ])
       };
       exports.default = Day;
 
@@ -58802,6 +58836,20 @@
       exports.__esModule = true;
       exports.popperPlacementPositions = undefined;
 
+      var _extends =
+        Object.assign ||
+        function(target) {
+          for (var i = 1; i < arguments.length; i++) {
+            var source = arguments[i];
+            for (var key in source) {
+              if (Object.prototype.hasOwnProperty.call(source, key)) {
+                target[key] = source[key];
+              }
+            }
+          }
+          return target;
+        };
+
       var _createClass = (function() {
         function defineProperties(target, props) {
           for (var i = 0; i < props.length; i++) {
@@ -58876,9 +58924,6 @@
       }
 
       var popperPlacementPositions = (exports.popperPlacementPositions = [
-        "auto",
-        "auto-left",
-        "auto-right",
         "bottom",
         "bottom-end",
         "bottom-start",
@@ -58923,12 +58968,26 @@
             );
             popper = _react2.default.createElement(
               _reactPopper.Popper,
-              {
-                className: classes,
-                modifiers: popperModifiers,
-                placement: popperPlacement
-              },
-              popperComponent
+              { modifiers: popperModifiers, placement: popperPlacement },
+              function(_ref) {
+                var ref = _ref.ref,
+                  style = _ref.style,
+                  placement = _ref.placement,
+                  arrowProps = _ref.arrowProps;
+                return _react2.default.createElement(
+                  "div",
+                  _extends(
+                    { ref: ref, style: style },
+                    {
+                      className: classes,
+                      "data-placement": placement
+                    }
+                  ),
+                  _react2.default.cloneElement(popperComponent, {
+                    arrowProps: arrowProps
+                  })
+                );
+              }
             );
           }
 
@@ -58941,14 +59000,30 @@
           }
 
           return _react2.default.createElement(
-            _reactPopper.Manager,
+            "div",
             null,
             _react2.default.createElement(
-              _reactPopper.Target,
-              { className: "react-datepicker-wrapper" },
-              targetComponent
-            ),
-            popper
+              _reactPopper.Manager,
+              null,
+              _react2.default.createElement(
+                _reactPopper.Reference,
+                null,
+                function(_ref2) {
+                  var ref = _ref2.ref,
+                    style = _ref2.style;
+                  return _react2.default.createElement(
+                    "div",
+                    {
+                      ref: ref,
+                      style: style,
+                      className: "react-datepicker-wrapper"
+                    },
+                    targetComponent
+                  );
+                }
+              ),
+              popper
+            )
           );
         };
 

--- a/docs/datepicker.md
+++ b/docs/datepicker.md
@@ -76,7 +76,7 @@ General datepicker component.
 | `title`                      | `string`                       |                 |                                            |
 | `todayButton`                | `string`                       |                 |                                            |
 | `useWeekdaysShort`           | `bool`                         |                 |                                            |
-| `utcOffset`                  | `number`                       |                 |                                            |
+| `utcOffset`                  | `union(number\|string)`        |                 |                                            |
 | `value`                      | `string`                       |                 |                                            |
 | `weekLabel`                  | `string`                       |                 |                                            |
 | `withPortal`                 | `bool`                         | `false`         |                                            |

--- a/docs/index.md
+++ b/docs/index.md
@@ -88,7 +88,7 @@ General datepicker component.
 | `todayButton`                 | `string`                       |                    |             |
 | `useShortMonthInDropdown`     | `bool`                         |                    |             |
 | `useWeekdaysShort`            | `bool`                         |                    |             |
-| `utcOffset`                   | `number`                       |                    |             |
+| `utcOffset`                   | `union(number\|string)`        |                    |             |
 | `value`                       | `string`                       |                    |             |
 | `weekLabel`                   | `string`                       |                    |             |
 | `withPortal`                  | `bool`                         | `false`            |             |

--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -105,7 +105,7 @@ export default class Calendar extends React.Component {
     useWeekdaysShort: PropTypes.bool,
     formatWeekDay: PropTypes.func,
     withPortal: PropTypes.bool,
-    utcOffset: PropTypes.number,
+    utcOffset: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     weekLabel: PropTypes.string,
     yearDropdownItemNumber: PropTypes.number,
     setOpen: PropTypes.func,

--- a/src/day.jsx
+++ b/src/day.jsx
@@ -29,7 +29,7 @@ export default class Day extends React.Component {
     selectsEnd: PropTypes.bool,
     selectsStart: PropTypes.bool,
     startDate: PropTypes.object,
-    utcOffset: PropTypes.number
+    utcOffset: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
   };
 
   handleClick = event => {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -140,7 +140,7 @@ export default class DatePicker extends React.Component {
     todayButton: PropTypes.string,
     useWeekdaysShort: PropTypes.bool,
     formatWeekDay: PropTypes.func,
-    utcOffset: PropTypes.number,
+    utcOffset: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     value: PropTypes.string,
     weekLabel: PropTypes.string,
     withPortal: PropTypes.bool,

--- a/src/month.jsx
+++ b/src/month.jsx
@@ -33,7 +33,7 @@ export default class Month extends React.Component {
     selectsStart: PropTypes.bool,
     showWeekNumbers: PropTypes.bool,
     startDate: PropTypes.object,
-    utcOffset: PropTypes.number
+    utcOffset: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
   };
 
   handleDayClick = (day, event) => {

--- a/src/week.jsx
+++ b/src/week.jsx
@@ -29,7 +29,7 @@ export default class Week extends React.Component {
     selectsStart: PropTypes.bool,
     showWeekNumber: PropTypes.bool,
     startDate: PropTypes.object,
-    utcOffset: PropTypes.number
+    utcOffset: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
   };
 
   handleDayClick = (day, event) => {

--- a/test/calendar_test.js
+++ b/test/calendar_test.js
@@ -38,8 +38,15 @@ describe("Calendar", function() {
   });
 
   it("should start with the today date with specified time zone", function() {
-    const utcOffset = 12;
-    const calendar = getCalendar({ utcOffset });
+    let utcOffset = 12;
+    let calendar = getCalendar({ utcOffset });
+    assert(
+      utils.isSameDay(calendar.state().date, utils.newDateWithOffset(utcOffset))
+    );
+
+    // using string offsets
+    utcOffset = "+12:00";
+    calendar = getCalendar({ utcOffset });
     assert(
       utils.isSameDay(calendar.state().date, utils.newDateWithOffset(utcOffset))
     );

--- a/test/date_utils_test.js
+++ b/test/date_utils_test.js
@@ -109,6 +109,12 @@ describe("date_utils", function() {
           setUTCOffset(newDate("2016-02-10"), -210)
         )
       ).to.be.false;
+      expect(
+        isSameUtcOffset(
+          setUTCOffset(newDate("2016-02-10"), "-05:45"),
+          setUTCOffset(newDate("2016-02-10"), "+01:00")
+        )
+      ).to.be.false;
     });
 
     it("should return true for equal utc offsets, regardless of dates", function() {
@@ -124,6 +130,18 @@ describe("date_utils", function() {
         isSameUtcOffset(
           setUTCOffset(newDate("2016-12-10"), 6),
           setUTCOffset(newDate("2016-02-15"), 6)
+        )
+      ).to.be.true;
+      expect(
+        isSameUtcOffset(
+          setUTCOffset(newDate("2016-12-10"), "+04:00"),
+          setUTCOffset(newDate("2016-02-15"), "+04:00")
+        )
+      ).to.be.true;
+      expect(
+        isSameUtcOffset(
+          setUTCOffset(newDate("2016-12-10"), "-02:00"),
+          setUTCOffset(newDate("2016-02-15"), "-0200")
         )
       ).to.be.true;
     });

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -799,6 +799,22 @@ describe("DatePicker", () => {
     expect(tmzDatePicker.find("input").prop("value")).to.equal(
       "2016-11-22 06:00"
     );
+
+    // using string offsets
+    tmzDatePicker.setState({ startDate: date, utcOffset: "-06:00" });
+
+    expect(tmzDatePicker.find("input").prop("value")).to.equal(
+      "2016-11-21 18:00"
+    );
+
+    tmzDatePicker.setState({
+      utcOffset: "+06:00",
+      startDate: utils.setUTCOffset(utils.cloneDate(date), 6)
+    });
+
+    expect(tmzDatePicker.find("input").prop("value")).to.equal(
+      "2016-11-22 06:00"
+    );
   });
   it("should correctly update the input when the value prop changes", () => {
     const datePicker = mount(<DatePicker />);


### PR DESCRIPTION
Moment, which ultimately consumes the offsets, accepts either numbers or strings. So I updated the relevant prop types and added a few tests with offsets specified as strings.