### PR TITLE
[WIP] Screen-reader accessibility fix 1

### DIFF
--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -464,7 +464,7 @@ export default class Calendar extends React.Component {
       classes.push("react-datepicker__current-month--hasMonthYearDropdown");
     }
     return (
-      <div className={classes.join(" ")}>
+      <div className={classes.join(" ")} aria-live="polite">
         {formatDate(date, this.props.dateFormat, this.props.locale)}
       </div>
     );

--- a/src/day.jsx
+++ b/src/day.jsx
@@ -204,7 +204,7 @@ export default class Day extends React.Component {
         onClick={this.handleClick}
         onMouseEnter={this.handleMouseEnter}
         aria-label={`day-${getDate(this.props.day)}`}
-        role="option"
+        role="button"
         aria-disabled={this.isDisabled()}
       >
         {this.props.renderDayContents

--- a/src/month.jsx
+++ b/src/month.jsx
@@ -239,6 +239,7 @@ export default class Month extends React.Component {
       <div className="react-datepicker__month-wrapper" key={i}>
         {month.map((m, j) => (
           <div
+            role="button"
             key={j}
             onClick={ev => {
               this.onMonthClick(ev, m);
@@ -296,7 +297,6 @@ export default class Month extends React.Component {
       <div
         className={this.getClassNames()}
         onMouseLeave={this.handleMouseLeave}
-        role="listbox"
         aria-label={"month-" + utils.formatDate(this.props.day, "yyyy-MM")}
       >
         {showMonthYearPicker


### PR DESCRIPTION
## Introduction
Currently, this component seems to have several problems regarding screen-reader accessibility. It is extremely difficult or completely impossible for screen-reader users like me to control the component.
If one of the main developers could review and update the component, I'm willing to PR some patches that will make it more SR friendly, without altering the visual layout.
You don't necessarily need to test the behavior using a screen-reader; I will always check so that it works. However, what I cannot do is making sure that the visual layout or the original behavior (E.G. focus handling) hasn't been broken by my changes.
As far as I know, this component has significant number of downloads on NPM, so I hope blind users would gain access to it as much as possible, and I would try my best to contribute to it.

## Overview of this PR
This PR will fix two issues:
- On the calendar, each day becomes identifiable as a controllable button by assistive technology .
- When switching months on the calendar, the changed month is automatically reported (read) by screen readers.