### PR TITLE
Custom time input element with customTimeInput prop

### DIFF
--- a/docs-site/src/components/Examples/index.js
+++ b/docs-site/src/components/Examples/index.js
@@ -67,6 +67,7 @@ import RangeMonthPicker from "../../examples/rangeMonthPicker";
 import QuarterPicker from "../../examples/quarterPicker";
 import RangeQuarterPicker from "../../examples/rangeQuarterPicker";
 import OnCalendarChangeStateCallbacks from "../../examples/onCalendarOpenStateCallbacks";
+import CustomTimeInput from "../../examples/customTimeInput";
 
 import "./style.scss";
 import "react-datepicker/dist/react-datepicker.css";
@@ -333,6 +334,10 @@ export default class exampleComponents extends React.Component {
     {
       title: "Calendar open state callbacks",
       component: OnCalendarChangeStateCallbacks
+    },
+    {
+      title: "Custom time input",
+      component: CustomTimeInput
     }
   ];
 

--- a/docs-site/src/examples/customTimeInput.js
+++ b/docs-site/src/examples/customTimeInput.js
@@ -1,0 +1,18 @@
+() => {
+  const [startDate, setStartDate] = useState(new Date());
+  const ExampleCustomTimeInput = ({ value, onChange }) => (
+    <input
+      value={value}
+      onChange={e => onChange(e.target.value)}
+      style={{ border: "solid 1px pink" }}
+    />
+  );
+  return (
+    <DatePicker
+      selected={startDate}
+      onChange={date => setStartDate(date)}
+      showTimeInput
+      customTimeInput={<ExampleCustomTimeInput />}
+    />
+  );
+};

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,105 +1,108 @@
 # `index` (component)
 
