### PR TITLE
[Fix] Fix classname undefined on custom inputs

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -733,7 +733,7 @@ export default class DatePicker extends React.Component {
       placeholder: this.props.placeholderText,
       disabled: this.props.disabled,
       autoComplete: this.props.autoComplete,
-      className: customInput.props.className + " " + className,
+      className: classnames(customInput.props.className, className),
       title: this.props.title,
       readOnly: this.props.readOnly,
       required: this.props.required,


### PR DESCRIPTION
### Problem
I'm seeing that when a custom input does not implement the classname property or does not have a specified classname, the value is undefined, resulting in `undefined` as a classname on the output.

Issue: #1897 

### Solution
Used classnames to handle undefined classname