### PR TITLE
Month picker minDate disabled state (issue #1765)

### DIFF
--- a/docs-site/bundle.js
+++ b/docs-site/bundle.js
@@ -319,7 +319,7 @@
     },
     /* 3 */
     [
-      824,
+      823,
       4,
       5,
       6,
@@ -374,7 +374,7 @@
       /***/
     },
     /* 6 */
-    [825, 7],
+    [824, 7],
     /* 7 */
     /***/ function(module, exports) {
       module.exports = function(exec) {
@@ -452,11 +452,11 @@
       /***/
     },
     /* 10 */
-    [826, 11, 17, 6],
+    [825, 11, 17, 6],
     /* 11 */
-    [827, 12, 14, 16, 6],
+    [826, 12, 14, 16, 6],
     /* 12 */
-    [828, 13],
+    [827, 13],
     /* 13 */
     /***/ function(module, exports) {
       module.exports = function(it) {
@@ -466,11 +466,11 @@
       /***/
     },
     /* 14 */
-    [829, 6, 7, 15],
+    [828, 6, 7, 15],
     /* 15 */
-    [830, 13, 4],
+    [829, 13, 4],
     /* 16 */
-    [831, 13],
+    [830, 13],
     /* 17 */
     /***/ function(module, exports) {
       module.exports = function(bitmap, value) {
@@ -537,7 +537,7 @@
       /***/
     },
     /* 20 */
-    [832, 21],
+    [831, 21],
     /* 21 */
     /***/ function(module, exports) {
       module.exports = function(it) {
@@ -549,17 +549,17 @@
       /***/
     },
     /* 22 */
-    [833, 19, 13, 5, 11, 7],
+    [832, 19, 13, 5, 11, 7],
     /* 23 */
-    [834, 4],
+    [833, 4],
     /* 24 */
-    [835, 11, 5, 25],
+    [834, 11, 5, 25],
     /* 25 */
-    [836, 23, 19, 4],
+    [835, 23, 19, 4],
     /* 26 */
-    [837, 25],
+    [836, 25],
     /* 27 */
-    [838, 4, 9, 28, 26, 11],
+    [837, 4, 9, 28, 26, 11],
     /* 28 */
     /***/ function(module, exports) {
       module.exports = false;
@@ -567,15 +567,15 @@
       /***/
     },
     /* 29 */
-    [839, 30, 42, 43],
+    [838, 30, 42, 43],
     /* 30 */
-    [840, 31, 41],
+    [839, 31, 41],
     /* 31 */
-    [841, 5, 32, 36, 40],
+    [840, 5, 32, 36, 40],
     /* 32 */
-    [842, 33, 35],
+    [841, 33, 35],
     /* 33 */
-    [843, 34],
+    [842, 34],
     /* 34 */
     /***/ function(module, exports) {
       var toString = {}.toString;
@@ -597,9 +597,9 @@
       /***/
     },
     /* 36 */
-    [844, 32, 37, 39],
+    [843, 32, 37, 39],
     /* 37 */
-    [845, 38],
+    [844, 38],
     /* 38 */
     /***/ function(module, exports) {
       // 7.1.4 ToInteger
@@ -612,9 +612,9 @@
       /***/
     },
     /* 39 */
-    [846, 38],
+    [845, 38],
     /* 40 */
-    [847, 23, 19],
+    [846, 23, 19],
     /* 41 */
     /***/ function(module, exports) {
       // IE 8- don't enum bug keys
@@ -637,21 +637,21 @@
       /***/
     },
     /* 44 */
-    [848, 34],
+    [847, 34],
     /* 45 */
-    [849, 12, 46, 41, 40, 15, 47],
+    [848, 12, 46, 41, 40, 15, 47],
     /* 46 */
-    [850, 11, 12, 30, 6],
+    [849, 11, 12, 30, 6],
     /* 47 */
-    [851, 4],
+    [850, 4],
     /* 48 */
-    [852, 32, 49],
+    [851, 32, 49],
     /* 49 */
-    [853, 31, 41],
+    [852, 31, 41],
     /* 50 */
-    [854, 43, 17, 32, 16, 5, 14, 6],
+    [853, 43, 17, 32, 16, 5, 14, 6],
     /* 51 */
-    [855, 8, 45],
+    [854, 8, 45],
     /* 52 */
     /***/ function(module, exports, __webpack_require__) {
       var $export = __webpack_require__(8);
@@ -724,9 +724,9 @@
       /***/
     },
     /* 57 */
-    [856, 35],
+    [855, 35],
     /* 58 */
-    [857, 5, 57, 40],
+    [856, 5, 57, 40],
     /* 59 */
     /***/ function(module, exports, __webpack_require__) {
       // 19.1.2.14 Object.keys(O)
@@ -840,9 +840,9 @@
       /***/
     },
     /* 67 */
-    [858, 8, 68],
+    [857, 8, 68],
     /* 68 */
-    [859, 30, 42, 43, 57, 33, 7],
+    [858, 30, 42, 43, 57, 33, 7],
     /* 69 */
     /***/ function(module, exports, __webpack_require__) {
       // 19.1.3.10 Object.is(value1, value2)
@@ -864,9 +864,9 @@
       /***/
     },
     /* 71 */
-    [860, 8, 72],
+    [859, 8, 72],
     /* 72 */
-    [861, 13, 12, 20, 50],
+    [860, 13, 12, 20, 50],
     /* 73 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
@@ -2044,11 +2044,11 @@
       /***/
     },
     /* 126 */
-    [862, 127, 128],
+    [861, 127, 128],
     /* 127 */
-    [863, 38, 35],
+    [862, 38, 35],
     /* 128 */
-    [864, 28, 8, 18, 10, 5, 129, 130, 24, 58, 25],
+    [863, 28, 8, 18, 10, 5, 129, 130, 24, 58, 25],
     /* 129 */
     /***/ function(module, exports) {
       module.exports = {};
@@ -2056,7 +2056,7 @@
       /***/
     },
     /* 130 */
-    [865, 45, 17, 24, 10, 25],
+    [864, 45, 17, 24, 10, 25],
     /* 131 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
@@ -3417,7 +3417,7 @@
       /***/
     },
     /* 194 */
-    [866, 187, 195, 129, 32, 128],
+    [865, 187, 195, 129, 32, 128],
     /* 195 */
     /***/ function(module, exports) {
       module.exports = function(done, value) {
@@ -6849,9 +6849,9 @@
       /***/
     },
     /* 264 */
-    [867, 27],
+    [866, 27],
     /* 265 */
-    [868, 27],
+    [867, 27],
     /* 266 */
     /***/ function(module, exports, __webpack_require__) {
       // https://github.com/tc39/proposal-object-getownpropertydescriptors
@@ -15543,7 +15543,7 @@
 
       var _example_components2 = _interopRequireDefault(_example_components);
 
-      var _hero_example = __webpack_require__(823);
+      var _hero_example = __webpack_require__(822);
 
       var _hero_example2 = _interopRequireDefault(_hero_example);
 
@@ -15755,257 +15755,257 @@
 
       var _default2 = _interopRequireDefault(_default);
 
-      var _code_example_component = __webpack_require__(736);
+      var _code_example_component = __webpack_require__(735);
 
       var _code_example_component2 = _interopRequireDefault(
         _code_example_component
       );
 
-      var _custom_date_format = __webpack_require__(737);
+      var _custom_date_format = __webpack_require__(736);
 
       var _custom_date_format2 = _interopRequireDefault(_custom_date_format);
 
-      var _custom_class_name = __webpack_require__(738);
+      var _custom_class_name = __webpack_require__(737);
 
       var _custom_class_name2 = _interopRequireDefault(_custom_class_name);
 
-      var _custom_calendar_class_name = __webpack_require__(739);
+      var _custom_calendar_class_name = __webpack_require__(738);
 
       var _custom_calendar_class_name2 = _interopRequireDefault(
         _custom_calendar_class_name
       );
 
-      var _custom_day_class_names = __webpack_require__(740);
+      var _custom_day_class_names = __webpack_require__(739);
 
       var _custom_day_class_names2 = _interopRequireDefault(
         _custom_day_class_names
       );
 
-      var _placeholder_text = __webpack_require__(741);
+      var _placeholder_text = __webpack_require__(740);
 
       var _placeholder_text2 = _interopRequireDefault(_placeholder_text);
 
-      var _specific_date_range = __webpack_require__(742);
+      var _specific_date_range = __webpack_require__(741);
 
       var _specific_date_range2 = _interopRequireDefault(_specific_date_range);
 
-      var _min_date = __webpack_require__(743);
+      var _min_date = __webpack_require__(742);
 
       var _min_date2 = _interopRequireDefault(_min_date);
 
-      var _max_date = __webpack_require__(744);
+      var _max_date = __webpack_require__(743);
 
       var _max_date2 = _interopRequireDefault(_max_date);
 
-      var _locale = __webpack_require__(745);
+      var _locale = __webpack_require__(744);
 
       var _locale2 = _interopRequireDefault(_locale);
 
-      var _locale_without_global_variable = __webpack_require__(748);
+      var _locale_without_global_variable = __webpack_require__(747);
 
       var _locale_without_global_variable2 = _interopRequireDefault(
         _locale_without_global_variable
       );
 
-      var _exclude_dates = __webpack_require__(755);
+      var _exclude_dates = __webpack_require__(754);
 
       var _exclude_dates2 = _interopRequireDefault(_exclude_dates);
 
-      var _highlight_dates = __webpack_require__(756);
+      var _highlight_dates = __webpack_require__(755);
 
       var _highlight_dates2 = _interopRequireDefault(_highlight_dates);
 
-      var _highlight_dates_with_ranges = __webpack_require__(757);
+      var _highlight_dates_with_ranges = __webpack_require__(756);
 
       var _highlight_dates_with_ranges2 = _interopRequireDefault(
         _highlight_dates_with_ranges
       );
 
-      var _include_dates = __webpack_require__(758);
+      var _include_dates = __webpack_require__(757);
 
       var _include_dates2 = _interopRequireDefault(_include_dates);
 
-      var _filter_dates = __webpack_require__(759);
+      var _filter_dates = __webpack_require__(758);
 
       var _filter_dates2 = _interopRequireDefault(_filter_dates);
 
-      var _disabled = __webpack_require__(760);
+      var _disabled = __webpack_require__(759);
 
       var _disabled2 = _interopRequireDefault(_disabled);
 
-      var _disabled_keyboard_navigation = __webpack_require__(761);
+      var _disabled_keyboard_navigation = __webpack_require__(760);
 
       var _disabled_keyboard_navigation2 = _interopRequireDefault(
         _disabled_keyboard_navigation
       );
 
-      var _clear_input = __webpack_require__(762);
+      var _clear_input = __webpack_require__(761);
 
       var _clear_input2 = _interopRequireDefault(_clear_input);
 
-      var _on_blur_callbacks = __webpack_require__(763);
+      var _on_blur_callbacks = __webpack_require__(762);
 
       var _on_blur_callbacks2 = _interopRequireDefault(_on_blur_callbacks);
 
-      var _configurePopper = __webpack_require__(764);
+      var _configurePopper = __webpack_require__(763);
 
       var _configurePopper2 = _interopRequireDefault(_configurePopper);
 
-      var _date_range = __webpack_require__(765);
+      var _date_range = __webpack_require__(764);
 
       var _date_range2 = _interopRequireDefault(_date_range);
 
-      var _date_range_with_show_disabled_navigation = __webpack_require__(766);
+      var _date_range_with_show_disabled_navigation = __webpack_require__(765);
 
       var _date_range_with_show_disabled_navigation2 = _interopRequireDefault(
         _date_range_with_show_disabled_navigation
       );
 
-      var _tab_index = __webpack_require__(767);
+      var _tab_index = __webpack_require__(766);
 
       var _tab_index2 = _interopRequireDefault(_tab_index);
 
-      var _year_dropdown = __webpack_require__(768);
+      var _year_dropdown = __webpack_require__(767);
 
       var _year_dropdown2 = _interopRequireDefault(_year_dropdown);
 
-      var _month_dropdown = __webpack_require__(769);
+      var _month_dropdown = __webpack_require__(768);
 
       var _month_dropdown2 = _interopRequireDefault(_month_dropdown);
 
-      var _month_year_dropdown = __webpack_require__(770);
+      var _month_year_dropdown = __webpack_require__(769);
 
       var _month_year_dropdown2 = _interopRequireDefault(_month_year_dropdown);
 
-      var _month_dropdown_short = __webpack_require__(771);
+      var _month_dropdown_short = __webpack_require__(770);
 
       var _month_dropdown_short2 = _interopRequireDefault(
         _month_dropdown_short
       );
 
-      var _year_select_dropdown = __webpack_require__(772);
+      var _year_select_dropdown = __webpack_require__(771);
 
       var _year_select_dropdown2 = _interopRequireDefault(
         _year_select_dropdown
       );
 
-      var _today = __webpack_require__(773);
+      var _today = __webpack_require__(772);
 
       var _today2 = _interopRequireDefault(_today);
 
-      var _inline = __webpack_require__(774);
+      var _inline = __webpack_require__(773);
 
       var _inline2 = _interopRequireDefault(_inline);
 
-      var _open_to_date = __webpack_require__(775);
+      var _open_to_date = __webpack_require__(774);
 
       var _open_to_date2 = _interopRequireDefault(_open_to_date);
 
-      var _fixed_calendar = __webpack_require__(776);
+      var _fixed_calendar = __webpack_require__(775);
 
       var _fixed_calendar2 = _interopRequireDefault(_fixed_calendar);
 
-      var _week_numbers = __webpack_require__(777);
+      var _week_numbers = __webpack_require__(776);
 
       var _week_numbers2 = _interopRequireDefault(_week_numbers);
 
-      var _custom_input = __webpack_require__(778);
+      var _custom_input = __webpack_require__(777);
 
       var _custom_input2 = _interopRequireDefault(_custom_input);
 
-      var _multi_month = __webpack_require__(779);
+      var _multi_month = __webpack_require__(778);
 
       var _multi_month2 = _interopRequireDefault(_multi_month);
 
-      var _multi_month_drp = __webpack_require__(780);
+      var _multi_month_drp = __webpack_require__(779);
 
       var _multi_month_drp2 = _interopRequireDefault(_multi_month_drp);
 
-      var _multi_month_inline = __webpack_require__(781);
+      var _multi_month_inline = __webpack_require__(780);
 
       var _multi_month_inline2 = _interopRequireDefault(_multi_month_inline);
 
-      var _children = __webpack_require__(782);
+      var _children = __webpack_require__(781);
 
       var _children2 = _interopRequireDefault(_children);
 
-      var _calendar_container = __webpack_require__(783);
+      var _calendar_container = __webpack_require__(782);
 
       var _calendar_container2 = _interopRequireDefault(_calendar_container);
 
-      var _portal = __webpack_require__(784);
+      var _portal = __webpack_require__(783);
 
       var _portal2 = _interopRequireDefault(_portal);
 
-      var _inline_portal = __webpack_require__(785);
+      var _inline_portal = __webpack_require__(784);
 
       var _inline_portal2 = _interopRequireDefault(_inline_portal);
 
-      var _raw_change = __webpack_require__(786);
+      var _raw_change = __webpack_require__(785);
 
       var _raw_change2 = _interopRequireDefault(_raw_change);
 
-      var _read_only = __webpack_require__(787);
+      var _read_only = __webpack_require__(786);
 
       var _read_only2 = _interopRequireDefault(_read_only);
 
-      var _show_time = __webpack_require__(788);
+      var _show_time = __webpack_require__(787);
 
       var _show_time2 = _interopRequireDefault(_show_time);
 
-      var _show_time_only = __webpack_require__(789);
+      var _show_time_only = __webpack_require__(788);
 
       var _show_time_only2 = _interopRequireDefault(_show_time_only);
 
-      var _exclude_times = __webpack_require__(790);
+      var _exclude_times = __webpack_require__(789);
 
       var _exclude_times2 = _interopRequireDefault(_exclude_times);
 
-      var _exclude_time_period = __webpack_require__(791);
+      var _exclude_time_period = __webpack_require__(790);
 
       var _exclude_time_period2 = _interopRequireDefault(_exclude_time_period);
 
-      var _include_times = __webpack_require__(792);
+      var _include_times = __webpack_require__(791);
 
       var _include_times2 = _interopRequireDefault(_include_times);
 
-      var _inject_times = __webpack_require__(793);
+      var _inject_times = __webpack_require__(792);
 
       var _inject_times2 = _interopRequireDefault(_inject_times);
 
-      var _dont_close_onSelect = __webpack_require__(794);
+      var _dont_close_onSelect = __webpack_require__(793);
 
       var _dont_close_onSelect2 = _interopRequireDefault(_dont_close_onSelect);
 
-      var _render_custom_header = __webpack_require__(795);
+      var _render_custom_header = __webpack_require__(794);
 
       var _render_custom_header2 = _interopRequireDefault(
         _render_custom_header
       );
 
-      var _render_custom_day = __webpack_require__(816);
+      var _render_custom_day = __webpack_require__(815);
 
       var _render_custom_day2 = _interopRequireDefault(_render_custom_day);
 
-      var _timeInput = __webpack_require__(817);
+      var _timeInput = __webpack_require__(816);
 
       var _timeInput2 = _interopRequireDefault(_timeInput);
 
-      var _strict_parsing = __webpack_require__(818);
+      var _strict_parsing = __webpack_require__(817);
 
       var _strict_parsing2 = _interopRequireDefault(_strict_parsing);
 
-      var _month_picker = __webpack_require__(819);
+      var _month_picker = __webpack_require__(818);
 
       var _month_picker2 = _interopRequireDefault(_month_picker);
 
-      var _range_month_picker = __webpack_require__(820);
+      var _range_month_picker = __webpack_require__(819);
 
       var _range_month_picker2 = _interopRequireDefault(_range_month_picker);
 
-      __webpack_require__(821);
+      __webpack_require__(820);
 
-      __webpack_require__(822);
+      __webpack_require__(821);
 
       function _interopRequireDefault(obj) {
         return obj && obj.__esModule ? obj : { default: obj };
@@ -40858,7 +40858,7 @@
 
       var _calendar2 = _interopRequireDefault(_calendar);
 
-      var _popper_component = __webpack_require__(636);
+      var _popper_component = __webpack_require__(635);
 
       var _popper_component2 = _interopRequireDefault(_popper_component);
 
@@ -40868,7 +40868,7 @@
 
       var _date_utils = __webpack_require__(542);
 
-      var _reactOnclickoutside = __webpack_require__(625);
+      var _reactOnclickoutside = __webpack_require__(624);
 
       var _reactOnclickoutside2 = _interopRequireDefault(_reactOnclickoutside);
 
@@ -40934,14 +40934,6 @@
         }
 
         return date1 !== date2;
-      }
-
-      function hasSelectionChanged(date1, date2) {
-        if (date1 && date2) {
-          return !(0, _date_utils.isEqual)(date1, date2);
-        }
-
-        return false;
       }
 
       /**
@@ -41234,7 +41226,7 @@
             }
 
             if (
-              !(0, _date_utils.isSameDay)(_this.props.selected, changedDate) ||
+              !(0, _date_utils.isEqual)(_this.props.selected, changedDate) ||
               _this.props.allowSameDay
             ) {
               if (changedDate !== null) {
@@ -41610,7 +41602,7 @@
           }
           if (
             !prevState.focused &&
-            hasSelectionChanged(prevProps.selected, this.props.selected)
+            !(0, _date_utils.isEqual)(prevProps.selected, this.props.selected)
           ) {
             this.setState({ inputValue: null });
           }
@@ -41730,9 +41722,9 @@
       /***/
     },
     /* 534 */
-    [869, 535],
+    [868, 535],
     /* 535 */
-    [870, 331, 536, 537],
+    [869, 331, 536, 537],
     /* 536 */
     /***/ function(module, exports, __webpack_require__) {
       /**
@@ -41854,23 +41846,23 @@
 
       var _year_dropdown2 = _interopRequireDefault(_year_dropdown);
 
-      var _month_dropdown = __webpack_require__(626);
+      var _month_dropdown = __webpack_require__(625);
 
       var _month_dropdown2 = _interopRequireDefault(_month_dropdown);
 
-      var _month_year_dropdown = __webpack_require__(628);
+      var _month_year_dropdown = __webpack_require__(627);
 
       var _month_year_dropdown2 = _interopRequireDefault(_month_year_dropdown);
 
-      var _month = __webpack_require__(630);
+      var _month = __webpack_require__(629);
 
       var _month2 = _interopRequireDefault(_month);
 
-      var _time = __webpack_require__(634);
+      var _time = __webpack_require__(633);
 
       var _time2 = _interopRequireDefault(_time);
 
-      var _inputTime = __webpack_require__(635);
+      var _inputTime = __webpack_require__(634);
 
       var _inputTime2 = _interopRequireDefault(_inputTime);
 
@@ -42703,7 +42695,7 @@
         _year_dropdown_options
       );
 
-      var _reactOnclickoutside = __webpack_require__(625);
+      var _reactOnclickoutside = __webpack_require__(624);
 
       var _reactOnclickoutside2 = _interopRequireDefault(_reactOnclickoutside);
 
@@ -43227,7 +43219,7 @@
         "use strict";
 
         exports.__esModule = true;
-        exports.isEqual = exports.isAfter = exports.isBefore = exports.subYears = exports.subMonths = exports.subWeeks = exports.subDays = exports.subHours = exports.subMinutes = exports.addYears = exports.addMonths = exports.addWeeks = exports.addDays = exports.addMinutes = exports.getTime = exports.getDate = exports.getDay = exports.getYear = exports.getMonth = exports.getHours = exports.getMinutes = exports.getSeconds = exports.setYear = exports.setMonth = exports.isDate = undefined;
+        exports.isAfter = exports.isBefore = exports.subYears = exports.subMonths = exports.subWeeks = exports.subDays = exports.subHours = exports.subMinutes = exports.addYears = exports.addMonths = exports.addWeeks = exports.addDays = exports.addMinutes = exports.getTime = exports.getDate = exports.getDay = exports.getYear = exports.getMonth = exports.getHours = exports.getMinutes = exports.getSeconds = exports.setYear = exports.setMonth = exports.isDate = undefined;
 
         var _typeof =
           typeof Symbol === "function" && typeof Symbol.iterator === "symbol"
@@ -43260,6 +43252,7 @@
         exports.isSameYear = isSameYear;
         exports.isSameMonth = isSameMonth;
         exports.isSameDay = isSameDay;
+        exports.isEqual = isEqual;
         exports.isDayInRange = isDayInRange;
         exports.getDaysDiff = getDaysDiff;
         exports.registerLocale = registerLocale;
@@ -43454,31 +43447,27 @@
 
         var _isEqual2 = _interopRequireDefault(_isEqual);
 
-        var _isSameWeek = __webpack_require__(612);
-
-        var _isSameWeek2 = _interopRequireDefault(_isSameWeek);
-
-        var _isSameDay = __webpack_require__(613);
+        var _isSameDay = __webpack_require__(612);
 
         var _isSameDay2 = _interopRequireDefault(_isSameDay);
 
-        var _isSameMonth = __webpack_require__(614);
+        var _isSameMonth = __webpack_require__(613);
 
         var _isSameMonth2 = _interopRequireDefault(_isSameMonth);
 
-        var _isSameYear = __webpack_require__(615);
+        var _isSameYear = __webpack_require__(614);
 
         var _isSameYear2 = _interopRequireDefault(_isSameYear);
 
-        var _isAfter = __webpack_require__(616);
+        var _isAfter = __webpack_require__(615);
 
         var _isAfter2 = _interopRequireDefault(_isAfter);
 
-        var _isBefore = __webpack_require__(617);
+        var _isBefore = __webpack_require__(616);
 
         var _isBefore2 = _interopRequireDefault(_isBefore);
 
-        var _isWithinInterval = __webpack_require__(618);
+        var _isWithinInterval = __webpack_require__(617);
 
         var _isWithinInterval2 = _interopRequireDefault(_isWithinInterval);
 
@@ -43486,7 +43475,7 @@
 
         var _toDate2 = _interopRequireDefault(_toDate);
 
-        var _parse = __webpack_require__(619);
+        var _parse = __webpack_require__(618);
 
         var _parse2 = _interopRequireDefault(_parse);
 
@@ -43710,7 +43699,6 @@
 
         exports.isBefore = _isBefore2.default;
         exports.isAfter = _isAfter2.default;
-        exports.isEqual = _isEqual2.default;
         function isSameYear(date1, date2) {
           if (date1 && date2) {
             return (0, _isSameYear2.default)(date1, date2);
@@ -43730,6 +43718,14 @@
         function isSameDay(date1, date2) {
           if (date1 && date2) {
             return (0, _isSameDay2.default)(date1, date2);
+          } else {
+            return !date1 && !date2;
+          }
+        }
+
+        function isEqual(date1, date2) {
+          if (date1 && date2) {
+            return (0, _isEqual2.default)(date1, date2);
           } else {
             return !date1 && !date2;
           }
@@ -43856,10 +43852,8 @@
             return startDateMonth <= m && m <= endDateMonth;
           } else if (startDateYear < endDateYear) {
             return (
-              (dayYear === startDateYear &&
-                (startDateMonth <= m || endDateMonth < m)) ||
-              (dayYear === endDateYear &&
-                (startDateMonth > m || endDateMonth >= m)) ||
+              (dayYear === startDateYear && startDateMonth <= m) ||
+              (dayYear === endDateYear && endDateMonth >= m) ||
               (dayYear < endDateYear && dayYear > startDateYear)
             );
           }
@@ -50148,82 +50142,6 @@
       Object.defineProperty(exports, "__esModule", {
         value: true
       });
-      exports.default = isSameWeek;
-
-      var _index = __webpack_require__(605);
-
-      var _index2 = _interopRequireDefault(_index);
-
-      function _interopRequireDefault(obj) {
-        return obj && obj.__esModule ? obj : { default: obj };
-      }
-
-      /**
-       * @name isSameWeek
-       * @category Week Helpers
-       * @summary Are the given dates in the same week?
-       *
-       * @description
-       * Are the given dates in the same week?
-       *
-       * @param {Date|String|Number} dateLeft - the first date to check
-       * @param {Date|String|Number} dateRight - the second date to check
-       * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
-       * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
-       * @param {0|1|2|3|4|5|6} [options.weekStartsOn=0] - the index of the first day of the week (0 - Sunday)
-       * @param {Locale} [options.locale=defaultLocale] - the locale object. See [Locale]{@link https://date-fns.org/docs/Locale}
-       * @returns {Boolean} the dates are in the same week
-       * @throws {TypeError} 2 arguments required
-       * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
-       * @throws {RangeError} `options.weekStartsOn` must be between 0 and 6
-       *
-       * @example
-       * // Are 31 August 2014 and 4 September 2014 in the same week?
-       * var result = isSameWeek(
-       *   new Date(2014, 7, 31),
-       *   new Date(2014, 8, 4)
-       * )
-       * //=> true
-       *
-       * @example
-       * // If week starts with Monday,
-       * // are 31 August 2014 and 4 September 2014 in the same week?
-       * var result = isSameWeek(
-       *   new Date(2014, 7, 31),
-       *   new Date(2014, 8, 4),
-       *   {weekStartsOn: 1}
-       * )
-       * //=> false
-       */
-      function isSameWeek(dirtyDateLeft, dirtyDateRight, dirtyOptions) {
-        if (arguments.length < 2) {
-          throw new TypeError(
-            "2 arguments required, but only " + arguments.length + " present"
-          );
-        }
-
-        var dateLeftStartOfWeek = (0, _index2.default)(
-          dirtyDateLeft,
-          dirtyOptions
-        );
-        var dateRightStartOfWeek = (0, _index2.default)(
-          dirtyDateRight,
-          dirtyOptions
-        );
-
-        return dateLeftStartOfWeek.getTime() === dateRightStartOfWeek.getTime();
-      }
-      module.exports = exports["default"];
-
-      /***/
-    },
-    /* 613 */
-    /***/ function(module, exports, __webpack_require__) {
-      "use strict";
-
-      Object.defineProperty(exports, "__esModule", {
-        value: true
-      });
       exports.default = isSameDay;
 
       var _index = __webpack_require__(602);
@@ -50280,7 +50198,7 @@
 
       /***/
     },
-    /* 614 */
+    /* 613 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -50339,7 +50257,7 @@
 
       /***/
     },
-    /* 615 */
+    /* 614 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -50395,7 +50313,7 @@
 
       /***/
     },
