### PR TITLE
Make date parsing conform strictly to the date format.

### DIFF
--- a/docs-site/src/example_components.jsx
+++ b/docs-site/src/example_components.jsx
@@ -51,6 +51,7 @@ import IncludeTimes from "./examples/include_times";
 import InjectTimes from "./examples/inject_times";
 import DontCloseOnSelect from "./examples/dont_close_onSelect";
 import RenderCustomHeader from "./examples/render_custom_header";
+import StrictParsing from "./examples/strict_parsing";
 
 import "react-datepicker/dist/react-datepicker.css";
 import "./style.scss";
@@ -256,6 +257,10 @@ export default class exampleComponents extends React.Component {
     {
       title: "Custom header",
       component: <RenderCustomHeader />
+    },
+    {
+      title: "Strict parsing",
+      component: <StrictParsing />
     }
   ];
 

--- a/docs-site/src/examples/strict_parsing.jsx
+++ b/docs-site/src/examples/strict_parsing.jsx
@@ -1,0 +1,42 @@
+import React from "react";
+import DatePicker from "react-datepicker";
+
+export default class StrictParsing extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      startDate: new Date()
+    };
+  }
+
+  handleChange = date => {
+    this.setState({
+      startDate: date
+    });
+  };
+
+  render() {
+    return (
+      <div className="row">
+        <pre className="column example__code">
+          <code className="jsx">
+            {`
+<DatePicker
+    selected={this.state.startDate}
+    onChange={this.handleChange}
+    strictParsing
+/>
+`}
+          </code>
+        </pre>
+        <div className="column">
+          <DatePicker
+            selected={this.state.startDate}
+            onChange={this.handleChange}
+            strictParsing
+          />
+        </div>
+      </div>
+    );
+  }
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,74 +1,100 @@
 # `index` (component)
 
