### PR TITLE
Set the height of the list explicitly

### DIFF
--- a/src/time.jsx
+++ b/src/time.jsx
@@ -45,6 +45,9 @@ export default class Time extends React.Component {
   };
 
   componentDidMount() {
+    // Set the height explicitly
+    this.list.style.height = this.props.monthRef.clientHeight - this.header.clientHeight;
+    
     // code to ensure selected time will always be in focus within time window when it first appears
     this.list.scrollTop = Time.calcCenterPosition(
       this.props.monthRef


### PR DESCRIPTION
The height currently doesn't take up the entire available space until the user hovers on the component. This fixes it.