### PR TITLE
Allow option in timepicker to default to minTime

### DIFF
--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -81,6 +81,7 @@ export default class Calendar extends React.Component {
     onWeekSelect: PropTypes.func,
     showTimeSelect: PropTypes.bool,
     showTimeSelectOnly: PropTypes.bool,
+    defaultToMinTime: PropTypes.bool,
     timeFormat: PropTypes.string,
     timeIntervals: PropTypes.number,
     onTimeChange: PropTypes.func,
@@ -634,6 +635,7 @@ export default class Calendar extends React.Component {
           intervals={this.props.timeIntervals}
           minTime={this.props.minTime}
           maxTime={this.props.maxTime}
+          defaultToMinTime={this.props.defaultToMinTime}
           excludeTimes={this.props.excludeTimes}
           timeCaption={this.props.timeCaption}
           todayButton={this.props.todayButton}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -158,6 +158,7 @@ export default class DatePicker extends React.Component {
     timeIntervals: PropTypes.number,
     minTime: PropTypes.object,
     maxTime: PropTypes.object,
+    defaultToMinTime: PropTypes.bool,
     excludeTimes: PropTypes.array,
     useShortMonthInDropdown: PropTypes.bool,
     clearButtonTitle: PropTypes.string,
@@ -234,10 +235,10 @@ export default class DatePicker extends React.Component {
     this.props.openToDate
       ? newDate(this.props.openToDate)
       : this.props.selectsEnd && this.props.startDate
-        ? newDate(this.props.startDate)
-        : this.props.selectsStart && this.props.endDate
-          ? newDate(this.props.endDate)
-          : now(this.props.utcOffset);
+      ? newDate(this.props.startDate)
+      : this.props.selectsStart && this.props.endDate
+      ? newDate(this.props.endDate)
+      : now(this.props.utcOffset);
 
   calcInitialState = () => {
     const defaultPreSelection = this.getPreSelection();
@@ -247,8 +248,8 @@ export default class DatePicker extends React.Component {
       minDate && isBefore(defaultPreSelection, minDate)
         ? minDate
         : maxDate && isAfter(defaultPreSelection, maxDate)
-          ? maxDate
-          : defaultPreSelection;
+        ? maxDate
+        : defaultPreSelection;
     return {
       open: this.props.startOpen || false,
       preventFocus: false,
@@ -643,6 +644,7 @@ export default class DatePicker extends React.Component {
         timeIntervals={this.props.timeIntervals}
         minTime={this.props.minTime}
         maxTime={this.props.maxTime}
+        defaultToMinTime={this.props.defaultToMinTime}
         excludeTimes={this.props.excludeTimes}
         timeCaption={this.props.timeCaption}
         className={this.props.calendarClassName}
@@ -671,8 +673,8 @@ export default class DatePicker extends React.Component {
       typeof this.props.value === "string"
         ? this.props.value
         : typeof this.state.inputValue === "string"
-          ? this.state.inputValue
-          : safeDateFormat(this.props.selected, this.props);
+        ? this.state.inputValue
+        : safeDateFormat(this.props.selected, this.props);
 
     return React.cloneElement(customInput, {
       [customInputRef]: input => {

--- a/src/time.jsx
+++ b/src/time.jsx
@@ -26,7 +26,8 @@ export default class Time extends React.Component {
     excludeTimes: PropTypes.array,
     monthRef: PropTypes.object,
     timeCaption: PropTypes.string,
-    injectTimes: PropTypes.array
+    injectTimes: PropTypes.array,
+    defaultToMinTime: PropTypes.bool
   };
 
   static get defaultProps() {
@@ -99,7 +100,11 @@ export default class Time extends React.Component {
     let times = [];
     const format = this.props.format ? this.props.format : "hh:mm A";
     const intervals = this.props.intervals;
-    const activeTime = this.props.selected ? this.props.selected : newDate();
+    const defaultTime =
+      this.props.defaultToMinTime && this.props.minTime
+        ? this.props.minTime
+        : newDate();
+    const activeTime = this.props.selected ? this.props.selected : defaultTime;
     const currH = getHour(activeTime);
     const currM = getMinute(activeTime);
     let base = getStartOfDay(newDate());

--- a/test/timepicker_test.js
+++ b/test/timepicker_test.js
@@ -51,6 +51,29 @@ describe("TimePicker", () => {
     expect(datePicker.state.open).to.be.true;
   });
 
+  it("should default to the minimum time if minTime and defaultToMinTime are supplied", () => {
+    var datePicker = TestUtils.renderIntoDocument(
+      <DatePicker
+        showTimeSelect
+        minTime={moment("February 28, 2018 7:00 AM", "LLL", true)}
+        maxTime={moment("February 28, 2018 6:00 PM", "LLL", true)}
+        defaultToMinTime
+      />
+    );
+
+    var dateInput = datePicker.input;
+    TestUtils.Simulate.focus(ReactDOM.findDOMNode(dateInput));
+
+    const time = TestUtils.findRenderedComponentWithType(datePicker, Time);
+    const listElems = time.list.querySelectorAll(
+      ".react-datepicker__time-list-item:not(.react-datepicker__time-list-item--disabled)"
+    );
+
+    expect(Array.from(listElems[0].classList)).to.include(
+      "react-datepicker__time-list-item--selected"
+    );
+  });
+
   function setManually(string) {
     TestUtils.Simulate.focus(datePicker.input);
     TestUtils.Simulate.change(datePicker.input, { target: { value: string } });


### PR DESCRIPTION
Currently the timepicker will scroll the list to the current time when it is first opened. This change allows you to supply an option (`defaultToMinTime`) that alters this behavior, instead using the value of the `minTime` prop to select a list item to scroll in view.