### PR TITLE
Pass event as second param when onChange is called at monthYearPicker

### DIFF
--- a/src/month.jsx
+++ b/src/month.jsx
@@ -193,7 +193,7 @@ export default class Month extends React.Component {
           <div
             key={j}
             onClick={ev => {
-              this.onMonthClick(ev.target, m);
+              this.onMonthClick(ev, m);
             }}
             className={this.getMonthClassNames(m)}
           >

--- a/src/month.jsx
+++ b/src/month.jsx
@@ -156,7 +156,8 @@ export default class Month extends React.Component {
 
   onMonthClick = (e, m) => {
     this.handleDayClick(
-      utils.getStartOfMonth(utils.setMonth(this.props.day, m), e)
+      utils.getStartOfMonth(utils.setMonth(this.props.day, m)),
+      e
     );
   };
 


### PR DESCRIPTION
### Description of bug
When datepicker is rendered with `showMonthYearPicker` prop and an option is selected, then `onChange` method is called, but without the event as second param. Instead it is `undefined`.