### PR TITLE
Add ariaLabelledBy to the documentation

### DIFF
--- a/docs/datepicker.md
+++ b/docs/datepicker.md
@@ -5,6 +5,7 @@ General datepicker component.
 | name                         | type                           | default value   | description                                |
 | ---------------------------- | ------------------------------ | --------------- | ------------------------------------------ |
 | `allowSameDay`               | `bool`                         | `false`         |                                            |
+| `ariaLabelledBy`             | `string`                       | `null`          |                                            |
 | `autoComplete`               | `string`                       |                 |                                            |
 | `autoFocus`                  | `bool`                         |                 |                                            |
 | `calendarClassName`          | `string`                       |                 |                                            |
@@ -13,7 +14,7 @@ General datepicker component.
 | `clearButtonTitle`           | `string`                       |                 |                                            |
 | `customInput`                | `element`                      |                 |                                            |
 | `customInputRef`             | `string`                       | `'ref'`         | The property used to pass the ref callback |
-| `dateFormat`                 | `union(string\|array)`         | `'MM/dd/yyyy'`           |                                            |
+| `dateFormat`                 | `union(string\|array)`         | `'MM/dd/yyyy'`  |                                            |
 | `dateFormatCalendar`         | `string`                       | `'LLLL yyyy'`   |                                            |
 | `dayClassName`               | `func`                         |                 |                                            |
 | `disabled`                   | `bool`                         | `false`         |                                            |

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -63,6 +63,7 @@ export default class DatePicker extends React.Component {
   static propTypes = {
     adjustDateOnChange: PropTypes.bool,
     allowSameDay: PropTypes.bool,
+    ariaLabelledBy: PropTypes.string,
     autoComplete: PropTypes.string,
     autoFocus: PropTypes.bool,
     calendarClassName: PropTypes.string,
@@ -757,7 +758,8 @@ export default class DatePicker extends React.Component {
       title: this.props.title,
       readOnly: this.props.readOnly,
       required: this.props.required,
-      tabIndex: this.props.tabIndex
+      tabIndex: this.props.tabIndex,
+      "aria-labelledby": this.props.ariaLabelledBy
     });
   };
 


### PR DESCRIPTION
I added ariaLabelledBy to the list of available props. I should have done this in the first PR. Sorry about that.