### PR TITLE
removing unused dateformat parameter from getMonthShortInLocale 

### DIFF
--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -295,7 +295,7 @@ export function getMonthInLocale(month, locale) {
   return formatDate(setMonth(newDate(), month), "LLLL", locale);
 }
 
-export function getMonthShortInLocale(month, dateFormat, locale) {
+export function getMonthShortInLocale(month, locale) {
   return formatDate(setMonth(newDate(), month), "LLL", locale);
 }
 


### PR DESCRIPTION
Removed an unused "dateformat" parameter from getMonthShortInLocale that was never sent when called. The unused variable was taking the value of the "locale" variable, creating a bug when setting a locale with the month/year picker.