### PR TITLE
Fix week numbers for non us locales.

### DIFF
--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -18,6 +18,7 @@ import getMinutes from "date-fns/getMinutes";
 import getHours from "date-fns/getHours";
 import getDay from "date-fns/getDay";
 import getDate from "date-fns/getDate";
+import dfgetWeek from "date-fns/getWeek";
 import getMonth from "date-fns/getMonth";
 import getQuarter from "date-fns/getQuarter";
 import getYear from "date-fns/getYear";
@@ -190,11 +191,9 @@ export {
   getTime
 };
 
-export function getWeek(date) {
-  if (!isSameYear(endOfWeek(date), date)) {
-    return 1;
-  }
-  return differenceInCalendarWeeks(date, startOfYear(date)) + 1;
+export function getWeek(date, locale) {
+  let localeObj = (locale && getLocaleObject(locale)) || (getDefaultLocale() && getLocaleObject(getDefaultLocale()));
+  return dfgetWeek(date, localeObj ? { locale: localeObj } : null);
 }
 
 export function getDayOfWeekCode(day, locale) {

--- a/src/week.jsx
+++ b/src/week.jsx
@@ -73,7 +73,7 @@ export default class Week extends React.Component {
     if (this.props.formatWeekNumber) {
       return this.props.formatWeekNumber(date);
     }
-    return utils.getWeek(date);
+    return utils.getWeek(date, this.props.locale);
   };
 
   renderDays = () => {


### PR DESCRIPTION
Leverage date-fns getWeek function to get correct week numbers. 

This solves problems with wrong week numbers for some non us locales like danish (da).
For example 1 Jan 2021 is in week 53 but is reported as 1.
This also fixes #1878