### PR TITLE
Added a specific css class to excluded dates

### DIFF
--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -360,6 +360,14 @@ export function isDayDisabled(
   );
 }
 
+export function isDayExcluded(day, { excludeDates } = {}) {
+  return (
+    (excludeDates &&
+      excludeDates.some(excludeDate => isSameDay(day, excludeDate))) ||
+    false
+  );
+}
+
 export function isMonthDisabled(
   month,
   { minDate, maxDate, excludeDates, includeDates, filterDate } = {}

--- a/src/day.jsx
+++ b/src/day.jsx
@@ -8,6 +8,7 @@ import {
   newDate,
   isSameDay,
   isDayDisabled,
+  isDayExcluded,
   isDayInRange,
   isEqual,
   isBefore,
@@ -57,6 +58,8 @@ export default class Day extends React.Component {
     this.isSameDay(this.props.preSelection);
 
   isDisabled = () => isDayDisabled(this.props.day, this.props);
+
+  isExcluded = () => isDayExcluded(this.props.day, this.props);
 
   getHighLightedClass = defaultClassName => {
     const { day, highlightDates } = this.props;
@@ -177,6 +180,7 @@ export default class Day extends React.Component {
       "react-datepicker__day--" + getDayOfWeekCode(this.props.day),
       {
         "react-datepicker__day--disabled": this.isDisabled(),
+        "react-datepicker__day--excluded": this.isExcluded(),
         "react-datepicker__day--selected": this.isSameDay(this.props.selected),
         "react-datepicker__day--keyboard-selected": this.isKeyboardSelected(),
         "react-datepicker__day--range-start": this.isRangeStart(),

--- a/test/date_utils_test.js
+++ b/test/date_utils_test.js
@@ -7,6 +7,7 @@ import {
   isSameMonth,
   isSameYear,
   isDayDisabled,
+  isDayExcluded,
   isMonthDisabled,
   monthDisabledBefore,
   monthDisabledAfter,
@@ -194,6 +195,26 @@ describe("date_utils", function() {
       };
       isDayDisabled(day, { filterDate });
       expect(isEqual(day, dayClone)).to.be.true;
+    });
+  });
+
+  describe("isDayExcluded", function() {
+    it("should not be excluded by default", () => {
+      const day = newDate();
+      expect(isDayExcluded(day)).to.be.false;
+    });
+
+    it("should be excluded if in excluded dates", () => {
+      const day = newDate();
+      expect(isDayExcluded(day, { excludeDates: [day] })).to.be.true;
+    });
+
+    it("should not be excluded if not in excluded dates", () => {
+      const day = newDate();
+      const excludedDay = newDate();
+      const currentMonth = excludedDay.getMonth();
+      excludedDay.setMonth(currentMonth === 11 ? 0 : currentMonth + 1);
+      expect(isDayExcluded(day, { excludeDates: [] }));
     });
   });
 


### PR DESCRIPTION
### Summary
Prior to this change, dates that were passed in via the excludedDates array prop used only had the same CSS class as all other disabled days, `react-datepicker__day--disabled`. 
This made it difficult to target only excluded days with custom styles. I've added an extra CSS class to these days, `react-datepicker__day--excluded`, which makes custom styling easier.

### BTW
 - One of the existing tests was already failing on a fresh checkout of `master`, `DatePicker should not manual select date if after maxDate`.
 - I didn't commit them, but `/docs-site/bundle.js` and `/docs-site/style.css` were changed a lot by the build script, I assume by `prettier`. If you want me to go ahead and commit those as well, just let me know (I'm assuming you update the docs site as part of release). 