### PR TITLE
Incorrect dateFormat default values

### DIFF
--- a/docs/datepicker.md
+++ b/docs/datepicker.md
@@ -13,8 +13,8 @@ General datepicker component.
 | `clearButtonTitle`           | `string`                       |                 |                                            |
 | `customInput`                | `element`                      |                 |                                            |
 | `customInputRef`             | `string`                       | `'ref'`         | The property used to pass the ref callback |
-| `dateFormat`                 | `union(string\|array)`         | `'L'`           |                                            |
-| `dateFormatCalendar`         | `string`                       | `'MMMM YYYY'`   |                                            |
+| `dateFormat`                 | `union(string\|array)`         | `'MM/dd/yyyy'`           |                                            |
+| `dateFormatCalendar`         | `string`                       | `'LLLL yyyy'`   |                                            |
 | `dayClassName`               | `func`                         |                 |                                            |
 | `disabled`                   | `bool`                         | `false`         |                                            |
 | `disabledKeyboardNavigation` | `bool`                         | `false`         |                                            |


### PR DESCRIPTION
Incorrect `dateFormat` and `dateFormatCalendar` defaults. See https://github.com/Hacker0x01/react-datepicker/blob/master/src/index.jsx