### PR TITLE
Custom class documentation example fix

### DIFF
--- a/docs-site/src/examples/customClassName.js
+++ b/docs-site/src/examples/customClassName.js
@@ -4,9 +4,7 @@
     <DatePicker
       selected={startDate}
       onChange={date => setStartDate(date)}
-      dayClassName={date =>
-        getDate(date) < Math.random() * 31 ? "random" : undefined
-      }
+      className="red-border"
     />
   );
 };


### PR DESCRIPTION
The "Custom class name" example in the documentation was a duplicate of the "Custom day class name" example.