-| name                         | type                           | default value      | description |
-| ---------------------------- | ------------------------------ | ------------------ | ----------- |
-| `adjustDateOnChange`         | `bool`                         |                    |             |
-| `allowSameDay`               | `bool`                         | `false`            |             |
-| `autoComplete`               | `string`                       |                    |             |
-| `autoFocus`                  | `bool`                         |                    |             |
-| `calendarClassName`          | `string`                       |                    |             |
-| `calendarContainer`          | `func`                         |                    |             |
-| `children`                   | `node`                         |                    |             |
-| `className`                  | `string`                       |                    |             |
-| `clearButtonTitle`           | `string`                       |                    |             |
-| `customInput`                | `element`                      |                    |             |
-| `customInputRef`             | `string`                       |                    |             |
-| `dateFormat`                 | `union(string\|array)`         | `"MM/dd/yyyy"`     |             |
-| `dateFormatCalendar`         | `string`                       | `"LLLL yyyy"`      |             |
-| `dayClassName`               | `func`                         |                    |             |
-| `disabled`                   | `bool`                         | `false`            |             |
-| `disabledKeyboardNavigation` | `bool`                         | `false`            |             |
-| `dropdownMode`               | `enum("scroll"\|"select")`     | `"scroll"`         |             |
-| `endDate`                    | `instanceOfDate`               |                    |             |
-| `excludeDates`               | `array`                        |                    |             |
-| `excludeTimes`               | `array`                        |                    |             |
-| `filterDate`                 | `func`                         |                    |             |
-| `fixedHeight`                | `bool`                         |                    |             |
-| `forceShowMonthNavigation`   | `bool`                         |                    |             |
-| `formatWeekDay`              | `func`                         |                    |             |
-| `formatWeekNumber`           | `func`                         |                    |             |
-| `highlightDates`             | `array`                        |                    |             |
-| `id`                         | `string`                       |                    |             |
-| `includeDates`               | `array`                        |                    |             |
-| `includeTimes`               | `array`                        |                    |             |
-| `injectTimes`                | `array`                        |                    |             |
-| `inline`                     | `bool`                         |                    |             |
-| `inlineFocusSelectedMonth`   | `bool`                         | `false`            |             |
-| `isClearable`                | `bool`                         |                    |             |
-| `locale`                     | `string`                       |                    |             |
-| `maxDate`                    | `instanceOfDate`               |                    |             |
-| `maxTime`                    | `instanceOfDate`               |                    |             |
-| `minDate`                    | `instanceOfDate`               |                    |             |
-| `minTime`                    | `instanceOfDate`               |                    |             |
-| `monthsShown`                | `number`                       | `1`                |             |
-| `name`                       | `string`                       |                    |             |
-| `nextMonthButtonLabel`       | `string`                       | `"Next month"`     |             |
-| `onBlur`                     | `func`                         | `function() {}`    |             |
-| `onChange`                   | `func`                         | `function() {}`    |             |
-| `onChangeRaw`                | `func`                         |                    |             |
-| `onClickOutside`             | `func`                         | `function() {}`    |             |
-| `onFocus`                    | `func`                         | `function() {}`    |             |
-| `onInputClick`               | `func`                         | `function() {}`    |             |
-| `onInputError`               | `func`                         | `function() {}`    |             |
-| `onKeyDown`                  | `func`                         | `function() {}`    |             |
-| `onMonthChange`              | `func`                         | `function() {}`    |             |
-| `onSelect`                   | `func`                         | `function() {}`    |             |
-| `onWeekSelect`               | `func`                         |                    |             |
-| `onYearChange`               | `func`                         | `function() {}`    |             |
-| `open`                       | `bool`                         |                    |             |
-| `openToDate`                 | `instanceOfDate`               |                    |             |
-| `peekNextMonth`              | `bool`                         |                    |             |
-| `placeholderText`            | `string`                       |                    |             |
-| `popperClassName`            | `string`                       |                    |             |
-| `popperContainer`            | `func`                         |                    |             |
-| `popperModifiers`            | `object`                       |                    |             |
-| `popperPlacement`            | `enumpopperPlacementPositions` |                    |             |
-| `popperProps`                | `object`                       |                    |             |
-| `preventOpenOnFocus`         | `bool`                         | `false`            |             |
-| `previousMonthButtonLabel`   | `string`                       | `"Previous Month"` |             |
-| `readOnly`                   | `bool`                         | `false`            |             |
-| `renderCustomHeader`         | `func`                         |                    |             |
-| `renderDayContents`          | `func`                         | `function(date) {  |
-
-return date;
-}`|| |`required`|`bool`||| |`scrollableMonthYearDropdown`|`bool`||| |`scrollableYearDropdown`|`bool`||| |`selected`|`instanceOfDate`||| |`selectsEnd`|`bool`||| |`selectsStart`|`bool`||| |`shouldCloseOnSelect`|`bool`|`true`|| |`showDisabledMonthNavigation`|`bool`||| |`showMonthDropdown`|`bool`||| |`showMonthYearDropdown`|`bool`||| |`showTimeSelect`|`bool`|`false`|| |`showTimeSelectOnly`|`bool`||| |`showWeekNumbers`|`bool`||| |`showYearDropdown`|`bool`||| |`startDate`|`instanceOfDate`||| |`startOpen`|`bool`||| |`tabIndex`|`number`||| |`timeCaption`|`string`|`"Time"`|| |`timeFormat`|`string`||| |`timeIntervals`|`number`|`30`|| |`title`|`string`||| |`todayButton`|`node`||| |`useShortMonthInDropdown`|`bool`||| |`useWeekdaysShort`|`bool`||| |`value`|`string`||| |`weekLabel`|`string`||| |`withPortal`|`bool`|`false`|| |`yearDropdownItemNumber`|`number`|||
+| name                          | type                           | default value                    | description                                                                                                                                                   |
+| ----------------------------- | ------------------------------ | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `adjustDateOnChange`          | `bool`                         |                                  |                                                                                                                                                               |
+| `allowSameDay`                | `bool`                         | `false`                          |                                                                                                                                                               |
+| `autoComplete`                | `string`                       |                                  |                                                                                                                                                               |
+| `autoFocus`                   | `bool`                         |                                  |                                                                                                                                                               |
+| `calendarClassName`           | `string`                       |                                  |                                                                                                                                                               |
+| `calendarContainer`           | `func`                         |                                  |                                                                                                                                                               |
+| `children`                    | `node`                         |                                  |                                                                                                                                                               |
+| `className`                   | `string`                       |                                  |                                                                                                                                                               |
+| `clearButtonTitle`            | `string`                       |                                  |                                                                                                                                                               |
+| `customInput`                 | `element`                      |                                  |                                                                                                                                                               |
+| `customInputRef`              | `string`                       |                                  |                                                                                                                                                               |
+| `dateFormat`                  | `union(string\|array)`         | `"MM/dd/yyyy"`                   |                                                                                                                                                               |
+| `dateFormatCalendar`          | `string`                       | `"LLLL yyyy"`                    |                                                                                                                                                               |
+| `dayClassName`                | `func`                         |                                  |                                                                                                                                                               |
+| `disabled`                    | `bool`                         | `false`                          |                                                                                                                                                               |
+| `disabledKeyboardNavigation`  | `bool`                         | `false`                          |                                                                                                                                                               |
+| `dropdownMode`                | `enum("scroll"\|"select")`     | `"scroll"`                       |                                                                                                                                                               |
+| `endDate`                     | `instanceOfDate`               |                                  |                                                                                                                                                               |
+| `excludeDates`                | `array`                        |                                  |                                                                                                                                                               |
+| `excludeTimes`                | `array`                        |                                  |                                                                                                                                                               |
+| `filterDate`                  | `func`                         |                                  |                                                                                                                                                               |
+| `fixedHeight`                 | `bool`                         |                                  |                                                                                                                                                               |
+| `forceShowMonthNavigation`    | `bool`                         |                                  |                                                                                                                                                               |
+| `formatWeekDay`               | `func`                         |                                  |                                                                                                                                                               |
+| `formatWeekNumber`            | `func`                         |                                  |                                                                                                                                                               |
+| `highlightDates`              | `array`                        |                                  |                                                                                                                                                               |
+| `id`                          | `string`                       |                                  |                                                                                                                                                               |
+| `includeDates`                | `array`                        |                                  |                                                                                                                                                               |
+| `includeTimes`                | `array`                        |                                  |                                                                                                                                                               |
+| `injectTimes`                 | `array`                        |                                  |                                                                                                                                                               |
+| `inline`                      | `bool`                         |                                  |                                                                                                                                                               |
+| `inlineFocusSelectedMonth`    | `bool`                         | `false`                          |                                                                                                                                                               |
+| `isClearable`                 | `bool`                         |                                  |                                                                                                                                                               |
+| `locale`                      | `string`                       |                                  |                                                                                                                                                               |
+| `maxDate`                     | `instanceOfDate`               |                                  |                                                                                                                                                               |
+| `maxTime`                     | `instanceOfDate`               |                                  |                                                                                                                                                               |
+| `minDate`                     | `instanceOfDate`               |                                  |                                                                                                                                                               |
+| `minTime`                     | `instanceOfDate`               |                                  |                                                                                                                                                               |
+| `monthsShown`                 | `number`                       | `1`                              |                                                                                                                                                               |
+| `name`                        | `string`                       |                                  |                                                                                                                                                               |
+| `nextMonthButtonLabel`        | `string`                       | `"Next month"`                   |                                                                                                                                                               |
+| `onBlur`                      | `func`                         | `function() {}`                  |                                                                                                                                                               |
+| `onChange`                    | `func`                         | `function() {}`                  |                                                                                                                                                               |
+| `onChangeRaw`                 | `func`                         |                                  |                                                                                                                                                               |
+| `onClickOutside`              | `func`                         | `function() {}`                  |                                                                                                                                                               |
+| `onFocus`                     | `func`                         | `function() {}`                  |                                                                                                                                                               |
+| `onInputClick`                | `func`                         | `function() {}`                  |                                                                                                                                                               |
+| `onInputError`                | `func`                         | `function() {}`                  |                                                                                                                                                               |
+| `onKeyDown`                   | `func`                         | `function() {}`                  |                                                                                                                                                               |
+| `onMonthChange`               | `func`                         | `function() {}`                  |                                                                                                                                                               |
+| `onSelect`                    | `func`                         | `function() {}`                  |                                                                                                                                                               |
+| `onWeekSelect`                | `func`                         |                                  |                                                                                                                                                               |
+| `onYearChange`                | `func`                         | `function() {}`                  |                                                                                                                                                               |
+| `open`                        | `bool`                         |                                  |                                                                                                                                                               |
+| `openToDate`                  | `instanceOfDate`               |                                  |                                                                                                                                                               |
+| `peekNextMonth`               | `bool`                         |                                  |                                                                                                                                                               |
+| `placeholderText`             | `string`                       |                                  |                                                                                                                                                               |
+| `popperClassName`             | `string`                       |                                  |                                                                                                                                                               |
+| `popperContainer`             | `func`                         |                                  |                                                                                                                                                               |
+| `popperModifiers`             | `object`                       |                                  |                                                                                                                                                               |
+| `popperPlacement`             | `enumpopperPlacementPositions` |                                  |                                                                                                                                                               |
+| `popperProps`                 | `object`                       |                                  |                                                                                                                                                               |
+| `preventOpenOnFocus`          | `bool`                         | `false`                          |                                                                                                                                                               |
+| `previousMonthButtonLabel`    | `string`                       | `"Previous Month"`               |                                                                                                                                                               |
+| `readOnly`                    | `bool`                         | `false`                          |                                                                                                                                                               |
+| `renderCustomHeader`          | `func`                         |                                  |                                                                                                                                                               |
+| `renderDayContents`           | `func`                         | `function(date) { return date;}` |                                                                                                                                                               |
+| `required`                    | `bool`                         |                                  |                                                                                                                                                               |
+| `scrollableMonthYearDropdown` | `bool`                         |                                  |                                                                                                                                                               |
+| `scrollableYearDropdown`      | `bool`                         |                                  |                                                                                                                                                               |
+| `selected`                    | `instanceOfDate`               |                                  |                                                                                                                                                               |
+| `selectsEnd`                  | `bool`                         |                                  |                                                                                                                                                               |
+| `selectsStart`                | `bool`                         |                                  |                                                                                                                                                               |
+| `shouldCloseOnSelect`         | `bool`                         | `true`                           |                                                                                                                                                               |
+| `showDisabledMonthNavigation` | `bool`                         |                                  |                                                                                                                                                               |
+| `showMonthDropdown`           | `bool`                         |                                  |                                                                                                                                                               |
+| `showMonthYearDropdown`       | `bool`                         |                                  |                                                                                                                                                               |
+| `showTimeSelect`              | `bool`                         | `false`                          |                                                                                                                                                               |
+| `showTimeSelectOnly`          | `bool`                         |                                  |                                                                                                                                                               |
+| `showWeekNumbers`             | `bool`                         |                                  |                                                                                                                                                               |
+| `showYearDropdown`            | `bool`                         |                                  |                                                                                                                                                               |
+| `startDate`                   | `instanceOfDate`               |                                  |                                                                                                                                                               |
+| `startOpen`                   | `bool`                         |                                  |                                                                                                                                                               |
+| `strictParsing`               | `bool`                         | `false`                          | When set to true, the format of the value in the date input must strictly match the dateFormat in order for the input value to be registered as a valid date. |
+| `tabIndex`                    | `number`                       |                                  |                                                                                                                                                               |
+| `timeCaption`                 | `string`                       | `"Time"`                         |                                                                                                                                                               |
+| `timeFormat`                  | `string`                       |                                  |                                                                                                                                                               |
+| `timeIntervals`               | `number`                       | `30`                             |                                                                                                                                                               |
+| `title`                       | `string`                       |                                  |                                                                                                                                                               |
+| `todayButton`                 | `node`                         |                                  |                                                                                                                                                               |
+| `useShortMonthInDropdown`     | `bool`                         |                                  |                                                                                                                                                               |
+| `useWeekdaysShort`            | `bool`                         |                                  |                                                                                                                                                               |
+| `value`                       | `string`                       |                                  |                                                                                                                                                               |
+| `weekLabel`                   | `string`                       |                                  |                                                                                                                                                               |
+| `withPortal`                  | `bool`                         | `false`                          |                                                                                                                                                               |
+| `yearDropdownItemNumber`      | `number`                       |                                  |                                                                                                                                                               |