-| name                          | type                           | default value                    | description   |
-| ----------------------------- | ------------------------------ | -------------------------------- | ------------- |
-| `adjustDateOnChange`          | `bool`                         |                                  |               |
-| `allowSameDay`                | `bool`                         | `false`                          |               |
-| `autoComplete`                | `string`                       |                                  |               |
-| `autoFocus`                   | `bool`                         |                                  |               |
-| `calendarClassName`           | `string`                       |                                  |               |
-| `calendarContainer`           | `func`                         |                                  |               |
-| `children`                    | `node`                         |                                  |               |
-| `className`                   | `string`                       |                                  |               |
-| `clearButtonTitle`            | `string`                       |                                  |               |
-| `customInput`                 | `element`                      |                                  |               |
-| `customInputRef`              | `string`                       |                                  |               |
-| `dateFormat`                  | `union(string\|array)`         | `"MM/dd/yyyy"`                   |               |
-| `dateFormatCalendar`          | `string`                       | `"LLLL yyyy"`                    |               |
-| `dayClassName`                | `func`                         |                                  |               |
-| `disabled`                    | `bool`                         | `false`                          |               |
-| `disabledKeyboardNavigation`  | `bool`                         | `false`                          |               |
-| `dropdownMode`                | `enum("scroll"\|"select")`     | `"scroll"`                       |               |
-| `endDate`                     | `instanceOfDate`               |                                  |               |
-| `excludeDates`                | `array`                        |                                  |               |
-| `excludeTimes`                | `array`                        |                                  |               |
-| `filterDate`                  | `func`                         |                                  |               |
-| `fixedHeight`                 | `bool`                         |                                  |               |
-| `forceShowMonthNavigation`    | `bool`                         |                                  |               |
-| `formatWeekDay`               | `func`                         |                                  |               |
-| `formatWeekNumber`            | `func`                         |                                  |               |
-| `highlightDates`              | `array`                        |                                  |               |
-| `id`                          | `string`                       |                                  |               |
-| `includeDates`                | `array`                        |                                  |               |
-| `includeTimes`                | `array`                        |                                  |               |
-| `injectTimes`                 | `array`                        |                                  |               |
-| `inline`                      | `bool`                         |                                  |               |
-| `inlineFocusSelectedMonth`    | `bool`                         | `false`                          |               |
-| `isClearable`                 | `bool`                         |                                  |               |
-| `locale`                      | `union(string\|shape)`         |                                  |               |
-| `maxDate`                     | `instanceOfDate`               |                                  |               |
-| `maxTime`                     | `instanceOfDate`               |                                  |               |
-| `minDate`                     | `instanceOfDate`               |                                  |               |
-| `minTime`                     | `instanceOfDate`               |                                  |               |
-| `monthsShown`                 | `number`                       | `1`                              |               |
-| `name`                        | `string`                       |                                  |               |
-| `nextMonthButtonLabel`        | `string`                       | `"Next month"`                   |               |
-| `onBlur`                      | `func`                         | `function() {}`                  |               |
-| `onCalendarClose`             | `func`                         |                                  |               |
-| `onCalendarOpen`              | `func`                         |                                  |               |
-| `onChange`                    | `func`                         | `function() {}`                  |               |
-| `onChangeRaw`                 | `func`                         |                                  |               |
-| `onClickOutside`              | `func`                         | `function() {}`                  |               |
-| `onDayMouseEnter`             | `func`                         |                                  |               |
-| `onFocus`                     | `func`                         | `function() {}`                  |               |
-| `onInputClick`                | `func`                         | `function() {}`                  |               |
-| `onInputError`                | `func`                         | `function() {}`                  |               |
-| `onKeyDown`                   | `func`                         | `function() {}`                  |               |
-| `onMonthChange`               | `func`                         | `function() {}`                  |               |
-| `onMonthMouseLeave`           | `func`                         |                                  |               |
-| `onSelect`                    | `func`                         | `function() {}`                  |               |
-| `onWeekSelect`                | `func`                         |                                  |               |
-| `onYearChange`                | `func`                         | `function() {}`                  |               |
-| `open`                        | `bool`                         |                                  |               |
-| `openToDate`                  | `instanceOfDate`               |                                  |               |
-| `peekNextMonth`               | `bool`                         |                                  |               |
-| `placeholderText`             | `string`                       |                                  |               |
-| `popperClassName`             | `string`                       |                                  |               |
-| `popperContainer`             | `func`                         |                                  |               |
-| `popperModifiers`             | `object`                       |                                  |               |
-| `popperPlacement`             | `enumpopperPlacementPositions` |                                  |               |
-| `popperProps`                 | `object`                       |                                  |               |
-| `preventOpenOnFocus`          | `bool`                         | `false`                          |               |
-| `previousMonthButtonLabel`    | `string`                       | `"Previous Month"`               |               |
-| `readOnly`                    | `bool`                         | `false`                          |               |
-| `renderCustomHeader`          | `func`                         |                                  |               |
-| `renderDayContents`           | `func`                         | `function(date) { return date;}` |               |
-| `required`                    | `bool`                         |                                  |               |
-| `scrollableMonthYearDropdown` | `bool`                         |                                  |               |
-| `scrollableYearDropdown`      | `bool`                         |                                  |               |
-| `selected`                    | `instanceOfDate`               |                                  |               |
-| `selectsEnd`                  | `bool`                         |                                  |               |
-| `selectsStart`                | `bool`                         |                                  |               |
-| `shouldCloseOnSelect`         | `bool`                         | `true`                           |               |
-| `showDisabledMonthNavigation` | `bool`                         |                                  |               |
-| `showMonthDropdown`           | `bool`                         |                                  |               |
-| `showMonthYearDropdown`       | `bool`                         |                                  |               |
-| `showMonthYearPicker`         | `bool`                         | `false`                          |               |
-| `showTimeInput`               | `bool`                         | `false`                          |               |
-| `showTimeSelect`              | `bool`                         | `false`                          |               |
-| `showTimeSelectOnly`          | `bool`                         |                                  |               |
-| `showWeekNumbers`             | `bool`                         |                                  |               |
-| `showYearDropdown`            | `bool`                         |                                  |               |
-| `startDate`                   | `instanceOfDate`               |                                  |               |
-| `startOpen`                   | `bool`                         |                                  |               |
-| `strictParsing`               | `bool`                         | `false`                          |               |
-| `tabIndex`                    | `number`                       |                                  |               |
-| `timeCaption`                 | `string`                       | `"Time"`                         |               |
-| `timeFormat`                  | `string`                       |                                  |               |
-| `timeInputLabel`              | `string`                       | `"Time"`                         |               |
-| `timeIntervals`               | `number`                       | `30`                             |               |
-| `title`                       | `string`                       |                                  | `todayButton` | `node` |
-| `useShortMonthInDropdown`     | `bool`                         |                                  |               |
-| `useWeekdaysShort`            | `bool`                         |                                  | `value`       | `string` |
-| `weekLabel`                   | `string`                       |                                  |               |
-| `withPortal`                  | `bool`                         | `false`                          |               |
-| `yearDropdownItemNumber`      | `number`                       |                                  |               |
+| name                          | type                           | default value                    | description |
+| ----------------------------- | ------------------------------ | -------------------------------- | ----------- |
+| `adjustDateOnChange`          | `bool`                         |                                  |             |
+| `allowSameDay`                | `bool`                         | `false`                          |             |
+| `autoComplete`                | `string`                       |                                  |             |
+| `autoFocus`                   | `bool`                         |                                  |             |
+| `calendarClassName`           | `string`                       |                                  |             |
+| `calendarContainer`           | `func`                         |                                  |             |
+| `children`                    | `node`                         |                                  |             |
+| `className`                   | `string`                       |                                  |             |
+| `clearButtonTitle`            | `string`                       |                                  |             |
+| `customInput`                 | `element`                      |                                  |             |
+| `customInputRef`              | `string`                       |                                  |             |
+| `dateFormat`                  | `union(string\|array)`         | `"MM/dd/yyyy"`                   |             |
+| `dateFormatCalendar`          | `string`                       | `"LLLL yyyy"`                    |             |
+| `dayClassName`                | `func`                         |                                  |             |
+| `disabled`                    | `bool`                         | `false`                          |             |
+| `disabledKeyboardNavigation`  | `bool`                         | `false`                          |             |
+| `dropdownMode`                | `enum("scroll"\|"select")`     | `"scroll"`                       |             |
+| `endDate`                     | `instanceOfDate`               |                                  |             |
+| `excludeDates`                | `array`                        |                                  |             |
+| `excludeTimes`                | `array`                        |                                  |             |
+| `filterDate`                  | `func`                         |                                  |             |
+| `fixedHeight`                 | `bool`                         |                                  |             |
+| `forceShowMonthNavigation`    | `bool`                         |                                  |             |
+| `formatWeekDay`               | `func`                         |                                  |             |
+| `formatWeekNumber`            | `func`                         |                                  |             |
+| `highlightDates`              | `array`                        |                                  |             |
+| `id`                          | `string`                       |                                  |             |
+| `includeDates`                | `array`                        |                                  |             |
+| `includeTimes`                | `array`                        |                                  |             |
+| `injectTimes`                 | `array`                        |                                  |             |
+| `inline`                      | `bool`                         |                                  |             |
+| `inlineFocusSelectedMonth`    | `bool`                         | `false`                          |             |
+| `isClearable`                 | `bool`                         |                                  |             |
+| `locale`                      | `union(string\|shape)`         |                                  |             |
+| `maxDate`                     | `instanceOfDate`               |                                  |             |
+| `maxTime`                     | `instanceOfDate`               |                                  |             |
+| `minDate`                     | `instanceOfDate`               |                                  |             |
+| `minTime`                     | `instanceOfDate`               |                                  |             |
+| `monthsShown`                 | `number`                       | `1`                              |             |
+| `name`                        | `string`                       |                                  |             |
+| `nextMonthButtonLabel`        | `string`                       | `"Next month"`                   |             |
+| `onBlur`                      | `func`                         | `function() {}`                  |             |
+| `onCalendarClose`             | `func`                         |                                  |             |
+| `onCalendarOpen`              | `func`                         |                                  |             |
+| `onChange`                    | `func`                         | `function() {}`                  |             |
+| `onChangeRaw`                 | `func`                         |                                  |             |
+| `onClickOutside`              | `func`                         | `function() {}`                  |             |
+| `onDayMouseEnter`             | `func`                         |                                  |             |
+| `onFocus`                     | `func`                         | `function() {}`                  |             |
+| `onInputClick`                | `func`                         | `function() {}`                  |             |
+| `onInputError`                | `func`                         | `function() {}`                  |             |
+| `onKeyDown`                   | `func`                         | `function() {}`                  |             |
+| `onMonthChange`               | `func`                         | `function() {}`                  |             |
+| `onMonthMouseLeave`           | `func`                         |                                  |             |
+| `onSelect`                    | `func`                         | `function() {}`                  |             |
+| `onWeekSelect`                | `func`                         |                                  |             |
+| `onYearChange`                | `func`                         | `function() {}`                  |             |
+| `open`                        | `bool`                         |                                  |             |
+| `openToDate`                  | `instanceOfDate`               |                                  |             |
+| `peekNextMonth`               | `bool`                         |                                  |             |
+| `placeholderText`             | `string`                       |                                  |             |
+| `popperClassName`             | `string`                       |                                  |             |
+| `popperContainer`             | `func`                         |                                  |             |
+| `popperModifiers`             | `object`                       |                                  |             |
+| `popperPlacement`             | `enumpopperPlacementPositions` |                                  |             |
+| `popperProps`                 | `object`                       |                                  |             |
+| `preventOpenOnFocus`          | `bool`                         | `false`                          |             |
+| `previousMonthButtonLabel`    | `string`                       | `"Previous Month"`               |             |
+| `readOnly`                    | `bool`                         | `false`                          |             |
+| `renderCustomHeader`          | `func`                         |                                  |             |
+| `renderDayContents`           | `func`                         | `function(date) { return date;}` |             |
+| `required`                    | `bool`                         |                                  |             |
+| `scrollableMonthYearDropdown` | `bool`                         |                                  |             |
+| `scrollableYearDropdown`      | `bool`                         |                                  |             |
+| `selected`                    | `instanceOfDate`               |                                  |             |
+| `selectsEnd`                  | `bool`                         |                                  |             |
+| `selectsStart`                | `bool`                         |                                  |             |
+| `shouldCloseOnSelect`         | `bool`                         | `true`                           |             |
+| `showDisabledMonthNavigation` | `bool`                         |                                  |             |
+| `showMonthDropdown`           | `bool`                         |                                  |             |
+| `showMonthYearDropdown`       | `bool`                         |                                  |             |
+| `showMonthYearPicker`         | `bool`                         | `false`                          |             |
+| `showTimeInput`               | `bool`                         | `false`                          |             |
+| `showTimeSelect`              | `bool`                         | `false`                          |             |
+| `showTimeSelectOnly`          | `bool`                         |                                  |             |
+| `showWeekNumbers`             | `bool`                         |                                  |             |
+| `showYearDropdown`            | `bool`                         |                                  |             |
+| `startDate`                   | `instanceOfDate`               |                                  |             |
+| `startOpen`                   | `bool`                         |                                  |             |
+| `strictParsing`               | `bool`                         | `false`                          |             |
+| `tabIndex`                    | `number`                       |                                  |             |
+| `timeCaption`                 | `string`                       | `"Time"`                         |             |
+| `timeFormat`                  | `string`                       |                                  |             |
+| `timeInputLabel`              | `string`                       | `"Time"`                         |             |
+| `timeIntervals`               | `number`                       | `30`                             |             |
+| `title`                       | `string`                       |                                  |             |
+| `todayButton`                 | `node`                         |                                  |             |
+| `useShortMonthInDropdown`     | `bool`                         |                                  |             |
+| `useWeekdaysShort`            | `bool`                         |                                  |             |
+| `value`                       | `string`                       |                                  |             |
+| `weekLabel`                   | `string`                       |                                  |             |
+| `withPortal`                  | `bool`                         | `false`                          |             |
+| `yearDropdownItemNumber`      | `number`                       |                                  |             |
+| `customTimeInput`             | `number`                       |                                  |             |

