### PR TITLE
Refactor date_range example

### DIFF
--- a/docs-site/src/examples/date_range.jsx
+++ b/docs-site/src/examples/date_range.jsx
@@ -14,11 +14,6 @@ export default class DateRange extends React.Component {
   handleChange = ({ startDate, endDate }) => {
     startDate = startDate || this.state.startDate;
     endDate = endDate || this.state.endDate;
-
-    if (isAfter(startDate, endDate)) {
-      endDate = startDate;
-    }
-
     this.setState({ startDate, endDate });
   };
 
@@ -46,6 +41,7 @@ export default class DateRange extends React.Component {
     startDate={this.state.startDate}
     endDate={this.state.endDate}
     onChange={this.handleChangeEnd}
+    minDate={this.state.startDate}
 />
 `}
           </code>
@@ -64,6 +60,7 @@ export default class DateRange extends React.Component {
             startDate={this.state.startDate}
             endDate={this.state.endDate}
             onChange={this.handleChangeEnd}
+            minDate={this.state.startDate}
           />
         </div>
       </div>


### PR DESCRIPTION
I want to make it impossible to select the end date before the start date when specifying the period.

If I add `minDate={this.state.startDate}`, `handleChange` method is easier.

like this.

<img width="1058" alt="スクリーンショット 2019-05-17 12 03 03" src="https://user-images.githubusercontent.com/27764298/57901281-586a3780-789f-11e9-95f0-b43ebdb29026.png">

