### PR TITLE
Fix keyboard bug selecting last day on calendar

### DIFF
--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -35,6 +35,7 @@ import startOfDay from "date-fns/startOfDay";
 import startOfWeek from "date-fns/startOfWeek";
 import startOfMonth from "date-fns/startOfMonth";
 import startOfYear from "date-fns/startOfYear";
+import endOfDay from "date-fns/endOfDay";
 import endOfWeek from "date-fns/endOfWeek";
 import endOfMonth from "date-fns/endOfMonth";
 import dfIsEqual from "date-fns/isEqual";
@@ -273,8 +274,11 @@ export function isEqual(date1, date2) {
 
 export function isDayInRange(day, startDate, endDate) {
   let valid;
+  const start = startOfDay(startDate);
+  const end = endOfDay(endDate);
+
   try {
-    valid = isWithinInterval(day, { start: startDate, end: endDate });
+    valid = isWithinInterval(day, { start, end });
   } catch (err) {
     valid = false;
   }

--- a/test/date_utils_test.js
+++ b/test/date_utils_test.js
@@ -431,23 +431,37 @@ describe("date_utils", function() {
 
   describe("isDayInRange", () => {
     it("should tell if day is in range", () => {
-      const day = newDate("2016-02-15");
-      const startDate = newDate("2016-02-01");
-      const endDate = newDate("2016-03-15");
+      const day = newDate("2016-02-15 09:40");
+      const startDate = newDate("2016-02-01 09:40");
+      const endDate = newDate("2016-03-15 08:40");
+      expect(isDayInRange(day, startDate, endDate)).to.be.true;
+    });
+
+    it("should tell if day is in range, max bound test", () => {
+      const day = newDate("2016-03-15 09:40");
+      const startDate = newDate("2016-02-01 09:40");
+      const endDate = newDate("2016-03-15 08:40");
+      expect(isDayInRange(day, startDate, endDate)).to.be.true;
+    });
+
+    it("should tell if day is in range, min bound test", () => {
+      const day = newDate("2016-02-01 08:40");
+      const startDate = newDate("2016-02-01 09:40");
+      const endDate = newDate("2016-03-15 08:40");
       expect(isDayInRange(day, startDate, endDate)).to.be.true;
     });
 
     it("should tell if day is not in range", () => {
-      const day = newDate("2016-07-15");
-      const startDate = newDate("2016-02-15");
-      const endDate = newDate("2016-03-15");
+      const day = newDate("2016-07-15 09:40");
+      const startDate = newDate("2016-02-15 09:40");
+      const endDate = newDate("2016-03-15 08:40");
       expect(isDayInRange(day, startDate, endDate)).to.be.false;
     });
 
     it("should not throw exception if end date is before start date", () => {
-      const day = newDate("2016-02-01");
-      const startDate = newDate("2016-02-15");
-      const endDate = newDate("2016-01-15");
+      const day = newDate("2016-02-01 09:40");
+      const startDate = newDate("2016-02-15 09:40");
+      const endDate = newDate("2016-01-15 08:40");
       expect(isDayInRange(day, startDate, endDate)).to.be.false;
     });
   });


### PR DESCRIPTION
See https://github.com/Hacker0x01/react-datepicker/issues/1867 for more details.

This simply sets the `startDate` and `endDate` to have times of 12:00AM and 11:59PM, respectively, before checking if `date` is within `startDate` and `endDate`.