--- a/docs/inputTime.md
+++ b/docs/inputTime.md
@@ -1,7 +1,8 @@
 # `inputTime` (component)
 
-| name             | type     | default value | description |
-| ---------------- | -------- | ------------- | ----------- |
-| `onChange`       | `func`   |               |             |
-| `timeInputLabel` | `string` |               |             |
-| `timeString`     | `string` |               |             |
+| name              | type     | default value | description |
+| ----------------- | -------- | ------------- | ----------- |
+| `onChange`        | `func`   |               |             |
+| `timeInputLabel`  | `string` |               |             |
+| `timeString`      | `string` |               |             |
+| `customTimeInput` | `string` |               |             |

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "HackerOne",
   "name": "react-datepicker",
   "description": "A simple and reusable datepicker component for React",
-  "version": "2.11.0",
+  "version": "2.11.1-beta",
   "license": "MIT",
   "homepage": "https://github.com/Hacker0x01/react-datepicker",
   "main": "dist/index.js",

--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -61,7 +61,8 @@ export default class Calendar extends React.Component {
       previousYearButtonLabel: "Previous Year",
       nextYearButtonLabel: "Next Year",
       previousMonthButtonLabel: "Previous Month",
-      nextMonthButtonLabel: "Next Month"
+      nextMonthButtonLabel: "Next Month",
+      customTimeInput: null
     };
   }
 
