### PR TITLE
Update to react 16 createRef API

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -80,7 +80,7 @@ export default class DatePicker extends React.Component {
     children: PropTypes.node,
     className: PropTypes.string,
     customInput: PropTypes.element,
-    customInputRef: PropTypes.string,
+    inputRef: PropTypes.any,
     // eslint-disable-next-line react/no-unused-prop-types
     dateFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
     dateFormatCalendar: PropTypes.string,
@@ -205,6 +205,7 @@ export default class DatePicker extends React.Component {
   constructor(props) {
     super(props);
     this.state = this.calcInitialState();
+    this.input = props.inputRef || React.createRef()
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -270,14 +271,14 @@ export default class DatePicker extends React.Component {
   };
 
   setFocus = () => {
-    if (this.input && this.input.focus) {
-      this.input.focus();
+    if (this.input && this.input.current && this.input.current.focus) {
+      this.input.current.focus();
     }
   };
 
   setBlur = () => {
-    if (this.input && this.input.blur) {
-      this.input.blur();
+    if (this.input && this.input.current && this.input.current.blur) {
+      this.input.current.blur();
     }
 
     this.cancelFocusInput();
@@ -665,7 +666,6 @@ export default class DatePicker extends React.Component {
     });
 
     const customInput = this.props.customInput || <input type="text" />;
-    const customInputRef = this.props.customInputRef || 'ref';
     const inputValue =
       typeof this.props.value === 'string'
         ? this.props.value
@@ -674,9 +674,7 @@ export default class DatePicker extends React.Component {
           : safeDateFormat(this.props.selected, this.props);
 
     return React.cloneElement(customInput, {
-      [customInputRef]: input => {
-        this.input = input;
-      },
+      ref: this.input,
       value: inputValue,
       onBlur: this.handleBlur,
       onChange: this.handleChange,


### PR DESCRIPTION
I want to preface this by saying that I don't expect this to be merged right away. This is just what I needed to change to get this working for us. Would like to know if you are interested at all in this as a pull request and if so I can do some more work if needed to get it merged.

I am not sure how customInputRef is meant to work as any value but ref seems to result in a console warning.

What I want to do is pass in my own reference to the input so I can have access to the dom node to check its size. The createRef API works great but react-datepicker has not been updated and overwrites the ref I put on the custom input. I can work around this by passing a dummy value to customInputRef but that seems kind of silly and puts a warning in the console.