-    /* 616 */
+    /* 615 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -50451,7 +50369,7 @@
 
       /***/
     },
-    /* 617 */
+    /* 616 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -50507,7 +50425,7 @@
 
       /***/
     },
-    /* 618 */
+    /* 617 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -50587,7 +50505,7 @@
 
       /***/
     },
-    /* 619 */
+    /* 618 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -50616,7 +50534,7 @@
 
       var _index10 = _interopRequireDefault(_index9);
 
-      var _index11 = __webpack_require__(620);
+      var _index11 = __webpack_require__(619);
 
       var _index12 = _interopRequireDefault(_index11);
 
@@ -51130,7 +51048,7 @@
 
       /***/
     },
-    /* 620 */
+    /* 619 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -51142,11 +51060,11 @@
 
       var _index2 = _interopRequireDefault(_index);
 
-      var _index3 = __webpack_require__(621);
+      var _index3 = __webpack_require__(620);
 
       var _index4 = _interopRequireDefault(_index3);
 
-      var _index5 = __webpack_require__(622);
+      var _index5 = __webpack_require__(621);
 
       var _index6 = _interopRequireDefault(_index5);
 
@@ -51154,11 +51072,11 @@
 
       var _index8 = _interopRequireDefault(_index7);
 
-      var _index9 = __webpack_require__(623);
+      var _index9 = __webpack_require__(622);
 
       var _index10 = _interopRequireDefault(_index9);
 
-      var _index11 = __webpack_require__(624);
+      var _index11 = __webpack_require__(623);
 
       var _index12 = _interopRequireDefault(_index11);
 
@@ -52684,7 +52602,7 @@
 
       /***/
     },
