### PR TITLE
set aria-disabled attribute when day is disabled

### DIFF
--- a/src/day.jsx
+++ b/src/day.jsx
@@ -205,6 +205,7 @@ export default class Day extends React.Component {
         onMouseEnter={this.handleMouseEnter}
         aria-label={`day-${getDate(this.props.day)}`}
         role="option"
+        aria-disabled={this.isDisabled()}
       >
         {this.props.renderDayContents
           ? this.props.renderDayContents(

--- a/test/day_test.js
+++ b/test/day_test.js
@@ -494,6 +494,17 @@ describe("Day", () => {
       const shallowDay = renderDay(day, { excludeDates: [day] });
       expect(shallowDay.hasClass(className)).to.equal(true);
     });
+
+    it("should have aria-disabled attribute with true value if date is disabled", () => {
+      const day = newDate();
+      const shallowDay = renderDay(day, { excludeDates: [day] });
+      expect(shallowDay.prop("aria-disabled")).to.equal(true);
+    });
+
+    it("should have aria-disabled attribute with false value if date is not disabled", () => {
+      const shallowDay = renderDay(newDate());
+      expect(shallowDay.prop("aria-disabled")).to.equal(false);
+    });
   });
 
   describe("click", () => {


### PR DESCRIPTION
When I applied styling that shows disabled dates as grayed out, my accessibility checker of choice ([React-axe](https://github.com/dequelabs/react-axe)) warned about insufficient color contrast. 

With the aria-disabled attribute with the right value, the warning is gone.
