### PR TITLE
IE11 fix 

### DIFF
--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -436,6 +436,8 @@ export default class Calendar extends React.Component {
         year={getYear(this.state.date)}
         scrollableYearDropdown={this.props.scrollableYearDropdown}
         yearDropdownItemNumber={this.props.yearDropdownItemNumber}
+        onBeforeShow={() => this.props.disableOnClickOutside()}
+        onAfterShow={() => this.props.enableOnClickOutside()}
       />
     );
   };
@@ -451,6 +453,8 @@ export default class Calendar extends React.Component {
         onChange={this.changeMonth}
         month={getMonth(this.state.date)}
         useShortMonthInDropdown={this.props.useShortMonthInDropdown}
+        onBeforeShow={() => this.props.disableOnClickOutside()}
+        onAfterShow={() => this.props.enableOnClickOutside()}
       />
     );
   };
@@ -469,6 +473,8 @@ export default class Calendar extends React.Component {
         maxDate={this.props.maxDate}
         date={this.state.date}
         scrollableMonthYearDropdown={this.props.scrollableMonthYearDropdown}
+        onBeforeShow={() => console.log("onBeforeShow")}
+        onAfterShow={() => this.props.enableOnClickOutside()}
       />
     );
   };

--- a/src/month_dropdown.jsx
+++ b/src/month_dropdown.jsx
@@ -12,7 +12,14 @@ export default class MonthDropdown extends React.Component {
     locale: PropTypes.string,
     month: PropTypes.number.isRequired,
     onChange: PropTypes.func.isRequired,
-    useShortMonthInDropdown: PropTypes.bool
+    useShortMonthInDropdown: PropTypes.bool,
+    onBeforeShow: PropTypes.func,
+    onAfterShow: PropTypes.func
+  };
+
+  static defaultProps = {
+    onBeforeShow: function() {},
+    onAfterShow: function() {}
   };
 
   state = {
@@ -77,10 +84,17 @@ export default class MonthDropdown extends React.Component {
     }
   };
 
-  toggleDropdown = () =>
+  toggleDropdown = () => {
+    if (!this.state.dropdownVisible) {
+      this.props.onBeforeShow();
+    } else {
+      this.props.onAfterShow();
+    }
+
     this.setState({
       dropdownVisible: !this.state.dropdownVisible
     });
+  };
 
   render() {
     const monthNames = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11].map(

--- a/src/year_dropdown.jsx
+++ b/src/year_dropdown.jsx
@@ -18,7 +18,14 @@ export default class YearDropdown extends React.Component {
     yearDropdownItemNumber: PropTypes.number,
     date: PropTypes.instanceOf(Date),
     onSelect: PropTypes.func,
-    setOpen: PropTypes.func
+    setOpen: PropTypes.func,
+    onBeforeShow: PropTypes.func,
+    onAfterShow: PropTypes.func
+  };
+
+  static defaultProps = {
+    onBeforeShow: function() {},
+    onAfterShow: function() {}
   };
 
   state = {
@@ -98,6 +105,12 @@ export default class YearDropdown extends React.Component {
   };
 
   toggleDropdown = event => {
+    if (!this.state.dropdownVisible) {
+      this.props.onBeforeShow();
+    } else {
+      this.props.onAfterShow();
+    }
+
     this.setState(
       {
         dropdownVisible: !this.state.dropdownVisible


### PR DESCRIPTION
Fix for IE issue: #1102
Disable clickOutside behavior if month or year dropdown are shown. And re-enable it when dropdown are hidden.

Description:
In IE if you have date picker rendered in `scroll` view for month and year selectors, when user open drop down and click outside - js error happens.
To fix this: I've introduced two additional methods (props) `beforeShow` and `afterShow` which allow me to get the moment of opening and closing those popups. At that moment I disable / enable outside click library for the main calendar control so when user clicks outside opened year drop down it will close only year drop down. So user can return to calendar view.