### PR TITLE
(docs) improve locale section

### DIFF
--- a/docs-site/src/examples/locale.jsx
+++ b/docs-site/src/examples/locale.jsx
@@ -26,6 +26,8 @@ export default class CustomStartDate extends React.Component {
             <br />
             {"// npm install --save date-fns@version"}
             <br />
+            {"import DatePicker, { registerLocale } from 'react-datepicker';"}
+            <br />
             {"import enGB from 'date-fns/locale/en-GB';"}
             <br />
             {"registerLocale('en-GB', enGB);"}


### PR DESCRIPTION
Just a small addition to improve the docs.

I started to use react-datepicker these days. I tried to reproduced the code of the locale example, and I didn't have success. Seems like other people faced the same problem (https://github.com/Hacker0x01/react-datepicker/issues/1643). I think this can improve the docs.