@@ -146,7 +147,8 @@ export default class Calendar extends React.Component {
     renderDayContents: PropTypes.func,
     onDayMouseEnter: PropTypes.func,
     onMonthMouseLeave: PropTypes.func,
-    showPopperArrow: PropTypes.bool
+    showPopperArrow: PropTypes.bool,
+    customTimeInput: PropTypes.element
   };
 
   constructor(props) {
@@ -380,8 +382,9 @@ export default class Calendar extends React.Component {
       classes.push("react-datepicker__navigation--previous--disabled");
       clickHandler = null;
     }
-    
-    const isForYear = this.props.showMonthYearPicker || this.props.showQuarterYearPicker;
+
+    const isForYear =
+      this.props.showMonthYearPicker || this.props.showQuarterYearPicker;
 
     return (
       <button
@@ -390,7 +393,7 @@ export default class Calendar extends React.Component {
         onClick={clickHandler}
         aria-label={isForYear ? "Previous Year" : "Previous Month"}
       >
-        {isForYear 
+        {isForYear
           ? this.props.previousYearButtonLabel
           : this.props.previousMonthButtonLabel}
       </button>
@@ -445,17 +448,18 @@ export default class Calendar extends React.Component {
       classes.push("react-datepicker__navigation--next--disabled");
       clickHandler = null;
     }
-  
-    const isForYear = this.props.showMonthYearPicker || this.props.showQuarterYearPicker;
-    
+
+    const isForYear =
+      this.props.showMonthYearPicker || this.props.showQuarterYearPicker;
+
     return (
       <button
         type="button"
         className={classes.join(" ")}
         onClick={clickHandler}
-        aria-label={isForYear ? "Next Year" : "Next Month"} 
+        aria-label={isForYear ? "Next Year" : "Next Month"}
       >
-        { isForYear
+        {isForYear
           ? this.props.nextYearButtonLabel
           : this.props.nextMonthButtonLabel}
       </button>
@@ -553,9 +557,7 @@ export default class Calendar extends React.Component {
     <div className="react-datepicker__header">
       {this.renderCurrentMonth(monthDate)}
       <div
-        className={`react-datepicker__header__dropdown react-datepicker__header__dropdown--${
-          this.props.dropdownMode
-        }`}
+        className={`react-datepicker__header__dropdown react-datepicker__header__dropdown--${this.props.dropdownMode}`}
         onFocus={this.handleDropdownFocus}
       >
         {this.renderMonthDropdown(i !== 0)}
@@ -743,6 +745,7 @@ export default class Calendar extends React.Component {
           timeString={timeString}
           timeInputLabel={this.props.timeInputLabel}
           onChange={this.props.onTimeChange}
+          customTimeInput={this.props.customTimeInput}
         />
       );
     }

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -103,7 +103,8 @@ export default class DatePicker extends React.Component {
         return date;
       },
       inlineFocusSelectedMonth: false,
-      showPopperArrow: true
+      showPopperArrow: true,
+      customTimeInput: null
     };
   }
 
@@ -222,7 +223,8 @@ export default class DatePicker extends React.Component {
     inlineFocusSelectedMonth: PropTypes.bool,
     onDayMouseEnter: PropTypes.func,
     onMonthMouseLeave: PropTypes.func,
-    showPopperArrow: PropTypes.bool
+    showPopperArrow: PropTypes.bool,
+    customTimeInput: PropTypes.element
   };
 
   constructor(props) {
@@ -720,6 +722,7 @@ export default class DatePicker extends React.Component {
         showMonthYearPicker={this.props.showMonthYearPicker}
         showQuarterYearPicker={this.props.showQuarterYearPicker}
         showPopperArrow={this.props.showPopperArrow}
+        customTimeInput={this.props.customTimeInput}
       >
         {this.props.children}
       </WrappedCalendar>

--- a/src/inputTime.jsx
+++ b/src/inputTime.jsx
@@ -5,7 +5,8 @@ export default class inputTime extends React.Component {
   static propTypes = {
     onChange: PropTypes.func,
     timeString: PropTypes.string,
-    timeInputLabel: PropTypes.string
+    timeInputLabel: PropTypes.string,
+    customTimeInput: PropTypes.element
   };
 
   constructor(props) {
@@ -24,9 +25,33 @@ export default class inputTime extends React.Component {
     this.props.onChange(date);
   };
 
-  render() {
+  renderTimeInput = () => {
     const { time } = this.state;
-    const { timeString } = this.props;
+    const { timeString, customTimeInput } = this.props;
+
+    if (customTimeInput) {
+      return React.cloneElement(customTimeInput, {
+        value: time,
+        onChange: this.onTimeChange
+      });
+    }
+
+    return (
+      <input
+        type="time"
+        className="react-datepicker-time__input"
+        placeholder="Time"
+        name="time-input"
+        required
+        value={time}
+        onChange={ev => {
+          this.onTimeChange(ev.target.value || timeString);
+        }}
+      />
+    );
+  };
+
+  render() {
     return (
       <div className="react-datepicker__input-time-container">
         <div className="react-datepicker-time__caption">
@@ -34,17 +59,7 @@ export default class inputTime extends React.Component {
         </div>
         <div className="react-datepicker-time__input-container">
           <div className="react-datepicker-time__input">
-            <input
-              type="time"
-              className="react-datepicker-time__input"
-              placeholder="Time"
-              name="time-input"
-              required
-              value={time}
-              onChange={ev => {
-                this.onTimeChange(ev.target.value || timeString);
-              }}
-            />
+            {this.renderTimeInput()}
           </div>
         </div>
       </div>

--- a/test/time_input_test.js
+++ b/test/time_input_test.js
@@ -2,6 +2,7 @@ import React from "react";
 import { mount, shallow } from "enzyme";
 import DatePicker from "../src/index.jsx";
 import InputTimeComponent from "../src/inputTime";
+import PropTypes from "prop-types";
 
 describe("DatePicker", () => {
   let sandbox;
@@ -54,6 +55,11 @@ describe("DatePicker", () => {
         style={{ border: "solid 1px pink" }}
       />
     );
+
+    CustomTimeInputComponent.propTypes = {
+      onChange: PropTypes.func,
+      value: PropTypes.string
+    };
 
     const timeComponent = shallow(
       <InputTimeComponent


### PR DESCRIPTION
Added a `customTimeInput` prop of PropTypes.element type to render a custom input in place of the default one used in the inputTime component. This enable the user to implement a custom time input control with low effort.

We already use this edited version of react-datepicker in production because our end users are used to work with a smarter time input we developed. We also have to support Safari which doesn't work with stardard date time inputs.

This doesn't affect other behaviours and should be easy to document!

Thanks!