### PR TITLE
Fixed CustomInput parent css not working

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -246,10 +246,10 @@ export default class DatePicker extends React.Component {
     this.props.openToDate
       ? this.props.openToDate
       : this.props.selectsEnd && this.props.startDate
-      ? this.props.startDate
-      : this.props.selectsStart && this.props.endDate
-      ? this.props.endDate
-      : newDate();
+        ? this.props.startDate
+        : this.props.selectsStart && this.props.endDate
+          ? this.props.endDate
+          : newDate();
 
   calcInitialState = () => {
     const defaultPreSelection = this.getPreSelection();
@@ -259,8 +259,8 @@ export default class DatePicker extends React.Component {
       minDate && isBefore(defaultPreSelection, minDate)
         ? minDate
         : maxDate && isAfter(defaultPreSelection, maxDate)
-        ? maxDate
-        : defaultPreSelection;
+          ? maxDate
+          : defaultPreSelection;
     return {
       open: this.props.startOpen || false,
       preventFocus: false,
@@ -703,8 +703,8 @@ export default class DatePicker extends React.Component {
       typeof this.props.value === "string"
         ? this.props.value
         : typeof this.state.inputValue === "string"
-        ? this.state.inputValue
-        : safeDateFormat(this.props.selected, this.props);
+          ? this.state.inputValue
+          : safeDateFormat(this.props.selected, this.props);
 
     return React.cloneElement(customInput, {
       [customInputRef]: input => {
@@ -721,7 +721,7 @@ export default class DatePicker extends React.Component {
       autoFocus: this.props.autoFocus,
       placeholder: this.props.placeholderText,
       disabled: this.props.disabled,
-      autoComplete: this.props.autoComplete,
+      autoComplete: customInput.props.className + " " + this.props.autoComplete,
       className: className,
       title: this.props.title,
       readOnly: this.props.readOnly,


### PR DESCRIPTION
If you insert directly a div like this into the customInput
`<DatePicker customInput={<div className="someclass"></div>}  />`
the css doesn't work. I fixed this by appending the className of the customInput to the className prop of React.cloneElement()

Fixes issue #1816 