### PR TITLE
Format time select based on locale

### DIFF
--- a/docs-site/src/example_components.jsx
+++ b/docs-site/src/example_components.jsx
@@ -12,6 +12,7 @@ import SpecificDateRange from "./examples/specific_date_range";
 import MinDate from "./examples/min_date";
 import MaxDate from "./examples/max_date";
 import Locale from "./examples/locale";
+import LocaleWithTime from "./examples/locale_with_time";
 import LocaleWithoutGlobalVariable from "./examples/locale_without_global_variable";
 import ExcludeDates from "./examples/exclude_dates";
 import HighlightDates from "./examples/highlight_dates";
@@ -139,6 +140,10 @@ export default class exampleComponents extends React.Component {
     {
       title: "Locale",
       component: <Locale />
+    },
+    {
+      title: "Locale with time",
+      component: <LocaleWithTime />
     },
     {
       title: "Locale without global variables",

--- a/docs-site/src/examples/locale_with_time.jsx
+++ b/docs-site/src/examples/locale_with_time.jsx
@@ -1,0 +1,63 @@
+import React from "react";
+import DatePicker, { registerLocale } from "react-datepicker";
+import ptBR from "date-fns/locale/pt-BR";
+
+registerLocale("pt-BR", ptBR);
+
+export default class LocaleWithTime extends React.Component {
+  state = {
+    startDate: null
+  };
+
+  handleChange = date => {
+    this.setState({
+      startDate: date
+    });
+  };
+
+  render() {
+    return (
+      <div className="row">
+        <pre className="column example__code">
+          <code className="jsx">
+            {"import DatePicker, { registerLocale } from 'react-datepicker';"}
+            <br />
+            {"import ptBR from 'date-fns/locale/pt-BR';"}
+            <br />
+            {"registerLocale('pt-BR', ptBR);"}
+            <br />
+            <br />
+            {"<DatePicker"}
+            <br />
+            {"  selected={this.state.startDate}"}
+            <br />
+            {"  onChange={this.handleChange}"}
+            <br />
+            <strong>{'  locale="pt-BR"'}</strong>
+            <br />
+            <strong>{"  showTimeSelect"}</strong>
+            <br />
+            <strong>{'  timeFormat="p"'}</strong>
+            <br />
+            <strong>{"  timeIntervals={15}"}</strong>
+            <br />
+            <strong>{'  dateFormat="Pp"'}</strong>
+            <br />
+            {"/>"}
+          </code>
+        </pre>
+        <div className="column">
+          <DatePicker
+            selected={this.state.startDate}
+            onChange={this.handleChange}
+            locale="pt-BR"
+            showTimeSelect
+            timeFormat="p"
+            timeIntervals={15}
+            dateFormat="Pp"
+          />
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -682,6 +682,7 @@ export default class Calendar extends React.Component {
           withPortal={this.props.withPortal}
           monthRef={this.state.monthContainer}
           injectTimes={this.props.injectTimes}
+          locale={this.props.locale}
         />
       );
     }

--- a/src/time.jsx
+++ b/src/time.jsx
@@ -25,7 +25,11 @@ export default class Time extends React.Component {
     excludeTimes: PropTypes.array,
     monthRef: PropTypes.object,
     timeCaption: PropTypes.string,
-    injectTimes: PropTypes.array
+    injectTimes: PropTypes.array,
+    locale: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.shape({ locale: PropTypes.object })
+    ])
   };
 
   static get defaultProps() {
@@ -45,7 +49,7 @@ export default class Time extends React.Component {
 
   state = {
     height: null
-  }
+  };
 
   componentDidMount() {
     // code to ensure selected time will always be in focus within time window when it first appears
@@ -146,7 +150,7 @@ export default class Time extends React.Component {
           }
         }}
       >
-        {formatDate(time, format)}
+        {formatDate(time, format, this.props.locale)}
       </li>
     ));
   };

--- a/test/time_format_test.js
+++ b/test/time_format_test.js
@@ -1,8 +1,12 @@
 import React from "react";
 import { mount } from "enzyme";
 import TimeComponent from "../src/time";
+import * as utils from "../src/date_utils";
+import ptBR from "date-fns/locale/pt-BR";
 
 describe("TimeComponent", () => {
+  utils.registerLocale("pt-BR", ptBR);
+
   let sandbox;
 
   beforeEach(() => {
@@ -19,6 +23,11 @@ describe("TimeComponent", () => {
   });
 
   describe("Format", () => {
+    let spy;
+    beforeEach(() => {
+      spy = sandbox.spy(TimeComponent, "calcCenterPosition");
+    });
+
     it("should forward the time format provided in timeFormat props", () => {
       var timeComponent = mount(<TimeComponent format="HH:mm" />);
 
@@ -26,6 +35,16 @@ describe("TimeComponent", () => {
         ".react-datepicker__time-list-item"
       );
       expect(timeListItem.at(0).text()).to.eq("00:00");
+    });
+
+    it("should format the time based on the default locale (en-US)", () => {
+      mount(<TimeComponent format="p" />);
+      expect(spy.args[0][1].innerHTML).to.eq("1:00 PM");
+    });
+
+    it("should format the time based on the pt-BR locale", () => {
+      mount(<TimeComponent format="p" locale="pt-BR" />);
+      expect(spy.args[0][1].innerHTML).to.eq("13:00");
     });
   });
 


### PR DESCRIPTION
Up to now, the time select did not use locale for formatting, even if using `p+` formatting tokens. This PR aims to fix this bug.

Before:

In the picture below, you can see that even using `timeFormat="p"` and `locale="pt-BR"` the options in the time select are still using the default locale (`en-US`) AM/PM style.

![image](https://user-images.githubusercontent.com/5971264/59070075-b632e380-888f-11e9-843f-38c871a9b601.png)

After:

Now, it's respecting the format of the locale (`pt-BR`) 24-hour style.

![image](https://user-images.githubusercontent.com/5971264/59068984-250e3d80-888c-11e9-99b5-23afebae9606.png)