-    /* 621 */
+    /* 620 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -52751,7 +52669,7 @@
 
       /***/
     },
-    /* 622 */
+    /* 621 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -52795,7 +52713,7 @@
 
       /***/
     },
-    /* 623 */
+    /* 622 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -52847,7 +52765,7 @@
 
       /***/
     },
-    /* 624 */
+    /* 623 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -52891,7 +52809,7 @@
 
       /***/
     },
-    /* 625 */
+    /* 624 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -53290,7 +53208,7 @@
 
       /***/
     },
-    /* 626 */
+    /* 625 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -53304,13 +53222,13 @@
 
       var _propTypes2 = _interopRequireDefault(_propTypes);
 
-      var _month_dropdown_options = __webpack_require__(627);
+      var _month_dropdown_options = __webpack_require__(626);
 
       var _month_dropdown_options2 = _interopRequireDefault(
         _month_dropdown_options
       );
 
-      var _reactOnclickoutside = __webpack_require__(625);
+      var _reactOnclickoutside = __webpack_require__(624);
 
       var _reactOnclickoutside2 = _interopRequireDefault(_reactOnclickoutside);
 
@@ -53528,7 +53446,7 @@
 
       /***/
     },
-    /* 627 */
+    /* 626 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -53658,7 +53576,7 @@
 
       /***/
     },
