### PR TITLE
Fix the use of react-popper to work w/React < 16

### DIFF
--- a/src/popper_component.jsx
+++ b/src/popper_component.jsx
@@ -79,14 +79,16 @@ export default class PopperComponent extends React.Component {
 
     return (
       <Manager>
-        <Reference>
-          {({ ref }) => (
-            <div ref={ref} className={wrapperClasses}>
-              {targetComponent}
-            </div>
-          )}
-        </Reference>
-        {popper}
+        <div>
+          <Reference>
+            {({ ref }) => (
+              <div ref={ref} className={wrapperClasses}>
+                {targetComponent}
+              </div>
+            )}
+          </Reference>
+          {popper}
+        </div>
       </Manager>
     );
   }


### PR DESCRIPTION
I have to admit that I haven't tried this with the newest version of datepicker, but it fixes the issue with v1.8.0.

For background, see Hacker0x01#1521