### PR TITLE
Do not change time if date picker only

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -444,7 +444,7 @@ export default class DatePicker extends React.Component {
       );
       return this.preventFocusTimeout;
     });
-    this.setSelected(date, event, undefined, monthSelectedIn);
+    this.setSelected(date, event, false, monthSelectedIn);
     if (!this.props.shouldCloseOnSelect || this.props.showTimeSelect) {
       this.setPreSelection(date);
     } else if (!this.props.inline) {
@@ -461,13 +461,17 @@ export default class DatePicker extends React.Component {
 
     if (!isEqual(this.props.selected, changedDate) || this.props.allowSameDay) {
       if (changedDate !== null) {
-        if (this.props.selected) {
-          let selected = this.props.selected;
-          if (keepInput) selected = newDate(changedDate);
+        if (
+          this.props.selected &&
+          (!keepInput ||
+            (!this.props.showTimeSelect &&
+              !this.props.showTimeSelectOnly &&
+              !this.props.showTimeInput))
+        ) {
           changedDate = setTime(changedDate, {
-            hour: getHours(selected),
-            minute: getMinutes(selected),
-            second: getSeconds(selected)
+            hour: getHours(this.props.selected),
+            minute: getMinutes(this.props.selected),
+            second: getSeconds(this.props.selected)
           });
         }
         if (!this.props.inline) {

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -399,7 +399,7 @@ describe("DatePicker", () => {
     expect(clearButtonText).to.equal("clear button");
   });
 
-  it("should save time from the selected date", () => {
+  it("should save time from the selected date during day change", () => {
     const selected = utils.newDate("2015-12-20 10:11:12");
     let date;
 
@@ -417,6 +417,28 @@ describe("DatePicker", () => {
       "react-datepicker__day"
     )[0];
     TestUtils.Simulate.click(dayButton);
+
+    expect(utils.getHours(date)).to.equal(10);
+    expect(utils.getMinutes(date)).to.equal(11);
+    expect(utils.getSeconds(date)).to.equal(12);
+  });
+
+  it("should save time from the selected date during date change", () => {
+    const selected = utils.newDate("2015-12-20 10:11:12");
+    let date;
+
+    var datePicker = TestUtils.renderIntoDocument(
+      <DatePicker
+        selected={selected}
+        onChange={d => {
+          date = d;
+        }}
+      />
+    );
+
+    var input = ReactDOM.findDOMNode(datePicker.input);
+    input.value = utils.newDate("2014-01-02");
+    TestUtils.Simulate.change(input);
 
     expect(utils.getHours(date)).to.equal(10);
     expect(utils.getMinutes(date)).to.equal(11);


### PR DESCRIPTION
Hello. For now date picker purges away selected time. This should not happen when it used without time picker.

I see that today overall code base looks over complicated. So I think you are going to rewrite it completely. Please keep date and time values separately and call `onChange` with merged value.