### PR TITLE
Fixed CustomInput parent css not working

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -705,7 +705,7 @@ export default class DatePicker extends React.Component {
       placeholder: this.props.placeholderText,
       disabled: this.props.disabled,
       autoComplete: this.props.autoComplete,
-      className: className,
+      className: customInput.props.className + " " + className,
       title: this.props.title,
       readOnly: this.props.readOnly,
       required: this.props.required,


### PR DESCRIPTION
If you insert directly a <div className="someclass"> into the customInput, the css is overridden. I fixed this by adding the className of the customInput to the className prop of React.cloneElement()

Fixes issue #1816 