### PR TITLE
Highlight days when changing the end date

### DIFF
--- a/docs-site/src/examples/dateRange.js
+++ b/docs-site/src/examples/dateRange.js
@@ -14,6 +14,7 @@
         selected={endDate}
         onChange={date => setEndDate(date)}
         selectsEnd
+        startDate={startDate}
         endDate={endDate}
         minDate={startDate}
       />


### PR DESCRIPTION
Days in datepicker get highlighted when changing the start date but not when changing the end date. Related to this issue: https://github.com/Hacker0x01/react-datepicker/issues/1251