-    /* 628 */
+    /* 627 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -53672,13 +53590,13 @@
 
       var _propTypes2 = _interopRequireDefault(_propTypes);
 
-      var _month_year_dropdown_options = __webpack_require__(629);
+      var _month_year_dropdown_options = __webpack_require__(628);
 
       var _month_year_dropdown_options2 = _interopRequireDefault(
         _month_year_dropdown_options
       );
 
-      var _reactOnclickoutside = __webpack_require__(625);
+      var _reactOnclickoutside = __webpack_require__(624);
 
       var _reactOnclickoutside2 = _interopRequireDefault(_reactOnclickoutside);
 
@@ -53911,7 +53829,7 @@
 
       /***/
     },
-    /* 629 */
+    /* 628 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -54068,7 +53986,7 @@
 
       /***/
     },
-    /* 630 */
+    /* 629 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -54086,7 +54004,7 @@
 
       var _classnames2 = _interopRequireDefault(_classnames);
 
-      var _week = __webpack_require__(631);
+      var _week = __webpack_require__(630);
 
       var _week2 = _interopRequireDefault(_week);
 
@@ -54367,7 +54285,7 @@
 
       /***/
     },
-    /* 631 */
+    /* 630 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -54398,11 +54316,11 @@
 
       var _propTypes2 = _interopRequireDefault(_propTypes);
 
-      var _day = __webpack_require__(632);
+      var _day = __webpack_require__(631);
 
       var _day2 = _interopRequireDefault(_day);
 
-      var _week_number = __webpack_require__(633);
+      var _week_number = __webpack_require__(632);
 
       var _week_number2 = _interopRequireDefault(_week_number);
 
@@ -54595,7 +54513,7 @@
 
       /***/
     },
-    /* 632 */
+    /* 631 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -54902,7 +54820,7 @@
 
       /***/
     },
-    /* 633 */
+    /* 632 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -55017,7 +54935,7 @@
 
       /***/
     },
-    /* 634 */
+    /* 633 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -55332,7 +55250,7 @@
 
       /***/
     },
-    /* 635 */
+    /* 634 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -55456,7 +55374,7 @@
 
       /***/
     },
-    /* 636 */
+    /* 635 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -55506,7 +55424,7 @@
 
       var _propTypes2 = _interopRequireDefault(_propTypes);
 
-      var _reactPopper = __webpack_require__(637);
+      var _reactPopper = __webpack_require__(636);
 
       function _interopRequireDefault(obj) {
         return obj && obj.__esModule ? obj : { default: obj };
@@ -55667,7 +55585,7 @@
 
       /***/
     },
-    /* 637 */
+    /* 636 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -55676,15 +55594,15 @@
       });
       exports.Reference = exports.Manager = exports.placements = exports.Popper = undefined;
 
-      var _Popper = __webpack_require__(638);
+      var _Popper = __webpack_require__(637);
 
       var _Popper2 = _interopRequireDefault(_Popper);
 
-      var _Manager = __webpack_require__(722);
+      var _Manager = __webpack_require__(721);
 
       var _Manager2 = _interopRequireDefault(_Manager);
 
-      var _Reference = __webpack_require__(734);
+      var _Reference = __webpack_require__(733);
 
       var _Reference2 = _interopRequireDefault(_Reference);
 
@@ -55703,7 +55621,7 @@
 
       /***/
     },
-    /* 638 */
+    /* 637 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -55712,21 +55630,21 @@
       });
       exports.placements = exports.InnerPopper = undefined;
 
-      var _extends2 = __webpack_require__(639);
+      var _extends2 = __webpack_require__(638);
 
       var _extends3 = _interopRequireDefault(_extends2);
 
-      var _classCallCheck2 = __webpack_require__(677);
+      var _classCallCheck2 = __webpack_require__(676);
 
       var _classCallCheck3 = _interopRequireDefault(_classCallCheck2);
 
-      var _possibleConstructorReturn2 = __webpack_require__(678);
+      var _possibleConstructorReturn2 = __webpack_require__(677);
 
       var _possibleConstructorReturn3 = _interopRequireDefault(
         _possibleConstructorReturn2
       );
 
-      var _inherits2 = __webpack_require__(713);
+      var _inherits2 = __webpack_require__(712);
 
       var _inherits3 = _interopRequireDefault(_inherits2);
 
@@ -55736,13 +55654,13 @@
 
       var React = _interopRequireWildcard(_react);
 
-      var _popper = __webpack_require__(721);
+      var _popper = __webpack_require__(720);
 
       var _popper2 = _interopRequireDefault(_popper);
 
-      var _Manager = __webpack_require__(722);
+      var _Manager = __webpack_require__(721);
 
-      var _utils = __webpack_require__(733);
+      var _utils = __webpack_require__(732);
 
       function _interopRequireWildcard(obj) {
         if (obj && obj.__esModule) {
@@ -55969,13 +55887,13 @@
 
       /***/
     },
-    /* 639 */
+    /* 638 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
       exports.__esModule = true;
 
-      var _assign = __webpack_require__(640);
+      var _assign = __webpack_require__(639);
 
       var _assign2 = _interopRequireDefault(_assign);
 
@@ -56001,27 +55919,27 @@
 
       /***/
     },
+    /* 639 */
+    /***/ function(module, exports, __webpack_require__) {
+      module.exports = { default: __webpack_require__(640), __esModule: true };
+
+      /***/
+    },
     /* 640 */
     /***/ function(module, exports, __webpack_require__) {
-      module.exports = { default: __webpack_require__(641), __esModule: true };
+      __webpack_require__(641);
+      module.exports = __webpack_require__(644).Object.assign;
 
       /***/
     },
     /* 641 */
-    /***/ function(module, exports, __webpack_require__) {
-      __webpack_require__(642);
-      module.exports = __webpack_require__(645).Object.assign;
-
-      /***/
-    },
+    [857, 642, 657],
     /* 642 */
-    [858, 643, 658],
-    /* 643 */
     /***/ function(module, exports, __webpack_require__) {
-      var global = __webpack_require__(644);
-      var core = __webpack_require__(645);
-      var ctx = __webpack_require__(646);
-      var hide = __webpack_require__(648);
+      var global = __webpack_require__(643);
+      var core = __webpack_require__(644);
+      var ctx = __webpack_require__(645);
+      var hide = __webpack_require__(647);
       var PROTOTYPE = "prototype";
 
       var $export = function(type, name, source) {
@@ -56099,73 +56017,73 @@
 
       /***/
     },
-    /* 644 */
+    /* 643 */
     4,
-    /* 645 */
+    /* 644 */
     9,
+    /* 645 */
+    [831, 646],
     /* 646 */
-    [832, 647],
-    /* 647 */
     21,
+    /* 647 */
+    [825, 648, 656, 652],
     /* 648 */
-    [826, 649, 657, 653],
+    [826, 649, 651, 655, 652],
     /* 649 */
-    [827, 650, 652, 656, 653],
+    [827, 650],
     /* 650 */
-    [828, 651],
-    /* 651 */
     13,
+    /* 651 */
+    [828, 652, 653, 654],
     /* 652 */
-    [829, 653, 654, 655],
+    [824, 653],
     /* 653 */
-    [825, 654],
-    /* 654 */
     7,
+    /* 654 */
+    [829, 650, 643],
     /* 655 */
-    [830, 651, 644],
+    [830, 650],
     /* 656 */
-    [831, 651],
-    /* 657 */
     17,
+    /* 657 */
+    [858, 658, 673, 674, 675, 662, 653],
     /* 658 */
-    [859, 659, 674, 675, 676, 663, 654],
+    [839, 659, 672],
     /* 659 */
-    [840, 660, 673],
+    [840, 660, 661, 665, 669],
     /* 660 */
-    [841, 661, 662, 666, 670],
-    /* 661 */
     5,
+    /* 661 */
+    [841, 662, 664],
     /* 662 */
-    [842, 663, 665],
+    [842, 663],
     /* 663 */
-    [843, 664],
-    /* 664 */
     34,
-    /* 665 */
+    /* 664 */
     35,
+    /* 665 */
+    [843, 661, 666, 668],
     /* 666 */
-    [844, 662, 667, 669],
+    [844, 667],
     /* 667 */
-    [845, 668],
-    /* 668 */
     38,
+    /* 668 */
+    [845, 667],
     /* 669 */
-    [846, 668],
+    [846, 670, 671],
     /* 670 */
-    [847, 671, 672],
+    [833, 643],
     /* 671 */
-    [834, 644],
-    /* 672 */
     19,
-    /* 673 */
+    /* 672 */
     41,
-    /* 674 */
+    /* 673 */
     42,
-    /* 675 */
+    /* 674 */
     43,
+    /* 675 */
+    [855, 664],
     /* 676 */
-    [856, 665],
-    /* 677 */
     /***/ function(module, exports) {
       "use strict";
 
@@ -56179,13 +56097,13 @@
 
       /***/
     },
-    /* 678 */
+    /* 677 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
       exports.__esModule = true;
 
-      var _typeof2 = __webpack_require__(679);
+      var _typeof2 = __webpack_require__(678);
 
       var _typeof3 = _interopRequireDefault(_typeof2);
 
@@ -56211,17 +56129,17 @@
 
       /***/
     },
