### PR TITLE
Update `value` prop type to allow a string or an instance of `Date`

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -148,7 +148,7 @@ export default class DatePicker extends React.Component {
     todayButton: PropTypes.node,
     useWeekdaysShort: PropTypes.bool,
     formatWeekDay: PropTypes.func,
-    value: PropTypes.string,
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date)]),
     weekLabel: PropTypes.string,
     withPortal: PropTypes.bool,
     yearDropdownItemNumber: PropTypes.number,


### PR DESCRIPTION
Resolves Issue: https://github.com/Hacker0x01/react-datepicker/issues/1588