### PR TITLE
For timepicker - allow defaulting the popup to the min time

### DIFF
--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -78,6 +78,7 @@ export default class Calendar extends React.Component {
     onWeekSelect: PropTypes.func,
     showTimeSelect: PropTypes.bool,
     showTimeSelectOnly: PropTypes.bool,
+    defaultToMinTime: PropTypes.bool,
     timeFormat: PropTypes.string,
     timeIntervals: PropTypes.number,
     onTimeChange: PropTypes.func,
@@ -613,6 +614,7 @@ export default class Calendar extends React.Component {
           intervals={this.props.timeIntervals}
           minTime={this.props.minTime}
           maxTime={this.props.maxTime}
+          defaultToMinTime={this.props.defaultToMinTime}
           excludeTimes={this.props.excludeTimes}
           timeCaption={this.props.timeCaption}
           todayButton={this.props.todayButton}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import Calendar from './calendar';
-import PopperComponent, { popperPlacementPositions } from './popper_component';
-import classnames from 'classnames';
+import React from "react";
+import PropTypes from "prop-types";
+import Calendar from "./calendar";
+import PopperComponent, { popperPlacementPositions } from "./popper_component";
+import classnames from "classnames";
 import {
   newDate,
   isDate,
@@ -35,14 +35,14 @@ import {
   registerLocale,
   setDefaultLocale,
   getDefaultLocale
-} from './date_utils';
-import onClickOutside from 'react-onclickoutside';
+} from "./date_utils";
+import onClickOutside from "react-onclickoutside";
 
-export { default as CalendarContainer } from './calendar_container';
+export { default as CalendarContainer } from "./calendar_container";
 
 export { registerLocale, setDefaultLocale, getDefaultLocale };
 
-const outsideClickIgnoreClass = 'react-datepicker-ignore-onclickoutside';
+const outsideClickIgnoreClass = "react-datepicker-ignore-onclickoutside";
 const WrappedCalendar = onClickOutside(Calendar);
 
 // Compares dates year+month combinations
@@ -67,7 +67,7 @@ function hasSelectionChanged(date1, date2) {
 /**
  * General datepicker component.
  */
-const INPUT_ERR_1 = 'Date input not valid.';
+const INPUT_ERR_1 = "Date input not valid.";
 
 export default class DatePicker extends React.Component {
   static propTypes = {
@@ -87,7 +87,7 @@ export default class DatePicker extends React.Component {
     dayClassName: PropTypes.func,
     disabled: PropTypes.bool,
     disabledKeyboardNavigation: PropTypes.bool,
-    dropdownMode: PropTypes.oneOf(['scroll', 'select']).isRequired,
+    dropdownMode: PropTypes.oneOf(["scroll", "select"]).isRequired,
     endDate: PropTypes.instanceOf(Date),
     excludeDates: PropTypes.array,
     filterDate: PropTypes.func,
@@ -159,6 +159,7 @@ export default class DatePicker extends React.Component {
     timeIntervals: PropTypes.number,
     minTime: PropTypes.instanceOf(Date),
     maxTime: PropTypes.instanceOf(Date),
+    defaultToMinTime: PropTypes.bool,
     excludeTimes: PropTypes.array,
     useShortMonthInDropdown: PropTypes.bool,
     clearButtonTitle: PropTypes.string,
@@ -171,12 +172,12 @@ export default class DatePicker extends React.Component {
   static get defaultProps() {
     return {
       allowSameDay: false,
-      dateFormat: 'MM/dd/yyyy',
-      dateFormatCalendar: 'LLLL yyyy',
+      dateFormat: "MM/dd/yyyy",
+      dateFormatCalendar: "LLLL yyyy",
       onChange() {},
       disabled: false,
       disabledKeyboardNavigation: false,
-      dropdownMode: 'scroll',
+      dropdownMode: "scroll",
       onFocus() {},
       onBlur() {},
       onKeyDown() {},
@@ -193,9 +194,9 @@ export default class DatePicker extends React.Component {
       shouldCloseOnSelect: true,
       showTimeSelect: false,
       timeIntervals: 30,
-      timeCaption: 'Time',
-      previousMonthButtonLabel: 'Previous Month',
-      nextMonthButtonLabel: 'Next month',
+      timeCaption: "Time",
+      previousMonthButtonLabel: "Previous Month",
+      nextMonthButtonLabel: "Next month",
       renderDayContents(date) {
         return date;
       }
@@ -235,10 +236,10 @@ export default class DatePicker extends React.Component {
     this.props.openToDate
       ? this.props.openToDate
       : this.props.selectsEnd && this.props.startDate
-        ? this.props.startDate
-        : this.props.selectsStart && this.props.endDate
-          ? this.props.endDate
-          : newDate();
+      ? this.props.startDate
+      : this.props.selectsStart && this.props.endDate
+      ? this.props.endDate
+      : newDate();
 
   calcInitialState = () => {
     const defaultPreSelection = this.getPreSelection();
@@ -248,8 +249,8 @@ export default class DatePicker extends React.Component {
       minDate && isBefore(defaultPreSelection, minDate)
         ? minDate
         : maxDate && isAfter(defaultPreSelection, maxDate)
-          ? maxDate
-          : defaultPreSelection;
+        ? maxDate
+        : defaultPreSelection;
     return {
       open: this.props.startOpen || false,
       preventFocus: false,
@@ -364,7 +365,7 @@ export default class DatePicker extends React.Component {
     if (this.props.onChangeRaw) {
       this.props.onChangeRaw.apply(this, allArgs);
       if (
-        typeof event.isDefaultPrevented !== 'function' ||
+        typeof event.isDefaultPrevented !== "function" ||
         event.isDefaultPrevented()
       ) {
         return;
@@ -446,8 +447,8 @@ export default class DatePicker extends React.Component {
 
   setPreSelection = date => {
     const isDateRangePresent =
-      typeof this.props.minDate !== 'undefined' &&
-      typeof this.props.maxDate !== 'undefined';
+      typeof this.props.minDate !== "undefined" &&
+      typeof this.props.maxDate !== "undefined";
     const isValidDateSelection =
       isDateRangePresent && date
         ? isDayInRange(date, this.props.minDate, this.props.maxDate)
@@ -495,13 +496,13 @@ export default class DatePicker extends React.Component {
       !this.props.inline &&
       !this.props.preventOpenOnFocus
     ) {
-      if (eventKey === 'ArrowDown' || eventKey === 'ArrowUp') {
+      if (eventKey === "ArrowDown" || eventKey === "ArrowUp") {
         this.onInputClick();
       }
       return;
     }
     const copy = newDate(this.state.preSelection);
-    if (eventKey === 'Enter') {
+    if (eventKey === "Enter") {
       event.preventDefault();
       if (
         this.inputOk() &&
@@ -512,40 +513,40 @@ export default class DatePicker extends React.Component {
       } else {
         this.setOpen(false);
       }
-    } else if (eventKey === 'Escape') {
+    } else if (eventKey === "Escape") {
       event.preventDefault();
 
       this.setOpen(false);
       if (!this.inputOk()) {
         this.props.onInputError({ code: 1, msg: INPUT_ERR_1 });
       }
-    } else if (eventKey === 'Tab') {
+    } else if (eventKey === "Tab") {
       this.setOpen(false, true);
     } else if (!this.props.disabledKeyboardNavigation) {
       let newSelection;
       switch (eventKey) {
-        case 'ArrowLeft':
+        case "ArrowLeft":
           newSelection = subDays(copy, 1);
           break;
-        case 'ArrowRight':
+        case "ArrowRight":
           newSelection = addDays(copy, 1);
           break;
-        case 'ArrowUp':
+        case "ArrowUp":
           newSelection = subWeeks(copy, 1);
           break;
-        case 'ArrowDown':
+        case "ArrowDown":
           newSelection = addWeeks(copy, 1);
           break;
-        case 'PageUp':
+        case "PageUp":
           newSelection = subMonths(copy, 1);
           break;
-        case 'PageDown':
+        case "PageDown":
           newSelection = addMonths(copy, 1);
           break;
-        case 'Home':
+        case "Home":
           newSelection = subYears(copy, 1);
           break;
-        case 'End':
+        case "End":
           newSelection = addYears(copy, 1);
           break;
       }
@@ -642,6 +643,7 @@ export default class DatePicker extends React.Component {
         timeIntervals={this.props.timeIntervals}
         minTime={this.props.minTime}
         maxTime={this.props.maxTime}
+        defaultToMinTime={this.props.defaultToMinTime}
         excludeTimes={this.props.excludeTimes}
         timeCaption={this.props.timeCaption}
         className={this.props.calendarClassName}
@@ -665,13 +667,13 @@ export default class DatePicker extends React.Component {
     });
 
     const customInput = this.props.customInput || <input type="text" />;
-    const customInputRef = this.props.customInputRef || 'ref';
+    const customInputRef = this.props.customInputRef || "ref";
     const inputValue =
-      typeof this.props.value === 'string'
+      typeof this.props.value === "string"
         ? this.props.value
-        : typeof this.state.inputValue === 'string'
-          ? this.state.inputValue
-          : safeDateFormat(this.props.selected, this.props);
+        : typeof this.state.inputValue === "string"
+        ? this.state.inputValue
+        : safeDateFormat(this.props.selected, this.props);
 
     return React.cloneElement(customInput, {
       [customInputRef]: input => {
@@ -756,5 +758,5 @@ export default class DatePicker extends React.Component {
   }
 }
 
-const PRESELECT_CHANGE_VIA_INPUT = 'input';
-const PRESELECT_CHANGE_VIA_NAVIGATE = 'navigate';
+const PRESELECT_CHANGE_VIA_INPUT = "input";
+const PRESELECT_CHANGE_VIA_NAVIGATE = "navigate";

--- a/src/time.jsx
+++ b/src/time.jsx
@@ -25,7 +25,8 @@ export default class Time extends React.Component {
     excludeTimes: PropTypes.array,
     monthRef: PropTypes.object,
     timeCaption: PropTypes.string,
-    injectTimes: PropTypes.array
+    injectTimes: PropTypes.array,
+    defaultToMinTime: PropTypes.bool
   };
 
   static get defaultProps() {
@@ -97,7 +98,11 @@ export default class Time extends React.Component {
     let times = [];
     const format = this.props.format ? this.props.format : "p";
     const intervals = this.props.intervals;
-    const activeTime = this.props.selected ? this.props.selected : newDate();
+    const defaultTime =
+      this.props.defaultToMinTime && this.props.minTime
+        ? this.props.minTime
+        : newDate();
+    const activeTime = this.props.selected ? this.props.selected : defaultTime;
     const currH = getHours(activeTime);
     const currM = getMinutes(activeTime);
     let base = getStartOfDay(newDate());

--- a/test/timepicker_test.js
+++ b/test/timepicker_test.js
@@ -54,6 +54,29 @@ describe('TimePicker', () => {
     expect(datePicker.state.open).to.be.true;
   });
 
+  it("should default to the minimum time if minTime and defaultToMinTime are supplied", () => {
+    var datePicker = TestUtils.renderIntoDocument(
+      <DatePicker
+        showTimeSelect
+        minTime={moment("February 28, 2018 7:00 AM", "LLL", true)}
+        maxTime={moment("February 28, 2018 6:00 PM", "LLL", true)}
+        defaultToMinTime
+      />
+    );
+
+    var dateInput = datePicker.input;
+    TestUtils.Simulate.focus(ReactDOM.findDOMNode(dateInput));
+
+    const time = TestUtils.findRenderedComponentWithType(datePicker, Time);
+    const listElems = time.list.querySelectorAll(
+      ".react-datepicker__time-list-item:not(.react-datepicker__time-list-item--disabled)"
+    );
+
+    expect(Array.from(listElems[0].classList)).to.include(
+      "react-datepicker__time-list-item--selected"
+    );
+  });
+
   function setManually(string) {
     TestUtils.Simulate.focus(datePicker.input);
     TestUtils.Simulate.change(datePicker.input, { target: { value: string } });

--- a/test/timepicker_test.js
+++ b/test/timepicker_test.js
@@ -1,55 +1,55 @@
-import React from 'react';
-import DatePicker from '../src/index.jsx';
-import TestUtils from 'react-dom/test-utils';
-import ReactDOM from 'react-dom';
-import Time from '../src/time';
-import { newDate, formatDate } from '../src/date_utils';
+import React from "react";
+import DatePicker from "../src/index.jsx";
+import TestUtils from "react-dom/test-utils";
+import ReactDOM from "react-dom";
+import Time from "../src/time";
+import { newDate, formatDate } from "../src/date_utils";
 
-describe('TimePicker', () => {
+describe("TimePicker", () => {
   let datePicker;
   let div;
   let onChangeMoment;
 
   beforeEach(() => {
-    div = document.createElement('div');
+    div = document.createElement("div");
   });
 
-  it('should update on input time change', () => {
-    renderDatePicker('February 28, 2018 4:43 PM');
-    expect(getInputString()).to.equal('February 28, 2018 4:43 PM');
+  it("should update on input time change", () => {
+    renderDatePicker("February 28, 2018 4:43 PM");
+    expect(getInputString()).to.equal("February 28, 2018 4:43 PM");
 
-    setManually('February 28, 2018 4:45 PM');
-    expect(formatDate(onChangeMoment, 'MMMM d, yyyy p')).to.equal(
-      'February 28, 2018 4:45 PM'
+    setManually("February 28, 2018 4:45 PM");
+    expect(formatDate(onChangeMoment, "MMMM d, yyyy p")).to.equal(
+      "February 28, 2018 4:45 PM"
     );
   });
 
-  it('should allow time changes after input change', () => {
-    renderDatePicker('February 28, 2018 4:43 PM');
-    setManually('February 28, 2018 4:45 PM');
+  it("should allow time changes after input change", () => {
+    renderDatePicker("February 28, 2018 4:43 PM");
+    setManually("February 28, 2018 4:45 PM");
     TestUtils.Simulate.focus(ReactDOM.findDOMNode(datePicker.input));
     const time = TestUtils.findRenderedComponentWithType(datePicker, Time);
-    const lis = TestUtils.scryRenderedDOMComponentsWithTag(time, 'li');
+    const lis = TestUtils.scryRenderedDOMComponentsWithTag(time, "li");
     TestUtils.Simulate.click(lis[1]);
-    expect(getInputString()).to.equal('February 28, 2018 12:30 AM');
+    expect(getInputString()).to.equal("February 28, 2018 12:30 AM");
   });
 
-  it('should allow for injected date if input does not have focus', () => {
-    renderDatePicker('February 28, 2018 4:43 PM');
-    setManually('February 28, 2018 4:45 PM');
+  it("should allow for injected date if input does not have focus", () => {
+    renderDatePicker("February 28, 2018 4:43 PM");
+    setManually("February 28, 2018 4:45 PM");
     TestUtils.Simulate.blur(datePicker.input);
-    renderDatePicker('February 28, 2018 4:43 PM');
-    expect(getInputString()).to.equal('February 28, 2018 4:43 PM');
+    renderDatePicker("February 28, 2018 4:43 PM");
+    expect(getInputString()).to.equal("February 28, 2018 4:43 PM");
   });
 
-  it('should not close datepicker after time clicked when shouldCloseOnSelect is false', () => {
+  it("should not close datepicker after time clicked when shouldCloseOnSelect is false", () => {
     var datePicker = TestUtils.renderIntoDocument(
       <DatePicker shouldCloseOnSelect={false} showTimeSelect />
     );
     var dateInput = datePicker.input;
     TestUtils.Simulate.focus(ReactDOM.findDOMNode(dateInput));
     const time = TestUtils.findRenderedComponentWithType(datePicker, Time);
-    const lis = TestUtils.scryRenderedDOMComponentsWithTag(time, 'li');
+    const lis = TestUtils.scryRenderedDOMComponentsWithTag(time, "li");
     TestUtils.Simulate.click(lis[0]);
     expect(datePicker.state.open).to.be.true;
   });
@@ -58,8 +58,8 @@ describe('TimePicker', () => {
     var datePicker = TestUtils.renderIntoDocument(
       <DatePicker
         showTimeSelect
-        minTime={moment("February 28, 2018 7:00 AM", "LLL", true)}
-        maxTime={moment("February 28, 2018 6:00 PM", "LLL", true)}
+        minTime={new Date("February 28, 2018 7:00 AM")}
+        maxTime={new Date("February 28, 2018 6:00 PM")}
         defaultToMinTime
       />
     );
@@ -94,7 +94,7 @@ describe('TimePicker', () => {
     datePicker = ReactDOM.render(
       <DatePicker
         selected={selected}
-        dateFormat={'MMMM d, yyyy p'}
+        dateFormat={"MMMM d, yyyy p"}
         allowSameDay
         onChange={onChange}
         showTimeSelect


### PR DESCRIPTION
Currently the timepicker will scroll the list to the current time when it is first opened.

This change allows you to supply an option (`defaultToMinTime`) that alters this behavior, instead using the value of the `minTime` prop to select a list item to scroll in view.

This will only work when `minTime` itself is specified, otherwise there will be no effect.

Let me know if there are any modifications to the approach here that you'd like, happy to iterate!

Note: There are also some format changes from the pre-commit hook.