-    /* 679 */
+    /* 678 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
       exports.__esModule = true;
 
-      var _iterator = __webpack_require__(680);
+      var _iterator = __webpack_require__(679);
 
       var _iterator2 = _interopRequireDefault(_iterator);
 
-      var _symbol = __webpack_require__(700);
+      var _symbol = __webpack_require__(699);
 
       var _symbol2 = _interopRequireDefault(_symbol);
 
@@ -56263,61 +56181,61 @@
 
       /***/
     },
+    /* 679 */
+    /***/ function(module, exports, __webpack_require__) {
+      module.exports = { default: __webpack_require__(680), __esModule: true };
+
+      /***/
+    },
     /* 680 */
     /***/ function(module, exports, __webpack_require__) {
-      module.exports = { default: __webpack_require__(681), __esModule: true };
+      __webpack_require__(681);
+      __webpack_require__(694);
+      module.exports = __webpack_require__(698).f("iterator");
 
       /***/
     },
     /* 681 */
-    /***/ function(module, exports, __webpack_require__) {
-      __webpack_require__(682);
-      __webpack_require__(695);
-      module.exports = __webpack_require__(699).f("iterator");
-
-      /***/
-    },
+    [861, 682, 683],
     /* 682 */
-    [862, 683, 684],
+    [862, 667, 664],
     /* 683 */
-    [863, 668, 665],
+    [863, 684, 642, 685, 647, 660, 686, 687, 691, 693, 692],
     /* 684 */
-    [864, 685, 643, 686, 648, 661, 687, 688, 692, 694, 693],
-    /* 685 */
     /***/ function(module, exports) {
       module.exports = true;
 
       /***/
     },
-    /* 686 */
+    /* 685 */
     /***/ function(module, exports, __webpack_require__) {
-      module.exports = __webpack_require__(648);
+      module.exports = __webpack_require__(647);
 
       /***/
     },
-    /* 687 */
+    /* 686 */
     129,
+    /* 687 */
+    [864, 688, 656, 691, 647, 692],
     /* 688 */
-    [865, 689, 657, 692, 648, 693],
+    [848, 649, 689, 672, 669, 654, 690],
     /* 689 */
-    [849, 650, 690, 673, 670, 655, 691],
+    [849, 648, 649, 658, 652],
     /* 690 */
-    [850, 649, 650, 659, 653],
+    [850, 643],
     /* 691 */
-    [851, 644],
+    [834, 648, 660, 692],
     /* 692 */
-    [835, 649, 661, 693],
+    [835, 670, 671, 643],
     /* 693 */
-    [836, 671, 672, 644],
+    [856, 660, 675, 669],
     /* 694 */
-    [857, 661, 676, 670],
-    /* 695 */
     /***/ function(module, exports, __webpack_require__) {
-      __webpack_require__(696);
-      var global = __webpack_require__(644);
-      var hide = __webpack_require__(648);
-      var Iterators = __webpack_require__(687);
-      var TO_STRING_TAG = __webpack_require__(693)("toStringTag");
+      __webpack_require__(695);
+      var global = __webpack_require__(643);
+      var hide = __webpack_require__(647);
+      var Iterators = __webpack_require__(686);
+      var TO_STRING_TAG = __webpack_require__(692)("toStringTag");
 
       var DOMIterables = (
         "CSSRuleList,CSSStyleDeclaration,CSSValueList,ClientRectList,DOMRectList,DOMStringList," +
@@ -56337,9 +56255,9 @@
 
       /***/
     },
+    /* 695 */
+    [865, 696, 697, 686, 661, 683],
     /* 696 */
-    [866, 697, 698, 687, 662, 684],
-    /* 697 */
     /***/ function(module, exports) {
       module.exports = function() {
         /* empty */
@@ -56347,96 +56265,96 @@
 
       /***/
     },
-    /* 698 */
+    /* 697 */
     195,
+    /* 698 */
+    [836, 692],
     /* 699 */
-    [837, 693],
+    /***/ function(module, exports, __webpack_require__) {
+      module.exports = { default: __webpack_require__(700), __esModule: true };
+
+      /***/
+    },
     /* 700 */
     /***/ function(module, exports, __webpack_require__) {
-      module.exports = { default: __webpack_require__(701), __esModule: true };
+      __webpack_require__(701);
+      __webpack_require__(709);
+      __webpack_require__(710);
+      __webpack_require__(711);
+      module.exports = __webpack_require__(644).Symbol;
 
       /***/
     },
     /* 701 */
-    /***/ function(module, exports, __webpack_require__) {
-      __webpack_require__(702);
-      __webpack_require__(710);
-      __webpack_require__(711);
-      __webpack_require__(712);
-      module.exports = __webpack_require__(645).Symbol;
-
-      /***/
-    },
-    /* 702 */
     [
-      824,
-      644,
-      661,
-      653,
+      823,
       643,
-      686,
-      703,
-      654,
+      660,
+      652,
+      642,
+      685,
+      702,
+      653,
+      670,
+      691,
       671,
       692,
-      672,
-      693,
-      699,
+      698,
+      703,
       704,
       705,
-      706,
-      650,
-      662,
-      656,
-      657,
-      689,
-      707,
-      709,
       649,
-      659,
+      661,
+      655,
+      656,
+      688,
+      706,
       708,
-      675,
+      648,
+      658,
+      707,
       674,
-      685,
-      648
+      673,
+      684,
+      647
     ],
+    /* 702 */
+    [832, 671, 650, 660, 648, 653],
     /* 703 */
-    [833, 672, 651, 661, 649, 654],
+    [837, 643, 644, 684, 698, 648],
     /* 704 */
-    [838, 644, 645, 685, 699, 649],
+    [838, 658, 673, 674],
     /* 705 */
-    [839, 659, 674, 675],
+    [847, 663],
     /* 706 */
-    [848, 664],
+    [851, 661, 707],
     /* 707 */
-    [852, 662, 708],
+    [852, 659, 672],
     /* 708 */
-    [853, 660, 673],
+    [853, 674, 656, 661, 655, 660, 651, 652],
     /* 709 */
-    [854, 675, 657, 662, 656, 661, 652, 653],
-    /* 710 */
     /***/ function(module, exports) {
       /***/
     },
+    /* 710 */
+    [866, 703],
     /* 711 */
-    [867, 704],
+    [867, 703],
     /* 712 */
-    [868, 704],
-    /* 713 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
       exports.__esModule = true;
 
-      var _setPrototypeOf = __webpack_require__(714);
+      var _setPrototypeOf = __webpack_require__(713);
 
       var _setPrototypeOf2 = _interopRequireDefault(_setPrototypeOf);
 
-      var _create = __webpack_require__(718);
+      var _create = __webpack_require__(717);
 
       var _create2 = _interopRequireDefault(_create);
 
-      var _typeof2 = __webpack_require__(679);
+      var _typeof2 = __webpack_require__(678);
 
       var _typeof3 = _interopRequireDefault(_typeof2);
 
@@ -56473,42 +56391,42 @@
 
       /***/
     },
+    /* 713 */
+    /***/ function(module, exports, __webpack_require__) {
+      module.exports = { default: __webpack_require__(714), __esModule: true };
+
+      /***/
+    },
     /* 714 */
     /***/ function(module, exports, __webpack_require__) {
-      module.exports = { default: __webpack_require__(715), __esModule: true };
+      __webpack_require__(715);
+      module.exports = __webpack_require__(644).Object.setPrototypeOf;
 
       /***/
     },
     /* 715 */
+    [859, 642, 716],
+    /* 716 */
+    [860, 650, 649, 645, 708],
+    /* 717 */
     /***/ function(module, exports, __webpack_require__) {
-      __webpack_require__(716);
-      module.exports = __webpack_require__(645).Object.setPrototypeOf;
+      module.exports = { default: __webpack_require__(718), __esModule: true };
 
       /***/
     },
-    /* 716 */
-    [860, 643, 717],
-    /* 717 */
-    [861, 651, 650, 646, 709],
     /* 718 */
     /***/ function(module, exports, __webpack_require__) {
-      module.exports = { default: __webpack_require__(719), __esModule: true };
-
-      /***/
-    },
-    /* 719 */
-    /***/ function(module, exports, __webpack_require__) {
-      __webpack_require__(720);
-      var $Object = __webpack_require__(645).Object;
+      __webpack_require__(719);
+      var $Object = __webpack_require__(644).Object;
       module.exports = function create(P, D) {
         return $Object.create(P, D);
       };
 
       /***/
     },
+    /* 719 */
+    [854, 642, 688],
     /* 720 */
-    [855, 643, 689],
-    /* 721 */
     /***/ function(module, exports, __webpack_require__) {
       /* WEBPACK VAR INJECTION */ (function(global) {
         /**!
@@ -59491,7 +59409,7 @@
 
       /***/
     },
-    /* 722 */
+    /* 721 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -59500,21 +59418,21 @@
       });
       exports.ManagerContext = undefined;
 
-      var _extends2 = __webpack_require__(639);
+      var _extends2 = __webpack_require__(638);
 
       var _extends3 = _interopRequireDefault(_extends2);
 
-      var _classCallCheck2 = __webpack_require__(677);
+      var _classCallCheck2 = __webpack_require__(676);
 
       var _classCallCheck3 = _interopRequireDefault(_classCallCheck2);
 
-      var _possibleConstructorReturn2 = __webpack_require__(678);
+      var _possibleConstructorReturn2 = __webpack_require__(677);
 
       var _possibleConstructorReturn3 = _interopRequireDefault(
         _possibleConstructorReturn2
       );
 
-      var _inherits2 = __webpack_require__(713);
+      var _inherits2 = __webpack_require__(712);
 
       var _inherits3 = _interopRequireDefault(_inherits2);
 
@@ -59522,7 +59440,7 @@
 
       var React = _interopRequireWildcard(_react);
 
-      var _createReactContext = __webpack_require__(723);
+      var _createReactContext = __webpack_require__(722);
 
       var _createReactContext2 = _interopRequireDefault(_createReactContext);
 
@@ -59598,7 +59516,7 @@
 
       /***/
     },
-    /* 723 */
+    /* 722 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -59608,7 +59526,7 @@
 
       var _react2 = _interopRequireDefault(_react);
 
-      var _implementation = __webpack_require__(724);
+      var _implementation = __webpack_require__(723);
 
       var _implementation2 = _interopRequireDefault(_implementation);
 
@@ -59622,7 +59540,7 @@
 
       /***/
     },
-    /* 724 */
+    /* 723 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -59632,15 +59550,15 @@
 
       var _react2 = _interopRequireDefault(_react);
 
-      var _propTypes = __webpack_require__(725);
+      var _propTypes = __webpack_require__(724);
 
       var _propTypes2 = _interopRequireDefault(_propTypes);
 
-      var _gud = __webpack_require__(730);
+      var _gud = __webpack_require__(729);
 
       var _gud2 = _interopRequireDefault(_gud);
 
-      var _warning = __webpack_require__(731);
+      var _warning = __webpack_require__(730);
 
       var _warning2 = _interopRequireDefault(_warning);
 
@@ -59905,17 +59823,17 @@
 
       /***/
     },
