### PR TITLE
Added ariaLabelledBy property for screen-reader support

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -63,6 +63,7 @@ export default class DatePicker extends React.Component {
   static propTypes = {
     adjustDateOnChange: PropTypes.bool,
     allowSameDay: PropTypes.bool,
+    ariaLabelledBy: PropTypes.string,
     autoComplete: PropTypes.string,
     autoFocus: PropTypes.bool,
     calendarClassName: PropTypes.string,
@@ -757,7 +758,8 @@ export default class DatePicker extends React.Component {
       title: this.props.title,
       readOnly: this.props.readOnly,
       required: this.props.required,
-      tabIndex: this.props.tabIndex
+      tabIndex: this.props.tabIndex,
+      "aria-labelledby": this.props.ariaLabelledBy
     });
   };
 


### PR DESCRIPTION
I wanted to apply aria-labelledby HTML property to the component, but there was no related props. This will allow us to pass aria-labelledby for the text field as ariaLabelledBy.
This is intended to be an optional props. Not specifying it should not cause any changes to the existing component.