### PR TITLE
Fixed custom header example issue when month changed

### DIFF
--- a/docs-site/src/examples/render_custom_header.jsx
+++ b/docs-site/src/examples/render_custom_header.jsx
@@ -93,7 +93,9 @@ export default class Default extends React.Component {
 
                 <select
                   value={months[getMonth(date)]}
-                  onChange={({ target: { value } }) => changeMonth(value)}
+                  onChange={({ target: { value } }) =>
+                    changeMonth(months.indexOf(value))
+                  }
                 >
                   {months.map(option => (
                     <option key={option} value={option}>


### PR DESCRIPTION
Custom Header example is breaking on month change because the month is being passed as string (for e.g. May, June) instead of month index. Fixed it and working fine now.