### PR TITLE
Add missing external to rollup config

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -16,7 +16,8 @@ import pkg from "./package.json";
 // see https://github.com/Hacker0x01/react-datepicker/issues/1606
 const dateFnsDirs = fs
   .readdirSync(path.join(".", "node_modules", "date-fns"))
-  .map(d => `date-fns/${d}`);
+  .map(d => `date-fns/${d}`)
+  .concat(["date-fns/_lib/format/longFormatters"]);
 
 const globals = {
   react: "React",


### PR DESCRIPTION
This adds date-fns/_lib/format/longFormatters to externals array. Otherwise the built file would contain this dependency and at would fail if bundled using rollup because of `Object.defineProperty(t, { __esModule: true })` call where `t` would be `undefined`