### PR TITLE
Updating main field in package.json and fixing january test

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "2.0.0",
   "license": "MIT",
   "homepage": "https://github.com/Hacker0x01/react-datepicker",
-  "main": "lib",
+  "main": "lib/index.js",
   "module": "es",
   "unpkg": "dist/react-datepicker.min.js",
   "style": "dist/react-datepicker.min.css",

--- a/test/calendar_test.js
+++ b/test/calendar_test.js
@@ -301,7 +301,7 @@ describe("Calendar", function() {
       prevMonth.simulate("click");
 
       expect(utils.getMonth(selected)).to.be.equal(
-        utils.getMonth(calendar.state().date) + 1
+        (utils.getMonth(calendar.state().date) + 1) % 12
       );
     });
 


### PR DESCRIPTION
My bundler gets confused and tries to get `lib.js` instead of `lib/index.js`.

Most packages use `lib/index.js` _https://github.com/react-dnd/react-dnd/blob/master/packages/react-dnd/package.json#L5_, and pointing to an actual file is a standard.