### PR TITLE
Stop time-list-item wrapping on windows

### DIFF
--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -279,6 +279,7 @@
         li.react-datepicker__time-list-item {
           height: 30px;
           padding: 5px 10px;
+          white-space: nowrap;
           &:hover {
             cursor: pointer;
             background-color: $datepicker__background-color;


### PR DESCRIPTION
Some of our users were having an issue with the date & time selector. On Windows the width of the scrollbar causes the time to wrap. This commit fixes that.

See before:

![Screenshot 2019-08-22 at 17 09 48](https://user-images.githubusercontent.com/23709612/63531909-77f9a780-c501-11e9-9381-cd462038ac42.png)

And after:

![Screenshot 2019-08-22 at 17 10 33](https://user-images.githubusercontent.com/23709612/63531920-7f20b580-c501-11e9-935c-20a4a572c763.png)

