### PR TITLE
Fix not working max and min date when change it manually (issue 1713)

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -22,7 +22,6 @@ import {
   subWeeks,
   subYears,
   isDayDisabled,
-  isOutOfBounds,
   isDayInRange,
   getEffectiveMinDate,
   getEffectiveMaxDate,
@@ -423,11 +422,6 @@ export default class DatePicker extends React.Component {
     let changedDate = date;
 
     if (changedDate !== null && isDayDisabled(changedDate, this.props)) {
-      if (isOutOfBounds(changedDate, this.props)) {
-        this.props.onChange(date, event);
-        this.props.onSelect(changedDate, event);
-      }
-
       return;
     }
 

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -610,7 +610,7 @@ describe("DatePicker", () => {
       utils.formatDate(data.datePicker.state.preSelection, data.testFormat)
     ).to.equal(utils.formatDate(data.copyM, data.testFormat));
   });
-  it("should not preSelect date if not after maxDate", () => {
+  it("should not preSelect date if after maxDate", () => {
     var data = getOnInputKeyDownStuff({
       maxDate: utils.addDays(utils.newDate(), 1)
     });
@@ -625,6 +625,32 @@ describe("DatePicker", () => {
     expect(data.datePicker.state.preSelection.valueOf()).to.equal(
       data.copyM.valueOf()
     );
+  });
+  it("should not manual select date if before minDate", () => {
+    var minDate = utils.subDays(utils.newDate(), 1);
+    var data = getOnInputKeyDownStuff({
+      minDate: minDate
+    });
+    TestUtils.Simulate.change(data.nodeInput, {
+      target: {
+        value: utils.formatDate(utils.subDays(minDate, 1), data.testFormat)
+      }
+    });
+    TestUtils.Simulate.keyDown(data.nodeInput, getKey("Enter"));
+    expect(data.callback.calledOnce).to.be.false;
+  });
+  it("should not manual select date if after maxDate", () => {
+    var maxDate = utils.addDays(utils.newDate(), 1);
+    var data = getOnInputKeyDownStuff({
+      maxDate: maxDate
+    });
+    TestUtils.Simulate.change(data.nodeInput, {
+      target: {
+        value: utils.formatDate(utils.addDays(maxDate, 1), data.testFormat)
+      }
+    });
+    TestUtils.Simulate.keyDown(data.nodeInput, getKey("Enter"));
+    expect(data.callback.calledOnce).to.be.false;
   });
   describe("onInputKeyDown Enter", () => {
     it("should update the selected date", () => {


### PR DESCRIPTION
I thinks it logical mistake – change date to the one that was entered if it is out of bounds. And `isDayDisabled` includes check `isOutOfBounds`.
Fix for https://github.com/Hacker0x01/react-datepicker/issues/1713