### PR TITLE
excludeScrollbar prop for react-onclickoutside

### DIFF
--- a/docs/datepicker.md
+++ b/docs/datepicker.md
@@ -23,6 +23,7 @@ General datepicker component.
 | `endDate`                    | `instanceOf(Date)`             |                 |                                            |
 | `excludeDates`               | `array`                        |                 |                                            |
 | `excludeTimes`               | `array`                        |                 |                                            |
+| `excludeScrollbar`           | `array`                        |                 |                                            |
 | `filterDate`                 | `func`                         |                 |                                            |
 | `fixedHeight`                | `bool`                         |                 |                                            |
 | `forceShowMonthNavigation`   | `bool`                         |                 |                                            |

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,7 @@
 | `endDate`                     | `instanceOfDate`               |                                  |               |
 | `excludeDates`                | `array`                        |                                  |               |
 | `excludeTimes`                | `array`                        |                                  |               |
+| `excludeScrollbar`            | `array`                        |                                  |               |
 | `filterDate`                  | `func`                         |                                  |               |
 | `fixedHeight`                 | `bool`                         |                                  |               |
 | `forceShowMonthNavigation`    | `bool`                         |                                  |               |

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -103,7 +103,8 @@ export default class DatePicker extends React.Component {
         return date;
       },
       inlineFocusSelectedMonth: false,
-      showPopperArrow: true
+      showPopperArrow: true,
+      excludeScrollbar: true
     };
   }
 
@@ -222,7 +223,8 @@ export default class DatePicker extends React.Component {
     inlineFocusSelectedMonth: PropTypes.bool,
     onDayMouseEnter: PropTypes.func,
     onMonthMouseLeave: PropTypes.func,
-    showPopperArrow: PropTypes.bool
+    showPopperArrow: PropTypes.bool,
+    excludeScrollbar: PropTypes.bool
   };
 
   constructor(props) {
@@ -720,6 +722,7 @@ export default class DatePicker extends React.Component {
         showMonthYearPicker={this.props.showMonthYearPicker}
         showQuarterYearPicker={this.props.showQuarterYearPicker}
         showPopperArrow={this.props.showPopperArrow}
+        excludeScrollbar={this.props.excludeScrollbar}
       >
         {this.props.children}
       </WrappedCalendar>


### PR DESCRIPTION
#2031 
By default, react-onclickoutside will not register clicks on the scrollbar if the users scrollbars are constantly visible (an OS setting).
The property is available to disable but it makes sense to enable this by default.

I wanted to create a test case for this, but testing onClickOutside on a scrollbar in a headless browser is really REALLY difficult.