### PR TITLE
Don't mark .css files as side effect free

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "es",
     "src/stylesheets"
   ],
-  "sideEffects": false,
+  "sideEffects": ["*.css"],
   "keywords": [
     "react",
     "datepicker",


### PR DESCRIPTION
Fixes #1967

I've included the css files in the sideEffects for webpack.