### PR TITLE
Allow React elements as button labels

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -79,8 +79,8 @@
 | `popperPlacement`            | `enumpopperPlacementPositions` |                    |             |
 | `popperProps`                | `object`                       |                    |             |
 | `preventOpenOnFocus`         | `bool`                         | `false`            |             |
-| `previousMonthButtonLabel`   | `string`                       | `"Previous Month"` |             |
-| `previousYearButtonLabel`    | `string`                       | `"Previous Year"`  |             |
+| `previousMonthButtonLabel`   | `union(string\|node)`          | `"Previous Month"` |             |
+| `previousYearButtonLabel`    | `union(string\|node)`          | `"Previous Year"`  |             |
 | `readOnly`                   | `bool`                         | `false`            |             |
 | `renderCustomHeader`         | `func`                         |                    |             |
 | `renderDayContents`          | `func`                         | `function(date) {  |

--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -148,8 +148,14 @@ export default class Calendar extends React.Component {
     shouldCloseOnSelect: PropTypes.bool,
     useShortMonthInDropdown: PropTypes.bool,
     showDisabledMonthNavigation: PropTypes.bool,
-    previousMonthButtonLabel: PropTypes.string,
-    nextMonthButtonLabel: PropTypes.string,
+    previousMonthButtonLabel: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.node
+    ]),
+    nextMonthButtonLabel: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.node
+    ]),
     previousYearButtonLabel: PropTypes.string,
     nextYearButtonLabel: PropTypes.string,
     renderCustomHeader: PropTypes.func,

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -221,8 +221,14 @@ export default class DatePicker extends React.Component {
     excludeTimes: PropTypes.array,
     useShortMonthInDropdown: PropTypes.bool,
     clearButtonTitle: PropTypes.string,
-    previousMonthButtonLabel: PropTypes.string,
-    nextMonthButtonLabel: PropTypes.string,
+    previousMonthButtonLabel: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.node
+    ]),
+    nextMonthButtonLabel: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.node
+    ]),
     previousYearButtonLabel: PropTypes.string,
     nextYearButtonLabel: PropTypes.string,
     timeInputLabel: PropTypes.string,


### PR DESCRIPTION
This updates the prop type and docs for `previousMonthButtonLabel` and `nextMonthButtonLabel` to allow any renderable content to be passed in. For my use case, I'm passing in some custom svgs for the icons. The code already supports this use, it just needs the updated prop type definitions.

![image](https://user-images.githubusercontent.com/10593890/80745461-34fec380-8ad5-11ea-9b49-b265238458d7.png)