--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -62,7 +62,7 @@ export function parseDate(value, dateFormat, locale) {
   if (Array.isArray(dateFormat)) {
     dateFormat.forEach(df => {
       let tryParseDate = parse(value, df, new Date(), localeObject);
-      if (isValid(tryParseDate) && value === format(tryParseDate, df)) {
+      if (isValid(tryParseDate) && value === format(tryParseDate, df, { awareOfUnicodeTokens: true })) {
         parsedDate = tryParseDate;
       }
     });
@@ -72,7 +72,7 @@ export function parseDate(value, dateFormat, locale) {
   if (!isValid(parsedDate)) {
     parsedDate = new Date(value);
   }
-  return isValid(parsedDate) && value === format(parsedDate, dateFormat) ? parsedDate : null;
+  return isValid(parsedDate) && value === format(parsedDate, dateFormat, { awareOfUnicodeTokens: true }) ? parsedDate : null;
 }
 
 // ** Date "Reflection" **

--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -78,10 +78,8 @@ export function parseDate(value, dateFormat, locale, strictParsing) {
   if (!isValid(parsedDate)) {
     parsedDate = new Date(value);
   }
-  ("");
 
   if (strictParsing && isValid(parsedDate)) {
-    debugger;
     strictParsingValueMatch =
       value === format(parsedDate, dateFormat, { awareOfUnicodeTokens: true });
   }

--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -63,7 +63,7 @@ export function parseDate(value, dateFormat, locale, strictParsing) {
   if (Array.isArray(dateFormat)) {
     dateFormat.forEach(df => {
       let tryParseDate = parse(value, df, new Date(), localeObject);
-      if (strictParsing) {
+      if (strictParsing && isValid(tryParseDate)) {
         strictParsingValueMatch =
           value === format(tryParseDate, df, { awareOfUnicodeTokens: true });
       }
@@ -78,8 +78,10 @@ export function parseDate(value, dateFormat, locale, strictParsing) {
   if (!isValid(parsedDate)) {
     parsedDate = new Date(value);
   }
+  ("");
 
-  if (strictParsing) {
+  if (strictParsing && isValid(parsedDate)) {
+    debugger;
     strictParsingValueMatch =
       value === format(parsedDate, dateFormat, { awareOfUnicodeTokens: true });
   }

--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -56,23 +56,35 @@ export function newDate(value) {
   return isValid(d) ? d : null;
 }
 
-export function parseDate(value, dateFormat, locale) {
+export function parseDate(value, dateFormat, locale, strictParsing) {
   let parsedDate = null;
   let localeObject = getLocaleObject(locale);
+  let strictParsingValueMatch = true;
   if (Array.isArray(dateFormat)) {
     dateFormat.forEach(df => {
       let tryParseDate = parse(value, df, new Date(), localeObject);
-      if (isValid(tryParseDate) && value === format(tryParseDate, df, { awareOfUnicodeTokens: true })) {
+      if (strictParsing) {
+        strictParsingValueMatch =
+          value === format(tryParseDate, df, { awareOfUnicodeTokens: true });
+      }
+      if (isValid(tryParseDate) && strictParsingValueMatch) {
         parsedDate = tryParseDate;
       }
     });
     return parsedDate;
   }
+
   parsedDate = parse(value, dateFormat, new Date(), localeObject);
   if (!isValid(parsedDate)) {
     parsedDate = new Date(value);
   }
-  return isValid(parsedDate) && value === format(parsedDate, dateFormat, { awareOfUnicodeTokens: true }) ? parsedDate : null;
+
+  if (strictParsing) {
+    strictParsingValueMatch =
+      value === format(parsedDate, dateFormat, { awareOfUnicodeTokens: true });
+  }
+
+  return isValid(parsedDate) && strictParsingValueMatch ? parsedDate : null;
 }
 
 // ** Date "Reflection" **

--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -62,7 +62,7 @@ export function parseDate(value, dateFormat, locale) {
   if (Array.isArray(dateFormat)) {
     dateFormat.forEach(df => {
       let tryParseDate = parse(value, df, new Date(), localeObject);
-      if (isValid(tryParseDate)) {
+      if (isValid(tryParseDate) && value === format(tryParseDate, df)) {
         parsedDate = tryParseDate;
       }
     });
@@ -72,7 +72,7 @@ export function parseDate(value, dateFormat, locale) {
   if (!isValid(parsedDate)) {
     parsedDate = new Date(value);
   }
-  return isValid(parsedDate) ? parsedDate : null;
+  return isValid(parsedDate) && value === format(parsedDate, dateFormat) ? parsedDate : null;
 }
 
 // ** Date "Reflection" **

--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -63,8 +63,9 @@ export function parseDate(value, dateFormat, locale, strictParsing) {
   if (Array.isArray(dateFormat)) {
     dateFormat.forEach(df => {
       let tryParseDate = parse(value, df, new Date(), localeObject);
-      if (strictParsing && isValid(tryParseDate)) {
+      if (strictParsing) {
         strictParsingValueMatch =
+          isValid(tryParseDate) &&
           value === format(tryParseDate, df, { awareOfUnicodeTokens: true });
       }
       if (isValid(tryParseDate) && strictParsingValueMatch) {
@@ -75,13 +76,13 @@ export function parseDate(value, dateFormat, locale, strictParsing) {
   }
 
   parsedDate = parse(value, dateFormat, new Date(), localeObject);
-  if (!isValid(parsedDate)) {
-    parsedDate = new Date(value);
-  }
 
-  if (strictParsing && isValid(parsedDate)) {
+  if (strictParsing) {
     strictParsingValueMatch =
+      isValid(parsedDate) &&
       value === format(parsedDate, dateFormat, { awareOfUnicodeTokens: true });
+  } else if (!isValid(parsedDate)) {
+    parsedDate = new Date(value);
   }
 
   return isValid(parsedDate) && strictParsingValueMatch ? parsedDate : null;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -138,6 +138,7 @@ export default class DatePicker extends React.Component {
     showMonthYearDropdown: PropTypes.bool,
     showWeekNumbers: PropTypes.bool,
     showYearDropdown: PropTypes.bool,
+    strictParsing: PropTypes.bool,
     forceShowMonthNavigation: PropTypes.bool,
     showDisabledMonthNavigation: PropTypes.bool,
     startDate: PropTypes.instanceOf(Date),
@@ -193,6 +194,7 @@ export default class DatePicker extends React.Component {
       withPortal: false,
       shouldCloseOnSelect: true,
       showTimeSelect: false,
+      strictParsing: false,
       timeIntervals: 30,
       timeCaption: "Time",
       previousMonthButtonLabel: "Previous Month",
@@ -243,10 +245,10 @@ export default class DatePicker extends React.Component {
     this.props.openToDate
       ? this.props.openToDate
       : this.props.selectsEnd && this.props.startDate
-        ? this.props.startDate
-        : this.props.selectsStart && this.props.endDate
-          ? this.props.endDate
-          : newDate();
+      ? this.props.startDate
+      : this.props.selectsStart && this.props.endDate
+      ? this.props.endDate
+      : newDate();
 
   calcInitialState = () => {
     const defaultPreSelection = this.getPreSelection();
@@ -256,8 +258,8 @@ export default class DatePicker extends React.Component {
       minDate && isBefore(defaultPreSelection, minDate)
         ? minDate
         : maxDate && isAfter(defaultPreSelection, maxDate)
-          ? maxDate
-          : defaultPreSelection;
+        ? maxDate
+        : defaultPreSelection;
     return {
       open: this.props.startOpen || false,
       preventFocus: false,
@@ -385,7 +387,8 @@ export default class DatePicker extends React.Component {
     const date = parseDate(
       event.target.value,
       this.props.dateFormat,
-      this.props.locale
+      this.props.locale,
+      this.props.strictParsing
     );
     if (date || !event.target.value) {
       this.setSelected(date, event, true);
@@ -686,8 +689,8 @@ export default class DatePicker extends React.Component {
       typeof this.props.value === "string"
         ? this.props.value
         : typeof this.state.inputValue === "string"
-          ? this.state.inputValue
-          : safeDateFormat(this.props.selected, this.props);
+        ? this.state.inputValue
+        : safeDateFormat(this.props.selected, this.props);
 
     return React.cloneElement(customInput, {
       [customInputRef]: input => {

--- a/test/date_utils_test.js
+++ b/test/date_utils_test.js
@@ -302,31 +302,38 @@ describe("date_utils", function() {
 
   describe("parseDate", () => {
     it("should parse date that matches the format", () => {
-      const value = "2019-03-04";
-      const dateFormat = "yyyy-MM-dd";
+      const value = "01/15/2019";
+      const dateFormat = "MM/dd/yyyy";
 
-      expect(parseDate(value, dateFormat, null)).to.not.be.null;
+      expect(parseDate(value, dateFormat, null, true)).to.not.be.null;
     });
 
     it("should parse date that matches one of the formats", () => {
-      const value = "2019-03-04";
-      const dateFormat = ["yyyy-MM-dd", "MM-dd-yyyy"];
+      const value = "01/15/2019";
+      const dateFormat = ["MM/dd/yyyy", "yyyy-MM-dd"];
 
-      expect(parseDate(value, dateFormat, null)).to.not.be.null;
+      expect(parseDate(value, dateFormat, null, true)).to.not.be.null;
     });
 
     it("should not parse date that does not match the format", () => {
-      const value = "20-03-04";
-      const dateFormat = "yyyy-MM-dd";
+      const value = "01/15/20";
+      const dateFormat = "MM/dd/yyyy";
 
-      expect(parseDate(value, dateFormat, null)).to.be.null;
+      expect(parseDate(value, dateFormat, null, true)).to.be.null;
     });
 
     it("should not parse date that does not match any of the formats", () => {
-      const value = "20-03-04";
-      const dateFormat = ["yyyy-MM-dd", "MM-dd-yyyy"];
+      const value = "01/15/20";
+      const dateFormat = ["MM/dd/yyyy", "yyyy-MM-dd"];
 
-      expect(parseDate(value, dateFormat, null)).to.be.null;
+      expect(parseDate(value, dateFormat, null, true)).to.be.null;
+    });
+
+    it("should parse date without strict parsing", () => {
+      const value = "01/15/20";
+      const dateFormat = "MM/dd/yyyy";
+
+      expect(parseDate(value, dateFormat, null, false)).to.not.be.null;
     });
   });
 });

--- a/test/date_utils_test.js
+++ b/test/date_utils_test.js
@@ -12,7 +12,8 @@ import {
   getEffectiveMinDate,
   getEffectiveMaxDate,
   isTimeInDisabledRange,
-  isDayInRange
+  isDayInRange,
+  parseDate
 } from "../src/date_utils";
 import setMinutes from "date-fns/setMinutes";
 import setHours from "date-fns/setHours";
@@ -296,6 +297,36 @@ describe("date_utils", function() {
       const startDate = newDate("2016-02-15");
       const endDate = newDate("2016-01-15");
       expect(isDayInRange(day, startDate, endDate)).to.be.false;
+    });
+  });
+
+  describe("parseDate", () => {
+    it("should parse date that matches the format", () => {
+      const value = "2019-03-04";
+      const dateFormat = "yyyy-MM-dd";
+
+      expect(parseDate(value, dateFormat, null)).to.not.be.null;
+    });
+
+    it("should parse date that matches one of the formats", () => {
+      const value = "2019-03-04";
+      const dateFormat = ["yyyy-MM-dd", "MM-dd-yyyy"];
+
+      expect(parseDate(value, dateFormat, null)).to.not.be.null;
+    });
+
+    it("should not parse date that does not match the format", () => {
+      const value = "20-03-04";
+      const dateFormat = "yyyy-MM-dd";
+
+      expect(parseDate(value, dateFormat, null)).to.be.null;
+    });
+
+    it("should not parse date that does not match any of the formats", () => {
+      const value = "20-03-04";
+      const dateFormat = ["yyyy-MM-dd", "MM-dd-yyyy"];
+
+      expect(parseDate(value, dateFormat, null)).to.be.null;
     });
   });
 });


### PR DESCRIPTION
Fixes #1655 

The date value entered in the input should be parsed strictly based on the provided `dateFormat`. For example, the provided `dateFormat` is `MM/dd/yyyy`. When changing the date value in the input from `03/04/2019` to `03/04/20`, one would expect the date picker to reject `03/04/20` as a valid date value since it does not conform to the date format. However, the date in the calendar is updated to March 4th, 2020 as it accepts `20` as a valid year even when the format has a 4-digit year.

This change is to make date parse conform strictly to the provided date format.