### PR TITLE
Replace `inlineFocusSelectedMonth` with `focusSelectedMonth`

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,7 @@
 | `includeTimes`               | `array`                        |                    |             |
 | `injectTimes`                | `array`                        |                    |             |
 | `inline`                     | `bool`                         |                    |             |
-| `inlineFocusSelectedMonth`   | `bool`                         | `false`            |             |
+| `focusSelectedMonth`         | `bool`                         | `false`            |             |
 | `isClearable`                | `bool`                         |                    |             |
 | `locale`                     | `union(string\|shape)`         |                    |             |
 | `maxDate`                    | `instanceOfDate`               |                    |             |

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -104,7 +104,7 @@ export default class DatePicker extends React.Component {
       renderDayContents(date) {
         return date;
       },
-      inlineFocusSelectedMonth: false,
+      focusSelectedMonth: false,
       showPopperArrow: true,
       excludeScrollbar: true,
       customTimeInput: null
@@ -229,7 +229,7 @@ export default class DatePicker extends React.Component {
     renderCustomHeader: PropTypes.func,
     renderDayContents: PropTypes.func,
     wrapperClassName: PropTypes.string,
-    inlineFocusSelectedMonth: PropTypes.bool,
+    focusSelectedMonth: PropTypes.bool,
     onDayMouseEnter: PropTypes.func,
     onMonthMouseLeave: PropTypes.func,
     showPopperArrow: PropTypes.bool,
@@ -482,11 +482,7 @@ export default class DatePicker extends React.Component {
             preSelection: changedDate
           });
         }
-        if (
-          this.props.inline &&
-          this.props.monthsShown > 1 &&
-          !this.props.inlineFocusSelectedMonth
-        ) {
+        if (!this.props.focusSelectedMonth) {
           this.setState({ monthSelectedIn: monthSelectedIn });
         }
       }

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -1182,33 +1182,9 @@ describe("DatePicker", () => {
     });
   });
 
-  it("should save monthSelectedIn only if calendar is inline", () => {
+  it("should disable non-jumping if prop focusSelectedMonth is true", () => {
     var datePickerInline = TestUtils.renderIntoDocument(
-      <DatePicker inline monthsShown={2} />
-    );
-    var dayButtonInline = TestUtils.scryRenderedDOMComponentsWithClass(
-      datePickerInline,
-      "react-datepicker__day"
-    )[45];
-    TestUtils.Simulate.click(dayButtonInline);
-    assert.equal(datePickerInline.state.monthSelectedIn, 1);
-
-    var datePicker = TestUtils.renderIntoDocument(
-      <DatePicker monthsShown={2} />
-    );
-    var dateInput = datePicker.input;
-    TestUtils.Simulate.focus(ReactDOM.findDOMNode(dateInput));
-    var day = TestUtils.scryRenderedComponentsWithType(
-      datePicker.calendar,
-      Day
-    )[40];
-    TestUtils.Simulate.click(ReactDOM.findDOMNode(day));
-    assert.equal(datePicker.state.monthSelectedIn, undefined);
-  });
-
-  it("should disable non-jumping if prop inlineFocusSelectedMonth is true", () => {
-    var datePickerInline = TestUtils.renderIntoDocument(
-      <DatePicker inline monthsShown={2} inlineFocusSelectedMonth />
+      <DatePicker inline monthsShown={2} focusSelectedMonth />
     );
     var dayButtonInline = TestUtils.scryRenderedDOMComponentsWithClass(
       datePickerInline,


### PR DESCRIPTION
`focusSelectedMonth` works like `inlineFocusSelectedMonth`
but doesn't depend on `inline`, nor `monthsShown`.

It  solves https://github.com/Hacker0x01/react-datepicker/pull/1541#issuecomment-569304221