### PR TITLE
Declare package side effect free

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "es",
     "src/stylesheets"
   ],
+  "sideEffects": false,
   "keywords": [
     "react",
     "datepicker",


### PR DESCRIPTION
This sets the package.json field sideEffects to false. This allows for better tree shaking by downstream consumers, see https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free for more information.

I skimmed over all included files and I did not see anything that would count following webpack's definition of tree shaking.