### PR TITLE
Fix range error

### DIFF
--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -224,7 +224,13 @@ export function isSameDay(date1, date2) {
 }
 
 export function isDayInRange(day, startDate, endDate) {
-  return isWithinInterval(day, { start: startDate, end: endDate });
+  let valid;
+  try {
+    valid = isWithinInterval(day, { start: startDate, end: endDate });
+  } catch (err) {
+    valid = false;
+  }
+  return valid;
 }
 
 // *** Diffing ***
@@ -326,7 +332,14 @@ export function isTimeInDisabledRange(time, { minTime, maxTime }) {
     setMinutes(base, getMinutes(maxTime)),
     getHours(maxTime)
   );
-  return !isWithinInterval(baseTime, { start: min, end: max });
+
+  let valid;
+  try {
+    valid = !isWithinInterval(baseTime, { start: min, end: max });
+  } catch (err) {
+    valid = false;
+  }
+  return valid;
 }
 
 export function monthDisabledBefore(day, { minDate, includeDates } = {}) {

--- a/test/date_utils_test.js
+++ b/test/date_utils_test.js
@@ -10,8 +10,12 @@ import {
   monthDisabledBefore,
   monthDisabledAfter,
   getEffectiveMinDate,
-  getEffectiveMaxDate
+  getEffectiveMaxDate,
+  isTimeInDisabledRange,
+  isDayInRange
 } from "../src/date_utils";
+import setMinutes from "date-fns/setMinutes";
+import setHours from "date-fns/setHours";
 
 describe("date_utils", function() {
   describe("isSameDay", function() {
@@ -243,6 +247,55 @@ describe("date_utils", function() {
       const date2 = newDate("2016-04-01");
       const includeDates = [date1, date2];
       assert(isEqual(getEffectiveMaxDate({ maxDate, includeDates }), date1));
+    });
+  });
+
+  describe("isTimeInDisabledRange", () => {
+    it("should tell if time is in disabled range", () => {
+      const date = newDate("2016-03-15");
+      const time = setHours(setMinutes(date, 30), 1);
+      const minTime = setHours(setMinutes(date, 30), 0);
+      const maxTime = setHours(setMinutes(date, 30), 5);
+      expect(isTimeInDisabledRange(time, { minTime, maxTime })).to.be.false;
+    });
+
+    it("should tell if time is not in disabled range", () => {
+      const date = newDate("2016-03-15");
+      const time = setHours(setMinutes(date, 30), 0);
+      const minTime = setHours(setMinutes(date, 30), 1);
+      const maxTime = setHours(setMinutes(date, 30), 5);
+      expect(isTimeInDisabledRange(time, { minTime, maxTime })).to.be.true;
+    });
+
+    it("should not throw an exception if max time is before min time", () => {
+      const date = newDate("2016-03-15");
+      const time = setHours(setMinutes(date, 30), 10);
+      const minTime = setHours(setMinutes(date, 30), 5);
+      const maxTime = setHours(setMinutes(date, 30), 0);
+      expect(isTimeInDisabledRange(time, { minTime, maxTime })).to.be.false;
+    });
+  });
+
+  describe("isDayInRange", () => {
+    it("should tell if day is in range", () => {
+      const day = newDate("2016-02-15");
+      const startDate = newDate("2016-02-01");
+      const endDate = newDate("2016-03-15");
+      expect(isDayInRange(day, startDate, endDate)).to.be.true;
+    });
+
+    it("should tell if day is not in range", () => {
+      const day = newDate("2016-07-15");
+      const startDate = newDate("2016-02-15");
+      const endDate = newDate("2016-03-15");
+      expect(isDayInRange(day, startDate, endDate)).to.be.false;
+    });
+
+    it("should not throw exception if end date is before start date", () => {
+      const day = newDate("2016-02-01");
+      const startDate = newDate("2016-02-15");
+      const endDate = newDate("2016-01-15");
+      expect(isDayInRange(day, startDate, endDate)).to.be.false;
     });
   });
 });


### PR DESCRIPTION
Fix for https://github.com/Hacker0x01/react-datepicker/issues/1563.

Instead of an uncaught exception, the error is handled simply as a `false` when considering if the dates are in range.