### PR TITLE
Improve focus/blur events and add handlers for determining state of calendar 

### DIFF
--- a/docs-site/src/examples/on_calendar_change_state_callbacks.jsx
+++ b/docs-site/src/examples/on_calendar_change_state_callbacks.jsx
@@ -1,0 +1,42 @@
+import React from "react";
+import DatePicker from "react-datepicker";
+
+export default class OnCalendarChangeStateCallbacks extends React.Component {
+  state = {
+    startDate: null
+  };
+
+  handleChange = date => {
+    this.setState({
+      startDate: date
+    });
+  };
+
+  render() {
+    return (
+      <div className="row">
+        <pre className="column example__code">
+          <br />
+          <code className="jsx">
+            {`
+<DatePicker
+  selected={this.state.startDate}
+  onChange={this.handleChange}
+  onCalendarOpen={() => console.log("Calendar is open")}
+  onCalendarClose={() => console.log("Calendar is close")}
+/>
+`}
+          </code>
+        </pre>
+        <div className="column">
+          <DatePicker
+            selected={this.state.startDate}
+            onChange={this.handleChange}
+            onCalendarOpen={() => console.log("Calendar is open")}
+            onCalendarClose={() => console.log("Calendar is close")}
+          />
+        </div>
+      </div>
+    );
+  }
+}

--- a/docs-site/src/examples/on_input_error_calback.jsx
+++ b/docs-site/src/examples/on_input_error_calback.jsx
@@ -1,14 +1,14 @@
 import React from "react";
 import DatePicker from "react-datepicker";
 
