### PR TITLE
fixed search in page, navigation to example and scroll back to top on second click.

### DIFF
--- a/docs-site/src/components/App/index.js
+++ b/docs-site/src/components/App/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import ExampleComponents from "../Examples";
 import ribbon from "./ribbon.png";
 import logo from "./logo.png";
@@ -7,10 +7,24 @@ import DatePicker from "react-datepicker";
 const Example = () => {
   const [isOpen, setIsOpen] = useState(true);
   const [startDate, setStartDate] = useState(new Date());
+  const [isScrolled, setIsScrolled] = useState(true);
+
+  useEffect(() => {
+    document.addEventListener("scroll", handleScroll);
+  }, []);
+
+  const handleScroll = () => {
+    const Show = window.scrollY < 400;
+    if (Show) {
+      setIsScrolled(true);
+    } else {
+      setIsScrolled(false);
+    }
+  };
 
   return (
     <DatePicker
-      open={isOpen}
+      open={isOpen && isScrolled}
       selected={startDate}
       onChange={date => {
         setStartDate(date);
@@ -31,7 +45,6 @@ const Root = () => (
             Crafted by{" "}
             <img
               src={logo}
-              ungiu
               className="hero__image"
               alt="HackerOne"
               title="HackerOne"

--- a/docs-site/src/components/Examples/index.js
+++ b/docs-site/src/components/Examples/index.js
@@ -346,6 +346,13 @@ export default class exampleComponents extends React.Component {
     }
   ];
 
+  handleAnchorClick = (e, id) => {
+    e.preventDefault();
+    document
+      .getElementById(id)
+      .scrollIntoView({ behavior: "smooth", block: "center" });
+  };
+
   render() {
     return (
       <>
@@ -353,7 +360,15 @@ export default class exampleComponents extends React.Component {
         <ul className="examples__navigation">
           {this.examples.map((example, index) => (
             <li className="examples__navigation-item" key={`link-${index}`}>
-              <a href={`#example-${slugify(example.title, { lower: true })}`}>
+              <a
+                href={`#example-${slugify(example.title, { lower: true })}`}
+                onClick={e =>
+                  this.handleAnchorClick(
+                    e,
+                    `example-${slugify(example.title, { lower: true })}`
+                  )
+                }
+              >
                 {example.title}
               </a>
             </li>


### PR DESCRIPTION
**Description of PR**
* currently on document website on click to example navigation anchor tag it's not scroll to particular example. which is inconvenient for developer to see the things and utilise the documentation properly and efficiently. this PR will solve this issue and give a nice and smooth scrolling to reach particular example.
* fixed bug of browser in search page. user can now search for text and it will navigate to the found text inspite of staying at the top of page.
* fixed bug of when user doble click on page it navigate it to top.

**Type of PR**

- [x] Bugfix

**Relevant Issues**  
Fixes #2106, Fixes #2109 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop

**Screenshots**
#### not navigating on anchor click (current).
![currentScene](https://user-images.githubusercontent.com/45959932/79272285-dc1d1180-7ebe-11ea-8c09-ffd407cd590d.gif)
<br>

#### After issue is solved (navigating to particular example).
![solved](https://user-images.githubusercontent.com/45959932/79272486-2605f780-7ebf-11ea-8b9b-b39e9896a343.gif)
<br>

#### not navigating on browser search in page (current)
![search](https://user-images.githubusercontent.com/45959932/79364504-0e824980-7f67-11ea-9abb-d8efb034056f.gif)
<br>

#### fixed of search in page
![solved search](https://user-images.githubusercontent.com/45959932/79364548-1f32bf80-7f67-11ea-9b2e-f73e8265f50d.gif)
<br>

#### one second click going to top (current)
![double click bug](https://user-images.githubusercontent.com/45959932/79364640-44bfc900-7f67-11ea-8e0f-9a1308aa7b49.gif)
<br>

#### fixed of second click
![fixed double click](https://user-images.githubusercontent.com/45959932/79364708-5903c600-7f67-11ea-8630-cc4f39856167.gif)


Thanks & Regards,
Binu Kumar