### PR TITLE
Render custom header for month/quarter pickers.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "author": "HackerOne",
-  "name": "@bartverbruggen/react-datepicker",
+  "name": "react-datepicker",
   "description": "A simple and reusable datepicker component for React",
   "version": "2.10.2",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A simple and reusable datepicker component for React",
   "version": "2.10.2",
   "license": "MIT",
-  "homepage": "https://github.com/Hacker0x01/react-datepicker",
+  "homepage": "https://github.com/bartverbruggen/react-datepicker",
   "main": "dist/index.js",
   "browser": "dist/react-datepicker.min.js",
   "module": "dist/es/index.js",

--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/Hacker0x01/react-datepicker.git"
+    "url": "git://github.com/bartverbruggen/react-datepicker.git"
   },
   "bugs": {
-    "url": "https://github.com/Hacker0x01/react-datepicker/issues"
+    "url": "https://github.com/bartverbruggen/react-datepicker/issues"
   },
   "devDependencies": {
     "@babel/core": "^7.5.5",

--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/bartverbruggen/react-datepicker.git"
+    "url": "git://github.com/Hacker0x01/react-datepicker.git"
   },
   "bugs": {
-    "url": "https://github.com/bartverbruggen/react-datepicker/issues"
+    "url": "https://github.com/Hacker0x01/react-datepicker/issues"
   },
   "devDependencies": {
     "@babel/core": "^7.5.5",

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "author": "HackerOne",
   "name": "react-datepicker",
   "description": "A simple and reusable datepicker component for React",
-  "version": "2.10.2",
+  "version": "2.10.1",
   "license": "MIT",
-  "homepage": "https://github.com/bartverbruggen/react-datepicker",
+  "homepage": "https://github.com/Hacker0x01/react-datepicker",
   "main": "dist/index.js",
   "browser": "dist/react-datepicker.min.js",
   "module": "dist/es/index.js",
@@ -29,10 +29,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/bartverbruggen/react-datepicker.git"
+    "url": "git://github.com/Hacker0x01/react-datepicker.git"
   },
   "bugs": {
-    "url": "https://github.com/bartverbruggen/react-datepicker/issues"
+    "url": "https://github.com/Hacker0x01/react-datepicker/issues"
   },
   "devDependencies": {
     "@babel/core": "^7.5.5",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "HackerOne",
   "name": "@bartverbruggen/react-datepicker",
   "description": "A simple and reusable datepicker component for React",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "license": "MIT",
   "homepage": "https://github.com/Hacker0x01/react-datepicker",
   "main": "dist/index.js",
@@ -27,9 +27,6 @@
     "date",
     "react-component"
   ],
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
-  },
   "repository": {
     "type": "git",
     "url": "git://github.com/bartverbruggen/react-datepicker.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "author": "HackerOne",
-  "name": "react-datepicker",
+  "name": "@bartverbruggen/react-datepicker",
   "description": "A simple and reusable datepicker component for React",
   "version": "2.10.1",
   "license": "MIT",
@@ -27,12 +27,15 @@
     "date",
     "react-component"
   ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
   "repository": {
     "type": "git",
-    "url": "git://github.com/Hacker0x01/react-datepicker.git"
+    "url": "git://github.com/bartverbruggen/react-datepicker.git"
   },
   "bugs": {
-    "url": "https://github.com/Hacker0x01/react-datepicker/issues"
+    "url": "https://github.com/bartverbruggen/react-datepicker/issues"
   },
   "devDependencies": {
     "@babel/core": "^7.5.5",

--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -574,6 +574,16 @@ export default class Calendar extends React.Component {
       this.props
     );
 
+    const prevYearButtonDisabled = yearDisabledBefore(
+      this.state.date,
+      this.props
+    );
+
+    const nextYearButtonDisabled = yearDisabledAfter(
+      this.state.date,
+      this.props
+    );
+
     return (
       <div
         className="react-datepicker__header react-datepicker__header--custom"
@@ -585,8 +595,12 @@ export default class Calendar extends React.Component {
           changeYear: this.changeYear,
           decreaseMonth: this.decreaseMonth,
           increaseMonth: this.increaseMonth,
+          decreaseYear: this.decreaseYear,
+          increaseYear: this.increaseYear,
           prevMonthButtonDisabled,
-          nextMonthButtonDisabled
+          nextMonthButtonDisabled,
+          prevYearButtonDisabled,
+          nextYearButtonDisabled
         })}
         <div className="react-datepicker__day-names">
           {this.header(monthDate)}

--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -617,6 +617,17 @@ export default class Calendar extends React.Component {
     );
   };
 
+  renderHeader = headerArgs => {
+    switch (true) {
+      case this.props.renderCustomHeader:
+        return this.renderCustomHeader(headerArgs);
+      case this.props.showMonthYearPicker || this.props.showQuarterYearPicker:
+        return this.renderYearHeader(headerArgs);
+      default:
+        return this.renderDefaultHeader(headerArgs);
+    }
+  };
+
   renderMonths = () => {
     if (this.props.showTimeSelectOnly) {
       return;
@@ -639,11 +650,7 @@ export default class Calendar extends React.Component {
           }}
           className="react-datepicker__month-container"
         >
-          {!this.props.showMonthYearPicker && !this.props.showQuarterYearPicker
-            ? this.props.renderCustomHeader
-              ? this.renderCustomHeader({ monthDate, i })
-              : this.renderDefaultHeader({ monthDate, i })
-            : this.renderYearHeader({ monthDate, i })}
+          {this.renderHeader({ monthDate, i })}
           <Month
             onChange={this.changeMonthYear}
             day={monthDate}

--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -619,7 +619,7 @@ export default class Calendar extends React.Component {
 
   renderHeader = headerArgs => {
     switch (true) {
-      case this.props.renderCustomHeader:
+      case this.props.renderCustomHeader !== undefined:
         return this.renderCustomHeader(headerArgs);
       case this.props.showMonthYearPicker || this.props.showQuarterYearPicker:
         return this.renderYearHeader(headerArgs);


### PR DESCRIPTION
When the renderCustomHeader prop is present, always use the custom header. All the order times, pick the right header based on month/quarter picker properties.

Also add year functions to the custom header render props.