### PR TITLE
Updated the aria role attributes for benefit of screenreaders

### DIFF
--- a/src/day.jsx
+++ b/src/day.jsx
@@ -240,14 +240,15 @@ export default class Day extends React.Component {
 
   getAriaLabel = () => {
     const {
-            day,
-            ariaLabelPrefixWhenEnabled = "Choose",
-            ariaLabelPrefixWhenDisabled = "Not available" 
+      day,
+      ariaLabelPrefixWhenEnabled = "Choose",
+      ariaLabelPrefixWhenDisabled = "Not available"
     } = this.props;
-    
-    const prefix = this.isDisabled() || this.isExcluded()
-                    ? ariaLabelPrefixWhenDisabled
-                    : ariaLabelPrefixWhenEnabled;
+
+    const prefix =
+      this.isDisabled() || this.isExcluded()
+        ? ariaLabelPrefixWhenDisabled
+        : ariaLabelPrefixWhenEnabled;
 
     return `${prefix} ${formatDate(day, "PPPP")}`;
   };
@@ -274,7 +275,7 @@ export default class Day extends React.Component {
       onMouseEnter={this.handleMouseEnter}
       tabIndex={this.getTabIndex()}
       aria-label={this.getAriaLabel()}
-      role="option"
+      role="button"
       aria-disabled={this.isDisabled()}
     >
       {this.props.renderDayContents

--- a/src/month.jsx
+++ b/src/month.jsx
@@ -317,7 +317,6 @@ export default class Month extends React.Component {
       <div
         className={this.getClassNames()}
         onMouseLeave={this.handleMouseLeave}
-        role="listbox"
         aria-label={`${ariaLabelPrefix} ${utils.formatDate(day, "yyyy-MM")}`}
       >
         {showMonthYearPicker


### PR DESCRIPTION
fixes #2095 

role "option" changed to "button", removed unnecessary "listbox" role

## to test this, enable a screenreader such as ChromeVox, and when focused on a calendar day, you should only here the announcement "Choose [date]" and you should not hear any declaration of "[option number] of 35" or "[option number] of 42".