+    /* 724 */
+    [868, 725],
     /* 725 */
-    [869, 726],
+    [869, 726, 727, 728],
     /* 726 */
-    [870, 727, 728, 729],
-    /* 727 */
     331,
-    /* 728 */
+    /* 727 */
     536,
-    /* 729 */
+    /* 728 */
     537,
-    /* 730 */
+    /* 729 */
     /***/ function(module, exports) {
       /* WEBPACK VAR INJECTION */ (function(global) {
         // @flow
@@ -59937,7 +59855,7 @@
 
       /***/
     },
-    /* 731 */
+    /* 730 */
     /***/ function(module, exports, __webpack_require__) {
       /**
        * Copyright (c) 2014-present, Facebook, Inc.
@@ -59949,7 +59867,7 @@
 
       "use strict";
 
-      var emptyFunction = __webpack_require__(732);
+      var emptyFunction = __webpack_require__(731);
 
       /**
        * Similar to invariant but only logs a warning if the condition is not met.
@@ -60021,9 +59939,9 @@
 
       /***/
     },
-    /* 732 */
+    /* 731 */
     331,
-    /* 733 */
+    /* 732 */
     /***/ function(module, exports) {
       "use strict";
 
@@ -60061,7 +59979,7 @@
 
       /***/
     },
-    /* 734 */
+    /* 733 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -60069,21 +59987,21 @@
         value: true
       });
 
-      var _extends2 = __webpack_require__(639);
+      var _extends2 = __webpack_require__(638);
 
       var _extends3 = _interopRequireDefault(_extends2);
 
-      var _classCallCheck2 = __webpack_require__(677);
+      var _classCallCheck2 = __webpack_require__(676);
 
       var _classCallCheck3 = _interopRequireDefault(_classCallCheck2);
 
-      var _possibleConstructorReturn2 = __webpack_require__(678);
+      var _possibleConstructorReturn2 = __webpack_require__(677);
 
       var _possibleConstructorReturn3 = _interopRequireDefault(
         _possibleConstructorReturn2
       );
 
-      var _inherits2 = __webpack_require__(713);
+      var _inherits2 = __webpack_require__(712);
 
       var _inherits3 = _interopRequireDefault(_inherits2);
 
@@ -60093,13 +60011,13 @@
 
       var React = _interopRequireWildcard(_react);
 
-      var _warning = __webpack_require__(735);
+      var _warning = __webpack_require__(734);
 
       var _warning2 = _interopRequireDefault(_warning);
 
-      var _Manager = __webpack_require__(722);
+      var _Manager = __webpack_require__(721);
 
-      var _utils = __webpack_require__(733);
+      var _utils = __webpack_require__(732);
 
       function _interopRequireWildcard(obj) {
         if (obj && obj.__esModule) {
@@ -60185,7 +60103,7 @@
 
       /***/
     },
-    /* 735 */
+    /* 734 */
     /***/ function(module, exports, __webpack_require__) {
       /**
        * Copyright 2014-2015, Facebook, Inc.
@@ -60252,7 +60170,7 @@
 
       /***/
     },
-    /* 736 */
+    /* 735 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -60344,7 +60262,7 @@
 
       /***/
     },
-    /* 737 */
+    /* 736 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -60465,7 +60383,7 @@
 
       /***/
     },
-    /* 738 */
+    /* 737 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -60576,7 +60494,7 @@
 
       /***/
     },
-    /* 739 */
+    /* 738 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -60687,7 +60605,7 @@
 
       /***/
     },
-    /* 740 */
+    /* 739 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -60806,7 +60724,7 @@
 
       /***/
     },
-    /* 741 */
+    /* 740 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -60850,7 +60768,7 @@
 
       /***/
     },
-    /* 742 */
+    /* 741 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -61000,7 +60918,7 @@
 
       /***/
     },
-    /* 743 */
+    /* 742 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -61142,7 +61060,7 @@
 
       /***/
     },
-    /* 744 */
+    /* 743 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -61284,7 +61202,7 @@
 
       /***/
     },
-    /* 745 */
+    /* 744 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -61298,7 +61216,7 @@
 
       var _reactDatepicker2 = _interopRequireDefault(_reactDatepicker);
 
-      var _enGB = __webpack_require__(746);
+      var _enGB = __webpack_require__(745);
 
       var _enGB2 = _interopRequireDefault(_enGB);
 
@@ -61439,7 +61357,7 @@
 
       /***/
     },
-    /* 746 */
+    /* 745 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -61451,7 +61369,7 @@
 
       var _index2 = _interopRequireDefault(_index);
 
-      var _index3 = __webpack_require__(747);
+      var _index3 = __webpack_require__(746);
 
       var _index4 = _interopRequireDefault(_index3);
 
@@ -61496,7 +61414,7 @@
 
       /***/
     },
-    /* 747 */
+    /* 746 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -61555,7 +61473,7 @@
 
       /***/
     },
-    /* 748 */
+    /* 747 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -61569,7 +61487,7 @@
 
       var _reactDatepicker2 = _interopRequireDefault(_reactDatepicker);
 
-      var _fi = __webpack_require__(749);
+      var _fi = __webpack_require__(748);
 
       var _fi2 = _interopRequireDefault(_fi);
 
@@ -61701,7 +61619,7 @@
 
       /***/
     },
-    /* 749 */
+    /* 748 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -61709,23 +61627,23 @@
         value: true
       });
 
-      var _index = __webpack_require__(750);
+      var _index = __webpack_require__(749);
 
       var _index2 = _interopRequireDefault(_index);
 
-      var _index3 = __webpack_require__(751);
+      var _index3 = __webpack_require__(750);
 
       var _index4 = _interopRequireDefault(_index3);
 
-      var _index5 = __webpack_require__(752);
+      var _index5 = __webpack_require__(751);
 
       var _index6 = _interopRequireDefault(_index5);
 
-      var _index7 = __webpack_require__(753);
+      var _index7 = __webpack_require__(752);
 
       var _index8 = _interopRequireDefault(_index7);
 
-      var _index9 = __webpack_require__(754);
+      var _index9 = __webpack_require__(753);
 
       var _index10 = _interopRequireDefault(_index9);
 
@@ -61760,7 +61678,7 @@
 
       /***/
     },
-    /* 750 */
+    /* 749 */
     /***/ function(module, exports) {
       "use strict";
 
@@ -61903,7 +61821,7 @@
 
       /***/
     },
-    /* 751 */
+    /* 750 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -61962,7 +61880,7 @@
 
       /***/
     },
-    /* 752 */
+    /* 751 */
     /***/ function(module, exports) {
       "use strict";
 
@@ -61986,7 +61904,7 @@
 
       /***/
     },
-    /* 753 */
+    /* 752 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -62163,9 +62081,9 @@
 
       /***/
     },
-    /* 754 */
+    /* 753 */
     556,
-    /* 755 */
+    /* 754 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -62308,7 +62226,7 @@
 
       /***/
     },
-    /* 756 */
+    /* 755 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -62456,7 +62374,7 @@
 
       /***/
     },
-    /* 757 */
+    /* 756 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -62645,7 +62563,7 @@
 
       /***/
     },
-    /* 758 */
+    /* 757 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -62788,7 +62706,7 @@
 
       /***/
     },
-    /* 759 */
+    /* 758 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -62932,7 +62850,7 @@
 
       /***/
     },
-    /* 760 */
+    /* 759 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -63057,7 +62975,7 @@
 
       /***/
     },
-    /* 761 */
+    /* 760 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -63181,7 +63099,7 @@
 
       /***/
     },
-    /* 762 */
+    /* 761 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -63293,7 +63211,7 @@
 
       /***/
     },
-    /* 763 */
+    /* 762 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -63457,7 +63375,7 @@
 
       /***/
     },
-    /* 764 */
+    /* 763 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -63580,7 +63498,7 @@
 
       /***/
     },
-    /* 765 */
+    /* 764 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -63594,7 +63512,7 @@
 
       var _reactDatepicker2 = _interopRequireDefault(_reactDatepicker);
 
-      var _isAfter = __webpack_require__(616);
+      var _isAfter = __webpack_require__(615);
 
       var _isAfter2 = _interopRequireDefault(_isAfter);
 
@@ -63717,7 +63635,7 @@
 
       /***/
     },
-    /* 766 */
+    /* 765 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -63846,7 +63764,7 @@
 
       /***/
     },
-    /* 767 */
+    /* 766 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -63957,7 +63875,7 @@
 
       /***/
     },
-    /* 768 */
+    /* 767 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -64071,7 +63989,7 @@
 
       /***/
     },
-    /* 769 */
+    /* 768 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -64182,7 +64100,7 @@
 
       /***/
     },
-    /* 770 */
+    /* 769 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -64304,7 +64222,7 @@
 
       /***/
     },
-    /* 771 */
+    /* 770 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -64416,7 +64334,7 @@
 
       /***/
     },
-    /* 772 */
+    /* 771 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -64530,7 +64448,7 @@
 
       /***/
     },
-    /* 773 */
+    /* 772 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -64641,7 +64559,7 @@
 
       /***/
     },
-    /* 774 */
+    /* 773 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -64752,7 +64670,7 @@
 
       /***/
     },
-    /* 775 */
+    /* 774 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -64875,7 +64793,7 @@
 
       /***/
     },