-export default class OnCalendarChangeStateCallbacks extends React.Component {
+export default class OnInputErrorCallback extends React.Component {
   state = {
     date: null
   };
 
   handleChange = date => {
     this.setState({
-      date: date
+      date
     });
   };
 
@@ -20,10 +20,9 @@ export default class OnCalendarChangeStateCallbacks extends React.Component {
           <code className="jsx">
             {`
 <DatePicker
-  selected={this.state.startDate}
+  selected={this.state.date}
   onChange={this.handleChange}
-  onCalendarOpen={() => console.log("Calendar is open")}
-  onCalendarClose={() => console.log("Calendar is close")}
+  onInputError={(error)=>console.log(error)}
 />
 `}
           </code>
@@ -32,8 +31,7 @@ export default class OnCalendarChangeStateCallbacks extends React.Component {
           <DatePicker
             selected={this.state.date}
             onChange={this.handleChange}
-            onCalendarOpen={() => console.log("Calendar is open")}
-            onCalendarClose={() => console.log("Calendar is close")}
+            onInputError={error => console.log(error)}
           />
         </div>
       </div>

--- a/docs-site/src/examples/on_input_error_calback_custom_message.jsx
+++ b/docs-site/src/examples/on_input_error_calback_custom_message.jsx
@@ -1,14 +1,14 @@
 import React from "react";
 import DatePicker from "react-datepicker";
 
-export default class OnCalendarChangeStateCallbacks extends React.Component {
+export default class OnInputErrorCallbackCustomMessage extends React.Component {
   state = {
-    date: null
+    dateA: null
   };
 
   handleChange = date => {
     this.setState({
-      date: date
+      date
     });
   };
 
@@ -20,10 +20,14 @@ export default class OnCalendarChangeStateCallbacks extends React.Component {
           <code className="jsx">
             {`
 <DatePicker
-  selected={this.state.startDate}
+  selected={this.state.date}
   onChange={this.handleChange}
-  onCalendarOpen={() => console.log("Calendar is open")}
-  onCalendarClose={() => console.log("Calendar is close")}
+  onInputError={(error)=>console.log(error)}
+  errors={{
+    dateInvalid: 'Custom invalid error',
+    dateOutOfBounds: 'Custom out of bounds error'
+  }}
+   maxDate={new Date()}
 />
 `}
           </code>
@@ -32,8 +36,12 @@ export default class OnCalendarChangeStateCallbacks extends React.Component {
           <DatePicker
             selected={this.state.date}
             onChange={this.handleChange}
-            onCalendarOpen={() => console.log("Calendar is open")}
-            onCalendarClose={() => console.log("Calendar is close")}
+            onInputError={error => console.log(error)}
+            errors={{
+              dateInvalid: "Custom invalid error",
+              dateOutOfBounds: "Custom out of bounds error"
+            }}
+            maxDate={new Date()}
           />
         </div>
       </div>

--- a/docs/datepicker.md
+++ b/docs/datepicker.md
@@ -41,15 +41,17 @@ General datepicker component.
 | `monthsShown`                | `number`                       | `1`             |                                            |
 | `name`                       | `string`                       |                 |                                            |
 | `onBlur`                     | `func`                         | `function() {}` |                                            |
+| `onCalendarClose`            | `func`                         |                 |                                            |
+| `onCalendarOpen`             | `func`                         |                 |                                            |
 | `onChange` (required)        | `func`                         | `function() {}` |                                            |
 | `onChangeRaw`                | `func`                         |                 |                                            |
 | `onClickOutside`             | `func`                         | `function() {}` |                                            |
 | `onFocus`                    | `func`                         | `function() {}` |                                            |
 | `onKeyDown`                  | `func`                         | `function() {}` |                                            |
 | `onMonthChange`              | `func`                         | `function() {}` |                                            |
-| `onYearChange`               | `func`                         | `function() {}` |                                            |
 | `onSelect`                   | `func`                         | `function() {}` |                                            |
 | `onWeekSelect`               | `func`                         |                 |                                            |
+| `onYearChange`               | `func`                         | `function() {}` |                                            |
 | `openToDate`                 | `instanceOf(Date)`             |                 |                                            |
 | `peekNextMonth`              | `bool`                         |                 |                                            |
 | `placeholderText`            | `string`                       |                 |                                            |

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,76 +1,105 @@
 # `index` (component)
 
-| name                         | type                           | default value      | description |
-| ---------------------------- | ------------------------------ | ------------------ | ----------- |
-| `adjustDateOnChange`         | `bool`                         |                    |             |
-| `allowSameDay`               | `bool`                         | `false`            |             |
-| `autoComplete`               | `string`                       |                    |             |
-| `autoFocus`                  | `bool`                         |                    |             |
-| `calendarClassName`          | `string`                       |                    |             |
-| `calendarContainer`          | `func`                         |                    |             |
-| `children`                   | `node`                         |                    |             |
-| `className`                  | `string`                       |                    |             |
-| `clearButtonTitle`           | `string`                       |                    |             |
-| `customInput`                | `element`                      |                    |             |
-| `customInputRef`             | `string`                       |                    |             |
-| `dateFormat`                 | `union(string\|array)`         | `"MM/dd/yyyy"`     |             |
-| `dateFormatCalendar`         | `string`                       | `"LLLL yyyy"`      |             |
-| `dayClassName`               | `func`                         |                    |             |
-| `disabled`                   | `bool`                         | `false`            |             |
-| `disabledKeyboardNavigation` | `bool`                         | `false`            |             |
-| `dropdownMode`               | `enum("scroll"\|"select")`     | `"scroll"`         |             |
-| `endDate`                    | `instanceOfDate`               |                    |             |
-| `excludeDates`               | `array`                        |                    |             |
-| `excludeTimes`               | `array`                        |                    |             |
-| `filterDate`                 | `func`                         |                    |             |
-| `fixedHeight`                | `bool`                         |                    |             |
-| `forceShowMonthNavigation`   | `bool`                         |                    |             |
-| `formatWeekDay`              | `func`                         |                    |             |
-| `formatWeekNumber`           | `func`                         |                    |             |
-| `highlightDates`             | `array`                        |                    |             |
-| `id`                         | `string`                       |                    |             |
-| `includeDates`               | `array`                        |                    |             |
-| `includeTimes`               | `array`                        |                    |             |
-| `injectTimes`                | `array`                        |                    |             |
-| `inline`                     | `bool`                         |                    |             |
-| `inlineFocusSelectedMonth`   | `bool`                         | `false`            |             |
-| `isClearable`                | `bool`                         |                    |             |
-| `locale`                     | `union(string\|shape)`         |                    |             |
-| `maxDate`                    | `instanceOfDate`               |                    |             |
-| `maxTime`                    | `instanceOfDate`               |                    |             |
-| `minDate`                    | `instanceOfDate`               |                    |             |
-| `minTime`                    | `instanceOfDate`               |                    |             |
-| `monthsShown`                | `number`                       | `1`                |             |
-| `name`                       | `string`                       |                    |             |
-| `nextMonthButtonLabel`       | `string`                       | `"Next month"`     |             |
-| `onBlur`                     | `func`                         | `function() {}`    |             |
-| `onChange`                   | `func`                         | `function() {}`    |             |
-| `onChangeRaw`                | `func`                         |                    |             |
-| `onClickOutside`             | `func`                         | `function() {}`    |             |
-| `onDayMouseEnter`            | `func`                         |                    |             |
-| `onFocus`                    | `func`                         | `function() {}`    |             |
-| `onInputClick`               | `func`                         | `function() {}`    |             |
-| `onInputError`               | `func`                         | `function() {}`    |             |
-| `onKeyDown`                  | `func`                         | `function() {}`    |             |
-| `onMonthChange`              | `func`                         | `function() {}`    |             |
-| `onMonthMouseLeave`          | `func`                         |                    |             |
-| `onSelect`                   | `func`                         | `function() {}`    |             |
-| `onWeekSelect`               | `func`                         |                    |             |
-| `onYearChange`               | `func`                         | `function() {}`    |             |
-| `open`                       | `bool`                         |                    |             |
-| `openToDate`                 | `instanceOfDate`               |                    |             |
-| `peekNextMonth`              | `bool`                         |                    |             |
-| `placeholderText`            | `string`                       |                    |             |
-| `popperClassName`            | `string`                       |                    |             |
-| `popperContainer`            | `func`                         |                    |             |
-| `popperModifiers`            | `object`                       |                    |             |
-| `popperPlacement`            | `enumpopperPlacementPositions` |                    |             |
-| `popperProps`                | `object`                       |                    |             |
-| `preventOpenOnFocus`         | `bool`                         | `false`            |             |
-| `previousMonthButtonLabel`   | `string`                       | `"Previous Month"` |             |
-| `readOnly`                   | `bool`                         | `false`            |             |
-| `renderCustomHeader`         | `func`                         |                    |             |
-| `renderDayContents`          | `func`                         | `function(date) {  |
-
-return date;
-}`|| |`required`|`bool`||| |`scrollableMonthYearDropdown`|`bool`||| |`scrollableYearDropdown`|`bool`||| |`selected`|`instanceOfDate`||| |`selectsEnd`|`bool`||| |`selectsStart`|`bool`||| |`shouldCloseOnSelect`|`bool`|`true`|| |`showDisabledMonthNavigation`|`bool`||| |`showMonthDropdown`|`bool`||| |`showMonthYearDropdown`|`bool`||| |`showMonthYearPicker`|`bool`|`false`|| |`showTimeInput`|`bool`|`false`|| |`showTimeSelect`|`bool`|`false`|| |`showTimeSelectOnly`|`bool`||| |`showWeekNumbers`|`bool`||| |`showYearDropdown`|`bool`||| |`startDate`|`instanceOfDate`||| |`startOpen`|`bool`||| |`strictParsing`|`bool`|`false`|| |`tabIndex`|`number`||| |`timeCaption`|`string`|`"Time"`|| |`timeFormat`|`string`||| |`timeInputLabel`|`string`|`"Time"`|| |`timeIntervals`|`number`|`30`|| |`title`|`string`||| |`todayButton`|`node`||| |`useShortMonthInDropdown`|`bool`||| |`useWeekdaysShort`|`bool`||| |`value`|`string`||| |`weekLabel`|`string`||| |`withPortal`|`bool`|`false`|| |`yearDropdownItemNumber`|`number`|||
+| name                          | type                           | default value                    | description   |
+| ----------------------------- | ------------------------------ | -------------------------------- | ------------- |
+| `adjustDateOnChange`          | `bool`                         |                                  |               |
+| `allowSameDay`                | `bool`                         | `false`                          |               |
+| `autoComplete`                | `string`                       |                                  |               |
+| `autoFocus`                   | `bool`                         |                                  |               |
+| `calendarClassName`           | `string`                       |                                  |               |
+| `calendarContainer`           | `func`                         |                                  |               |
+| `children`                    | `node`                         |                                  |               |
+| `className`                   | `string`                       |                                  |               |
+| `clearButtonTitle`            | `string`                       |                                  |               |
+| `customInput`                 | `element`                      |                                  |               |
+| `customInputRef`              | `string`                       |                                  |               |
+| `dateFormat`                  | `union(string\|array)`         | `"MM/dd/yyyy"`                   |               |
+| `dateFormatCalendar`          | `string`                       | `"LLLL yyyy"`                    |               |
+| `dayClassName`                | `func`                         |                                  |               |
+| `disabled`                    | `bool`                         | `false`                          |               |
+| `disabledKeyboardNavigation`  | `bool`                         | `false`                          |               |
+| `dropdownMode`                | `enum("scroll"\|"select")`     | `"scroll"`                       |               |
+| `endDate`                     | `instanceOfDate`               |                                  |               |
+| `excludeDates`                | `array`                        |                                  |               |
+| `excludeTimes`                | `array`                        |                                  |               |
+| `filterDate`                  | `func`                         |                                  |               |
+| `fixedHeight`                 | `bool`                         |                                  |               |
+| `forceShowMonthNavigation`    | `bool`                         |                                  |               |
+| `formatWeekDay`               | `func`                         |                                  |               |
+| `formatWeekNumber`            | `func`                         |                                  |               |
+| `highlightDates`              | `array`                        |                                  |               |
+| `id`                          | `string`                       |                                  |               |
+| `includeDates`                | `array`                        |                                  |               |
+| `includeTimes`                | `array`                        |                                  |               |
+| `injectTimes`                 | `array`                        |                                  |               |
+| `inline`                      | `bool`                         |                                  |               |
+| `inlineFocusSelectedMonth`    | `bool`                         | `false`                          |               |
+| `isClearable`                 | `bool`                         |                                  |               |
+| `locale`                      | `union(string\|shape)`         |                                  |               |
+| `maxDate`                     | `instanceOfDate`               |                                  |               |
+| `maxTime`                     | `instanceOfDate`               |                                  |               |
+| `minDate`                     | `instanceOfDate`               |                                  |               |
+| `minTime`                     | `instanceOfDate`               |                                  |               |
+| `monthsShown`                 | `number`                       | `1`                              |               |
+| `name`                        | `string`                       |                                  |               |
+| `nextMonthButtonLabel`        | `string`                       | `"Next month"`                   |               |
+| `onBlur`                      | `func`                         | `function() {}`                  |               |
+| `onCalendarClose`             | `func`                         |                                  |               |
+| `onCalendarOpen`              | `func`                         |                                  |               |
+| `onChange`                    | `func`                         | `function() {}`                  |               |
+| `onChangeRaw`                 | `func`                         |                                  |               |
+| `onClickOutside`              | `func`                         | `function() {}`                  |               |
+| `onDayMouseEnter`             | `func`                         |                                  |               |
+| `onFocus`                     | `func`                         | `function() {}`                  |               |
+| `onInputClick`                | `func`                         | `function() {}`                  |               |
+| `onInputError`                | `func`                         | `function() {}`                  |               |
+| `onKeyDown`                   | `func`                         | `function() {}`                  |               |
+| `onMonthChange`               | `func`                         | `function() {}`                  |               |
+| `onMonthMouseLeave`           | `func`                         |                                  |               |
+| `onSelect`                    | `func`                         | `function() {}`                  |               |
+| `onWeekSelect`                | `func`                         |                                  |               |
+| `onYearChange`                | `func`                         | `function() {}`                  |               |
+| `open`                        | `bool`                         |                                  |               |
+| `openToDate`                  | `instanceOfDate`               |                                  |               |
+| `peekNextMonth`               | `bool`                         |                                  |               |
+| `placeholderText`             | `string`                       |                                  |               |
+| `popperClassName`             | `string`                       |                                  |               |
+| `popperContainer`             | `func`                         |                                  |               |
+| `popperModifiers`             | `object`                       |                                  |               |
+| `popperPlacement`             | `enumpopperPlacementPositions` |                                  |               |
+| `popperProps`                 | `object`                       |                                  |               |
+| `preventOpenOnFocus`          | `bool`                         | `false`                          |               |
+| `previousMonthButtonLabel`    | `string`                       | `"Previous Month"`               |               |
+| `readOnly`                    | `bool`                         | `false`                          |               |
+| `renderCustomHeader`          | `func`                         |                                  |               |
+| `renderDayContents`           | `func`                         | `function(date) { return date;}` |               |
+| `required`                    | `bool`                         |                                  |               |
+| `scrollableMonthYearDropdown` | `bool`                         |                                  |               |
+| `scrollableYearDropdown`      | `bool`                         |                                  |               |
+| `selected`                    | `instanceOfDate`               |                                  |               |
+| `selectsEnd`                  | `bool`                         |                                  |               |
+| `selectsStart`                | `bool`                         |                                  |               |
+| `shouldCloseOnSelect`         | `bool`                         | `true`                           |               |
+| `showDisabledMonthNavigation` | `bool`                         |                                  |               |
+| `showMonthDropdown`           | `bool`                         |                                  |               |
+| `showMonthYearDropdown`       | `bool`                         |                                  |               |
+| `showMonthYearPicker`         | `bool`                         | `false`                          |               |
+| `showTimeInput`               | `bool`                         | `false`                          |               |
+| `showTimeSelect`              | `bool`                         | `false`                          |               |
+| `showTimeSelectOnly`          | `bool`                         |                                  |               |
+| `showWeekNumbers`             | `bool`                         |                                  |               |
+| `showYearDropdown`            | `bool`                         |                                  |               |
+| `startDate`                   | `instanceOfDate`               |                                  |               |
+| `startOpen`                   | `bool`                         |                                  |               |
+| `strictParsing`               | `bool`                         | `false`                          |               |
+| `tabIndex`                    | `number`                       |                                  |               |
+| `timeCaption`                 | `string`                       | `"Time"`                         |               |
+| `timeFormat`                  | `string`                       |                                  |               |
+| `timeInputLabel`              | `string`                       | `"Time"`                         |               |
+| `timeIntervals`               | `number`                       | `30`                             |               |
+| `title`                       | `string`                       |                                  | `todayButton` | `node` |
+| `useShortMonthInDropdown`     | `bool`                         |                                  |               |
+| `useWeekdaysShort`            | `bool`                         |                                  | `value`       | `string` |
+| `weekLabel`                   | `string`                       |                                  |               |
+| `withPortal`                  | `bool`                         | `false`                          |               |
+| `yearDropdownItemNumber`      | `number`                       |                                  |               |

--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -197,7 +197,7 @@ export function getWeek(date) {
 }
 
 export function getDayOfWeekCode(day, locale) {
-  return formatDate(day, "ddd", (locale: locale));
+  return formatDate(day, "iii", locale).toLowerCase();
 }
 
 // *** Start of ***

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -235,6 +235,7 @@ export default class DatePicker extends React.Component {
   constructor(props) {
     super(props);
     this.state = this.calcInitialState();
+    this.preventFocus = false;
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -279,10 +280,6 @@ export default class DatePicker extends React.Component {
     }
   }
 
-  componentWillUnmount() {
-    this.clearPreventFocusTimeout();
-  }
-
   getPreSelection = () =>
     this.props.openToDate
       ? this.props.openToDate
@@ -304,7 +301,6 @@ export default class DatePicker extends React.Component {
         : defaultPreSelection;
     return {
       open: this.props.startOpen || false,
-      preventFocus: false,
       preSelection: this.props.selected
         ? this.props.selected
         : boundedPreSelection,
@@ -313,12 +309,6 @@ export default class DatePicker extends React.Component {
       highlightDates: getHightLightDaysMap(this.props.highlightDates),
       focused: false
     };
-  };
-
-  clearPreventFocusTimeout = () => {
-    if (this.preventFocusTimeout) {
-      clearTimeout(this.preventFocusTimeout);
-    }
   };
 
   setFocus = () => {
@@ -353,7 +343,7 @@ export default class DatePicker extends React.Component {
       : this.props.open;
 
   handleFocus = event => {
-    if (!this.state.preventFocus) {
+    if (!this.preventFocus) {
       this.props.onFocus(event);
       if (!this.props.preventOpenOnFocus && !this.props.readOnly) {
         this.setOpen(true);
@@ -386,7 +376,9 @@ export default class DatePicker extends React.Component {
     } else {
       this.props.onBlur(event);
     }
+
     this.setState({ focused: false });
+    this.preventFocus = false;
   };
 
   handleCalendarClickOutside = event => {
@@ -428,13 +420,8 @@ export default class DatePicker extends React.Component {
   handleSelect = (date, event, monthSelectedIn) => {
     // Preventing onFocus event to fix issue
     // https://github.com/Hacker0x01/react-datepicker/issues/628
-    this.setState({ preventFocus: true }, () => {
-      this.preventFocusTimeout = setTimeout(
-        () => this.setState({ preventFocus: false }),
-        50
-      );
-      return this.preventFocusTimeout;
-    });
+    this.preventFocus = true;
+
     this.setSelected(date, event, undefined, monthSelectedIn);
     if (!this.props.shouldCloseOnSelect || this.props.showTimeSelect) {
       this.setPreSelection(date);

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -111,6 +111,8 @@ export default class DatePicker extends React.Component {
     onYearChange: PropTypes.func,
     onInputError: PropTypes.func,
     open: PropTypes.bool,
+    onCalendarOpen: PropTypes.func,
+    onCalendarClose: PropTypes.func,
     openToDate: PropTypes.instanceOf(Date),
     peekNextMonth: PropTypes.bool,
     placeholderText: PropTypes.string,
@@ -189,6 +191,8 @@ export default class DatePicker extends React.Component {
       onSelect() {},
       onClickOutside() {},
       onMonthChange() {},
+      onCalendarOpen() {},
+      onCalendarClose() {},
       preventOpenOnFocus: false,
       onYearChange() {},
       onInputError() {},
@@ -245,6 +249,22 @@ export default class DatePicker extends React.Component {
       !isEqual(prevProps.selected, this.props.selected)
     ) {
       this.setState({ inputValue: null });
+    }
+
+    if (
+      prevState.open === false &&
+      this.state.open === true &&
+      prevState.open !== this.state.open
+    ) {
+      this.props.onCalendarOpen();
+    }
+
+    if (
+      prevState.open === true &&
+      this.state.open === false &&
+      prevState.open !== this.state.open
+    ) {
+      this.props.onCalendarClose();
     }
   }
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -304,32 +304,16 @@ export default class DatePicker extends React.Component {
     this.cancelFocusInput();
   };
 
-  setOpen = (open, skipSetBlur = false) => {
-    this.setState(
-      {
-        open: open,
-        preSelection:
-          open && this.state.open
-            ? this.state.preSelection
-            : this.calcInitialState().preSelection,
-        lastPreSelectChange: PRESELECT_CHANGE_VIA_NAVIGATE
-      },
-      () => {
-        if (!open) {
-          this.setState(
-            prev => ({
-              focused: skipSetBlur ? prev.focused : false
-            }),
-            () => {
-              !skipSetBlur && this.setBlur();
+  setOpen = open =>
+    this.setState({
+      open: open,
+      preSelection:
+        open && this.state.open
+          ? this.state.preSelection
+          : this.calcInitialState().preSelection,
+      lastPreSelectChange: PRESELECT_CHANGE_VIA_NAVIGATE
+    });
 
-              this.setState({ inputValue: null });
-            }
-          );
-        }
-      }
-    );
-  };
   inputOk = () => isDate(this.state.preSelection);
 
   isCalendarOpen = () =>
@@ -557,7 +541,7 @@ export default class DatePicker extends React.Component {
         this.props.onInputError({ code: 1, msg: INPUT_ERR_1 });
       }
     } else if (eventKey === "Tab") {
-      this.setOpen(false, true);
+      this.setOpen(false);
     } else if (!this.props.disabledKeyboardNavigation) {
       let newSelection;
       switch (eventKey) {

--- a/test/calendar_test.js
+++ b/test/calendar_test.js
@@ -743,6 +743,26 @@ describe("Calendar", function() {
     expect(utils.formatDate(date, "dd.MM.yyyy")).to.equal(expectedDate);
   });
 
+  it("should trigger onCalendarOpen and onCalendarClose", () => {
+    const onCalendarOpen = sinon.spy();
+    const onCalendarClose = sinon.spy();
+
+    const datePicker = TestUtils.renderIntoDocument(
+      <DatePicker
+        onCalendarOpen={onCalendarOpen}
+        onCalendarClose={onCalendarClose}
+      />
+    );
+
+    TestUtils.Simulate.focus(ReactDOM.findDOMNode(datePicker.input));
+
+    assert(onCalendarOpen.called === true, "onCalendarOpen should be called");
+
+    TestUtils.Simulate.blur(ReactDOM.findDOMNode(datePicker.input));
+
+    assert(onCalendarOpen.called === true, "onCalendarClose should be called");
+  });
+
   describe("onMonthChange", () => {
     let onMonthChangeSpy = sinon.spy();
     let calendar;

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -726,6 +726,57 @@ describe("DatePicker", () => {
       expect(data.onInputErrorCallback.calledOnce).to.be.true;
     });
   });
+
+  describe("should trigger onInputError", () => {
+    it("when date is out of bounds", () => {
+      const onInputErrorSpy = sandbox.spy();
+
+      const onChange = date => datePicker.setProps({ selected: date });
+      const datePicker = mount(
+        <DatePicker
+          onChange={onChange}
+          minDate={new Date(2019, 4, 4)}
+          onInputError={onInputErrorSpy}
+        />
+      );
+
+      datePicker.find("input").simulate("change", {
+        target: { value: "01/01/2018" }
+      });
+
+      expect(
+        onInputErrorSpy.calledWith({ code: 2, msg: "Date is out of bounds" })
+      ).to.be.true;
+    });
+
+    it("with custom message", () => {
+      const onInputErrorSpy = sandbox.spy();
+
+      const onChange = date => datePicker.setProps({ selected: date });
+      const datePicker = mount(
+        <DatePicker
+          onChange={onChange}
+          minDate={new Date(2019, 4, 4)}
+          onInputError={onInputErrorSpy}
+          errors={{
+            dateOutOfBounds: "Custom message out of bounds"
+          }}
+        />
+      );
+
+      datePicker.find("input").simulate("change", {
+        target: { value: "01/01/18" }
+      });
+
+      expect(
+        onInputErrorSpy.calledWith({
+          code: 2,
+          msg: "Custom message out of bounds"
+        })
+      ).to.be.true;
+    });
+  });
+
   it("should reset the keyboard selection when closed", () => {
     var data = getOnInputKeyDownStuff();
     TestUtils.Simulate.keyDown(data.nodeInput, getKey("ArrowLeft"));
@@ -779,17 +830,6 @@ describe("DatePicker", () => {
     var datePicker = ReactDOM.render(<DatePicker />, div);
     datePicker.setFocus();
     expect(div.querySelector("input")).to.equal(document.activeElement);
-  });
-  it("should clear preventFocus timeout id when component is unmounted", () => {
-    var div = document.createElement("div");
-    document.body.appendChild(div);
-    var datePicker = ReactDOM.render(<DatePicker inline />, div);
-    datePicker.clearPreventFocusTimeout = sinon.spy();
-    ReactDOM.unmountComponentAtNode(div);
-    assert(
-      datePicker.clearPreventFocusTimeout.calledOnce,
-      "should call clearPreventFocusTimeout"
-    );
   });
 
   function getOnInputKeyDownDisabledKeyboardNavigationStuff() {


### PR DESCRIPTION
**Please review this PR - this is draft until our QA doesn't accept the changes**
In the current project, we faced a few issues and here is what I changed.

**1. Fix blur on select and fix focus issue on IE**
**2. Replaced `preventFocus` from timeouts to flag in component**

![ezgif-3-64b769451847](https://user-images.githubusercontent.com/14991661/60703656-a516da00-9f02-11e9-8567-9d00a012bfc0.gif)

**What I did**
* Removed blur event on setOpen - when a user selects the date the focus should be still on the input
* Replaced `preventFocus` timeout to flag because of the timeouts causes an unexpected open of the calendar like on the image. After that change everything is ok, and the calendar behaves properly.

**3. New handlers for determining the state of the calendar - Fixes #1797** 

**What I did**
When the calendar is opened the `onCalendarOpen` is triggered and when the calendar is closed the `onCalendarClose` is triggered

**4. Fixed custom header example**
#1735 and #1691 

**5. Revert class name for day in calendar**
After migration from moment to date-fns we loose information about what day is under the element from day class name.
**Before change:**
`react-datepicker__day react-datepicker__day--005 react-datepicker__day--selected react-datepicker__day--today`
**After change**
`react-datepicker__day react-datepicker__day--fir react-datepicker__day--selected react-datepicker__day--today`

**6. onInputError returns new messages**
```
{
  dateInvalid: { code: 1, msg: "Date input not valid" },
  dateOutOfBounds: { code: 2, msg: "Date is out of bounds" }
}
```