### PR TITLE
Add ariaLabelledBy to the list of available props

### DIFF
--- a/docs/datepicker.md
+++ b/docs/datepicker.md
@@ -5,6 +5,7 @@ General datepicker component.
 | name                         | type                           | default value   | description                                |
 | ---------------------------- | ------------------------------ | --------------- | ------------------------------------------ |
 | `allowSameDay`               | `bool`                         | `false`         |                                            |
+| `ariaLabelledBy`             | `string`                       | `null`          |                                            |
 | `autoComplete`               | `string`                       |                 |                                            |
 | `autoFocus`                  | `bool`                         |                 |                                            |
 | `calendarClassName`          | `string`                       |                 |                                            |


### PR DESCRIPTION
I updated the documentation and added ariaLabelledBy to the available props list. Sorry for my repeated mistakes; I should've done this in the first PR.