-    /* 776 */
+    /* 775 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -65004,7 +64922,7 @@
 
       /***/
     },
-    /* 777 */
+    /* 776 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -65115,7 +65033,7 @@
 
       /***/
     },
-    /* 778 */
+    /* 777 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -65257,7 +65175,7 @@
 
       /***/
     },
-    /* 779 */
+    /* 778 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -65368,7 +65286,7 @@
 
       /***/
     },
-    /* 780 */
+    /* 779 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -65480,7 +65398,7 @@
 
       /***/
     },
-    /* 781 */
+    /* 780 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -65592,7 +65510,7 @@
 
       /***/
     },
-    /* 782 */
+    /* 781 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -65710,7 +65628,7 @@
 
       /***/
     },
-    /* 783 */
+    /* 782 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -65850,7 +65768,7 @@
 
       /***/
     },
-    /* 784 */
+    /* 783 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -65961,7 +65879,7 @@
 
       /***/
     },
-    /* 785 */
+    /* 784 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -66091,7 +66009,7 @@
 
       /***/
     },
-    /* 786 */
+    /* 785 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -66228,7 +66146,7 @@
 
       /***/
     },
-    /* 787 */
+    /* 786 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -66353,7 +66271,7 @@
 
       /***/
     },
-    /* 788 */
+    /* 787 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -66474,7 +66392,7 @@
 
       /***/
     },
-    /* 789 */
+    /* 788 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -66595,7 +66513,7 @@
 
       /***/
     },
-    /* 790 */
+    /* 789 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -66768,7 +66686,7 @@
 
       /***/
     },
-    /* 791 */
+    /* 790 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -66929,7 +66847,7 @@
 
       /***/
     },
-    /* 792 */
+    /* 791 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -67102,7 +67020,7 @@
 
       /***/
     },
-    /* 793 */
+    /* 792 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -67258,7 +67176,7 @@
 
       /***/
     },
-    /* 794 */
+    /* 793 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -67369,7 +67287,7 @@
 
       /***/
     },
-    /* 795 */
+    /* 794 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -67383,7 +67301,7 @@
 
       var _reactDatepicker2 = _interopRequireDefault(_reactDatepicker);
 
-      var _range = __webpack_require__(796);
+      var _range = __webpack_require__(795);
 
       var _range2 = _interopRequireDefault(_range);
 
@@ -67580,9 +67498,9 @@
 
       /***/
     },
-    /* 796 */
+    /* 795 */
     /***/ function(module, exports, __webpack_require__) {
-      var createRange = __webpack_require__(797);
+      var createRange = __webpack_require__(796);
 
       /**
        * Creates an array of numbers (positive and/or negative) progressing from
@@ -67631,11 +67549,11 @@
 
       /***/
     },
-    /* 797 */
+    /* 796 */
     /***/ function(module, exports, __webpack_require__) {
-      var baseRange = __webpack_require__(798),
-        isIterateeCall = __webpack_require__(799),
-        toFinite = __webpack_require__(812);
+      var baseRange = __webpack_require__(797),
+        isIterateeCall = __webpack_require__(798),
+        toFinite = __webpack_require__(811);
 
       /**
        * Creates a `_.range` or `_.rangeRight` function.
@@ -67670,7 +67588,7 @@
 
       /***/
     },
-    /* 798 */
+    /* 797 */
     /***/ function(module, exports) {
       /* Built-in method references for those with the same name as other `lodash` methods. */
       var nativeCeil = Math.ceil,
@@ -67703,12 +67621,12 @@
 
       /***/
     },
-    /* 799 */
+    /* 798 */
     /***/ function(module, exports, __webpack_require__) {
-      var eq = __webpack_require__(800),
-        isArrayLike = __webpack_require__(801),
-        isIndex = __webpack_require__(811),
-        isObject = __webpack_require__(809);
+      var eq = __webpack_require__(799),
+        isArrayLike = __webpack_require__(800),
+        isIndex = __webpack_require__(810),
+        isObject = __webpack_require__(808);
 
       /**
        * Checks if the given arguments are from an iteratee call.
@@ -67739,7 +67657,7 @@
 
       /***/
     },
-    /* 800 */
+    /* 799 */
     /***/ function(module, exports) {
       /**
        * Performs a
@@ -67781,10 +67699,10 @@
 
       /***/
     },
-    /* 801 */
+    /* 800 */
     /***/ function(module, exports, __webpack_require__) {
-      var isFunction = __webpack_require__(802),
-        isLength = __webpack_require__(810);
+      var isFunction = __webpack_require__(801),
+        isLength = __webpack_require__(809);
 
       /**
        * Checks if `value` is array-like. A value is considered array-like if it's
@@ -67819,10 +67737,10 @@
 
       /***/
     },
-    /* 802 */
+    /* 801 */
     /***/ function(module, exports, __webpack_require__) {
-      var baseGetTag = __webpack_require__(803),
-        isObject = __webpack_require__(809);
+      var baseGetTag = __webpack_require__(802),
+        isObject = __webpack_require__(808);
 
       /** `Object#toString` result references. */
       var asyncTag = "[object AsyncFunction]",
@@ -67863,11 +67781,11 @@
 
       /***/
     },
-    /* 803 */
+    /* 802 */
     /***/ function(module, exports, __webpack_require__) {
-      var Symbol = __webpack_require__(804),
-        getRawTag = __webpack_require__(807),
-        objectToString = __webpack_require__(808);
+      var Symbol = __webpack_require__(803),
+        getRawTag = __webpack_require__(806),
+        objectToString = __webpack_require__(807);
 
       /** `Object#toString` result references. */
       var nullTag = "[object Null]",
@@ -67896,9 +67814,9 @@
 
       /***/
     },
-    /* 804 */
+    /* 803 */
     /***/ function(module, exports, __webpack_require__) {
-      var root = __webpack_require__(805);
+      var root = __webpack_require__(804);
 
       /** Built-in value references. */
       var Symbol = root.Symbol;
@@ -67907,9 +67825,9 @@
 
       /***/
     },
-    /* 805 */
+    /* 804 */
     /***/ function(module, exports, __webpack_require__) {
-      var freeGlobal = __webpack_require__(806);
+      var freeGlobal = __webpack_require__(805);
 
       /** Detect free variable `self`. */
       var freeSelf =
@@ -67922,7 +67840,7 @@
 
       /***/
     },
-    /* 806 */
+    /* 805 */
     /***/ function(module, exports) {
       /* WEBPACK VAR INJECTION */ (function(global) {
         /** Detect free variable `global` from Node.js. */
@@ -67944,9 +67862,9 @@
 
       /***/
     },
-    /* 807 */
+    /* 806 */
     /***/ function(module, exports, __webpack_require__) {
-      var Symbol = __webpack_require__(804);
+      var Symbol = __webpack_require__(803);
 
       /** Used for built-in method references. */
       var objectProto = Object.prototype;
@@ -67995,7 +67913,7 @@
 
       /***/
     },
-    /* 808 */
+    /* 807 */
     /***/ function(module, exports) {
       /** Used for built-in method references. */
       var objectProto = Object.prototype;
@@ -68022,7 +67940,7 @@
 
       /***/
     },
-    /* 809 */
+    /* 808 */
     /***/ function(module, exports) {
       /**
        * Checks if `value` is the
@@ -68058,7 +67976,7 @@
 
       /***/
     },
-    /* 810 */
+    /* 809 */
     /***/ function(module, exports) {
       /** Used as references for various `Number` constants. */
       var MAX_SAFE_INTEGER = 9007199254740991;
@@ -68102,7 +68020,7 @@
 
       /***/
     },
-    /* 811 */
+    /* 810 */
     /***/ function(module, exports) {
       /** Used as references for various `Number` constants. */
       var MAX_SAFE_INTEGER = 9007199254740991;
@@ -68131,9 +68049,9 @@
 
       /***/
     },
-    /* 812 */
+    /* 811 */
     /***/ function(module, exports, __webpack_require__) {
-      var toNumber = __webpack_require__(813);
+      var toNumber = __webpack_require__(812);
 
       /** Used as references for various `Number` constants. */
       var INFINITY = 1 / 0,
@@ -68178,10 +68096,10 @@
 
       /***/
     },
-    /* 813 */
+    /* 812 */
     /***/ function(module, exports, __webpack_require__) {
-      var isObject = __webpack_require__(809),
-        isSymbol = __webpack_require__(814);
+      var isObject = __webpack_require__(808),
+        isSymbol = __webpack_require__(813);
 
       /** Used as references for various `Number` constants. */
       var NAN = 0 / 0;
@@ -68252,10 +68170,10 @@
 
       /***/
     },
-    /* 814 */
+    /* 813 */
     /***/ function(module, exports, __webpack_require__) {
-      var baseGetTag = __webpack_require__(803),
-        isObjectLike = __webpack_require__(815);
+      var baseGetTag = __webpack_require__(802),
+        isObjectLike = __webpack_require__(814);
 
       /** `Object#toString` result references. */
       var symbolTag = "[object Symbol]";
@@ -68288,7 +68206,7 @@
 
       /***/
     },
-    /* 815 */
+    /* 814 */
     /***/ function(module, exports) {
       /**
        * Checks if `value` is object-like. A value is object-like if it's not `null`
@@ -68322,7 +68240,7 @@
 
       /***/
     },
-    /* 816 */
+    /* 815 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -68446,7 +68364,7 @@
 
       /***/
     },
-    /* 817 */
+    /* 816 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -68559,7 +68477,7 @@
 
       /***/
     },
-    /* 818 */
+    /* 817 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -68670,7 +68588,7 @@
 
       /***/
     },
-    /* 819 */
+    /* 818 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -68782,7 +68700,7 @@
 
       /***/
     },
-    /* 820 */
+    /* 819 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -68796,7 +68714,7 @@
 
       var _reactDatepicker2 = _interopRequireDefault(_reactDatepicker);
 
-      var _isAfter = __webpack_require__(616);
+      var _isAfter = __webpack_require__(615);
 
       var _isAfter2 = _interopRequireDefault(_isAfter);
 
@@ -68927,14 +68845,14 @@
 
       /***/
     },
-    /* 821 */
+    /* 820 */
     /***/ function(module, exports) {
       // removed by extract-text-webpack-plugin
       /***/
     },
+    /* 821 */
+    820,
     /* 822 */
