### PR TITLE
Years in dropdown should include current year

### DIFF
--- a/src/year_dropdown.jsx
+++ b/src/year_dropdown.jsx
@@ -25,12 +25,22 @@ export default class YearDropdown extends React.Component {
     dropdownVisible: false
   };
 
+  getMinYear = () => {
+    let minYear = 1900;
+    if (this.props.minDate) {
+      minYear = getYear(this.props.minDate);
+    }
+    if (this.props.year < minYear) {
+      minYear = this.props.year;
+    }
+    return minYear;
+  };
+
   renderSelectOptions = () => {
-    const minYear = this.props.minDate ? getYear(this.props.minDate) : 1900;
     const maxYear = this.props.maxDate ? getYear(this.props.maxDate) : 2100;
 
     const options = [];
-    for (let i = minYear; i <= maxYear; i++) {
+    for (let i = this.getMinYear(); i <= maxYear; i++) {
       options.push(
         <option key={i} value={i}>
           {i}
@@ -140,9 +150,7 @@ export default class YearDropdown extends React.Component {
 
     return (
       <div
-        className={`react-datepicker__year-dropdown-container react-datepicker__year-dropdown-container--${
-          this.props.dropdownMode
-        }`}
+        className={`react-datepicker__year-dropdown-container react-datepicker__year-dropdown-container--${this.props.dropdownMode}`}
       >
         {renderedDropdown}
       </div>


### PR DESCRIPTION
If the current year is less than the minDate's, the current year (and any years between the two) was not an option in the dropdown. This caused the minDate's year to be the currently selected option even though the calendar was still showing the current year. So, the only way to navigate to the minDate was to select a year after and then back (or by hitting the next month chevron multiple times).

This is easier to see than explain. To see the problem, add 'showYearDropdown dropdownMode="select"' to the two DatePicker's in dateRange.js. Then, use the year dropdown to change the start date to a year later. Then, open the end date picker. Notice that the calendar is still showing the original end date. The dropdown has 2015 selected. Dropdown and try to re-select 2015--nothing happens.

With my change, the end date picker's dropdown still has 2014 selected. So, the user can select 2015 which will cause the calendar to update. It will also cause the dropdown to remove the 2014 option. That last bit may seem a bit strange, but it is consistent with the previous month chevron not appearing even when you navigate to the next month until you are past the minDate's month.