### PR TITLE
utcOffset Removal from Props List

### DIFF
--- a/docs/datepicker.md
+++ b/docs/datepicker.md
@@ -76,7 +76,6 @@ General datepicker component.
 | `title`                      | `string`                       |                 |                                            |
 | `todayButton`                | `node`                         |                 |                                            |
 | `useWeekdaysShort`           | `bool`                         |                 |                                            |
-| `utcOffset`                  | `union(number\|string)`        |                 |                                            |
 | `value`                      | `string`                       |                 |                                            |
 | `weekLabel`                  | `string`                       |                 |                                            |
 | `withPortal`                 | `bool`                         | `false`         |                                            |


### PR DESCRIPTION
Removed utcOffset from props list as it was removed in https://github.com/Hacker0x01/react-datepicker/pull/1527 .