-    821,
-    /* 823 */
     /***/ function(module, exports, __webpack_require__) {
       "use strict";
 
@@ -69028,7 +68946,7 @@
 
       /***/
     },
-    /* 824 */
+    /* 823 */
     /***/ function(
       module,
       exports,
@@ -69423,7 +69341,7 @@
 
       /***/
     },
-    /* 825 */
+    /* 824 */
     /***/ function(
       module,
       exports,
@@ -69445,7 +69363,7 @@
 
       /***/
     },
-    /* 826 */
+    /* 825 */
     /***/ function(
       module,
       exports,
@@ -69471,7 +69389,7 @@
 
       /***/
     },
-    /* 827 */
+    /* 826 */
     /***/ function(
       module,
       exports,
@@ -69512,7 +69430,7 @@
 
       /***/
     },
-    /* 828 */
+    /* 827 */
     /***/ function(
       module,
       exports,
@@ -69529,7 +69447,7 @@
 
       /***/
     },
-    /* 829 */
+    /* 828 */
     /***/ function(
       module,
       exports,
@@ -69560,7 +69478,7 @@
 
       /***/
     },
-    /* 830 */
+    /* 829 */
     /***/ function(
       module,
       exports,
@@ -69581,7 +69499,7 @@
 
       /***/
     },
-    /* 831 */
+    /* 830 */
     /***/ function(
       module,
       exports,
@@ -69619,7 +69537,7 @@
 
       /***/
     },
-    /* 832 */
+    /* 831 */
     /***/ function(
       module,
       exports,
@@ -69654,7 +69572,7 @@
 
       /***/
     },
-    /* 833 */
+    /* 832 */
     /***/ function(
       module,
       exports,
@@ -69738,7 +69656,7 @@
 
       /***/
     },
-    /* 834 */
+    /* 833 */
     /***/ function(
       module,
       exports,
@@ -69754,7 +69672,7 @@
 
       /***/
     },
-    /* 835 */
+    /* 834 */
     /***/ function(
       module,
       exports,
@@ -69776,7 +69694,7 @@
 
       /***/
     },
-    /* 836 */
+    /* 835 */
     /***/ function(
       module,
       exports,
@@ -69806,7 +69724,7 @@
 
       /***/
     },
-    /* 837 */
+    /* 836 */
     /***/ function(
       module,
       exports,
@@ -69817,7 +69735,7 @@
 
       /***/
     },
-    /* 838 */
+    /* 837 */
     /***/ function(
       module,
       exports,
@@ -69844,7 +69762,7 @@
 
       /***/
     },
-    /* 839 */
+    /* 838 */
     /***/ function(
       module,
       exports,
@@ -69873,7 +69791,7 @@
 
       /***/
     },
-    /* 840 */
+    /* 839 */
     /***/ function(
       module,
       exports,
@@ -69895,7 +69813,7 @@
 
       /***/
     },
-    /* 841 */
+    /* 840 */
     /***/ function(
       module,
       exports,
@@ -69932,7 +69850,7 @@
 
       /***/
     },
-    /* 842 */
+    /* 841 */
     /***/ function(
       module,
       exports,
@@ -69949,7 +69867,7 @@
 
       /***/
     },
-    /* 843 */
+    /* 842 */
     /***/ function(
       module,
       exports,
@@ -69967,7 +69885,7 @@
 
       /***/
     },
-    /* 844 */
+    /* 843 */
     /***/ function(
       module,
       exports,
@@ -70013,7 +69931,7 @@
 
       /***/
     },
-    /* 845 */
+    /* 844 */
     /***/ function(
       module,
       exports,
@@ -70031,7 +69949,7 @@
 
       /***/
     },
-    /* 846 */
+    /* 845 */
     /***/ function(
       module,
       exports,
@@ -70050,7 +69968,7 @@
 
       /***/
     },
-    /* 847 */
+    /* 846 */
     /***/ function(
       module,
       exports,
@@ -70068,7 +69986,7 @@
 
       /***/
     },
-    /* 848 */
+    /* 847 */
     /***/ function(
       module,
       exports,
@@ -70085,7 +70003,7 @@
 
       /***/
     },
-    /* 849 */
+    /* 848 */
     /***/ function(
       module,
       exports,
@@ -70157,7 +70075,7 @@
 
       /***/
     },
-    /* 850 */
+    /* 849 */
     /***/ function(
       module,
       exports,
@@ -70189,7 +70107,7 @@
 
       /***/
     },
-    /* 851 */
+    /* 850 */
     /***/ function(
       module,
       exports,
@@ -70202,7 +70120,7 @@
 
       /***/
     },
-    /* 852 */
+    /* 851 */
     /***/ function(
       module,
       exports,
@@ -70238,7 +70156,7 @@
 
       /***/
     },
-    /* 853 */
+    /* 852 */
     /***/ function(
       module,
       exports,
@@ -70260,7 +70178,7 @@
 
       /***/
     },
-    /* 854 */
+    /* 853 */
     /***/ function(
       module,
       exports,
@@ -70305,7 +70223,7 @@
 
       /***/
     },
-    /* 855 */
+    /* 854 */
     /***/ function(
       module,
       exports,
@@ -70321,7 +70239,7 @@
 
       /***/
     },
-    /* 856 */
+    /* 855 */
     /***/ function(
       module,
       exports,
@@ -70336,7 +70254,7 @@
 
       /***/
     },
-    /* 857 */
+    /* 856 */
     /***/ function(
       module,
       exports,
@@ -70371,7 +70289,7 @@
 
       /***/
     },
-    /* 858 */
+    /* 857 */
     /***/ function(
       module,
       exports,
@@ -70388,7 +70306,7 @@
 
       /***/
     },
-    /* 859 */
+    /* 858 */
     /***/ function(
       module,
       exports,
@@ -70452,7 +70370,7 @@
 
       /***/
     },
-    /* 860 */
+    /* 859 */
     /***/ function(
       module,
       exports,
@@ -70470,7 +70388,7 @@
 
       /***/
     },
-    /* 861 */
+    /* 860 */
     /***/ function(
       module,
       exports,
@@ -70526,7 +70444,7 @@
 
       /***/
     },
-    /* 862 */
+    /* 861 */
     /***/ function(
       module,
       exports,
@@ -70561,7 +70479,7 @@
 
       /***/
     },
-    /* 863 */
+    /* 862 */
     /***/ function(
       module,
       exports,
@@ -70599,7 +70517,7 @@
 
       /***/
     },
-    /* 864 */
+    /* 863 */
     /***/ function(
       module,
       exports,
@@ -70737,7 +70655,7 @@
 
       /***/
     },
-    /* 865 */
+    /* 864 */
     /***/ function(
       module,
       exports,
@@ -70776,7 +70694,7 @@
 
       /***/
     },
-    /* 866 */
+    /* 865 */
     /***/ function(
       module,
       exports,
@@ -70838,7 +70756,7 @@
 
       /***/
     },
-    /* 867 */
+    /* 866 */
     /***/ function(
       module,
       exports,
@@ -70851,7 +70769,7 @@
 
       /***/
     },
-    /* 868 */
+    /* 867 */
     /***/ function(
       module,
       exports,
@@ -70862,7 +70780,7 @@
 
       /***/
     },
-    /* 869 */
+    /* 868 */
     /***/ function(
       module,
       exports,
@@ -70908,7 +70826,7 @@
 
       /***/
     },
-    /* 870 */
+    /* 869 */
     /***/ function(
       module,
       exports,

--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -340,9 +340,8 @@ export function isMonthinRange(startDate, endDate, m, day) {
     return startDateMonth <= m && m <= endDateMonth;
   } else if (startDateYear < endDateYear) {
     return (
-      (dayYear === startDateYear &&
-        (startDateMonth <= m || endDateMonth < m)) ||
-      (dayYear === endDateYear && (startDateMonth > m || endDateMonth >= m)) ||
+      (dayYear === startDateYear && startDateMonth <= m) ||
+      (dayYear === endDateYear && endDateMonth >= m) ||
       (dayYear < endDateYear && dayYear > startDateYear)
     );
   }

--- a/test/date_utils_test.js
+++ b/test/date_utils_test.js
@@ -38,8 +38,7 @@ describe("date_utils", function() {
     });
 
     it("should return false for non-equal dates", function() {
-      expect(isEqual(newDate("2016-02-10"), newDate("2016-02-11"))).to.be
-        .false;
+      expect(isEqual(newDate("2016-02-10"), newDate("2016-02-11"))).to.be.false;
     });
 
     it("should return false for non-equal date and date with time", function() {
@@ -48,18 +47,17 @@ describe("date_utils", function() {
     });
 
     it("should return false for non-equal time", function() {
-      expect(isEqual(newDate("2016-02-10 13:13"), newDate("2016-02-11 13:14"))).to.be
-        .false;
+      expect(isEqual(newDate("2016-02-10 13:13"), newDate("2016-02-11 13:14")))
+        .to.be.false;
     });
 
     it("should return true for equal dates", function() {
-      expect(isEqual(newDate("2016-02-10"), newDate("2016-02-10"))).to.be
-        .true;
+      expect(isEqual(newDate("2016-02-10"), newDate("2016-02-10"))).to.be.true;
     });
 
     it("should return true for equal time", function() {
-      expect(isEqual(newDate("2016-02-10 13:13"), newDate("2016-02-10 13:13"))).to.be
-        .true;
+      expect(isEqual(newDate("2016-02-10 13:13"), newDate("2016-02-10 13:13")))
+        .to.be.true;
     });
   });
 
@@ -408,6 +406,14 @@ describe("date_utils", function() {
       const endDate = newDate("2015-08-01");
 
       expect(isMonthinRange(startDate, endDate, 9, day)).to.be.false;
+    });
+
+    it("should return true if the month passed is in range and maxDate +1 year", () => {
+      const day = newDate("2019-06-04");
+      const startDate = newDate("2019-06-04");
+      const endDate = newDate("2020-02-01");
+
+      expect(isMonthinRange(startDate, endDate, 5, day)).to.be.true;
     });
   });
 });


### PR DESCRIPTION
Fixes issue https://github.com/Hacker0x01/react-datepicker/issues/1765

Easier to read the logic in `isMonthinRange`, and grays out the appropriate months in month picker.
