### PR TITLE
Update locale example, clearify date-fns version

### DIFF
--- a/docs-site/src/examples/locale.jsx
+++ b/docs-site/src/examples/locale.jsx
@@ -20,6 +20,12 @@ export default class CustomStartDate extends React.Component {
       <div className="row">
         <pre className="column example__code">
           <code className="jsx">
+            {"// Note: Make sure to npm install the right version of date-fns as"}
+            <br />
+            {"// specified in packaged.json. The default one may not be compatiable"}
+            <br />
+            {"// npm install --save date-fns@version"}
+            <br />
             {"import enGB from 'date-fns/locale/en-GB';"}
             <br />
             {"registerLocale('en-GB', enGB);"}


### PR DESCRIPTION
It's confusing because the default date-fns version is not compatible. Added a few lines of comments about how to install the compatible version.