### PR TITLE
Fix the time container whitespace issue

### DIFF
--- a/src/time.jsx
+++ b/src/time.jsx
@@ -43,6 +43,10 @@ export default class Time extends React.Component {
     );
   };
 
+  state = {
+    height: null
+  }
+
   componentDidMount() {
     // code to ensure selected time will always be in focus within time window when it first appears
     this.list.scrollTop = Time.calcCenterPosition(
@@ -51,6 +55,11 @@ export default class Time extends React.Component {
         : this.list.clientHeight,
       this.centerLi
     );
+    if (this.props.monthRef && this.header) {
+      this.setState({
+        height: this.props.monthRef.clientHeight - this.header.clientHeight
+      });
+    }
   }
 
   handleClick = time => {
@@ -143,10 +152,7 @@ export default class Time extends React.Component {
   };
 
   render() {
-    let height = null;
-    if (this.props.monthRef && this.header) {
-      height = this.props.monthRef.clientHeight - this.header.clientHeight;
-    }
+    const { height } = this.state;
 
     return (
       <div

--- a/yarn.lock
+++ b/yarn.lock
@@ -999,9 +999,10 @@ babel-plugin-transform-react-jsx@^6.24.1:
     babel-plugin-syntax-jsx "^6.8.0"
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-react-remove-prop-types@^0.4.19:
-  version "0.4.20"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.20.tgz#688bdea1e27ea0023775dea817fa2d3f8df8802b"
+babel-plugin-transform-react-remove-prop-types@^0.4.24:
+  version "0.4.24"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz#f2edaf9b4c6a5fbe5c1d678bfb531078c1555f3a"
+  integrity sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA==
 
 babel-plugin-transform-regenerator@^6.22.0:
   version "6.26.0"


### PR DESCRIPTION
## Description
Within the `Time` component, the height of the container is calculated in the `render` method. This is not bad practice, but in this specific scenario, `monthRef` is null because React calls `componentDidMount` on *children* first, not parents. 

As updating the prop of a component does not re-render the DOM, there are two ways we can solve this issue:

1. Put the height in the component's state
2. Implement `componentWillReceiveProps`

In this PR, I chose option 1. It should fix #1596.

## Current Behaviour

<img width="1098" alt="Screen Shot 2019-04-19 at 15 19 11" src="https://user-images.githubusercontent.com/8782666/56495198-e8a99c80-64ec-11e9-9d57-c25945d769cc.png">

## Expected Behaviour

<img width="1098" alt="Screen Shot 2019-04-19 at 15 21 05" src="https://user-images.githubusercontent.com/8782666/56495335-61a8f400-64ed-11e9-8111-b9c13df2b563.png">