### PR TITLE
More convenient examples navigation

### DIFF
--- a/docs-site/src/examples.scss
+++ b/docs-site/src/examples.scss
@@ -15,6 +15,15 @@
   }
 }
 
+@supports (position: sticky) {
+  .examples__navigation {
+    overflow-y: scroll;
+    max-height: 100vh;
+    position: sticky;
+    top: 0;
+  }
+}
+
 .examples__navigation-item {
   border-bottom: 1px solid #e4e4e4;
 


### PR DESCRIPTION
Using `position: sticky` if supported for more always visible navbar