### PR TITLE
Reset preventFocus after closing the popper with Escape.

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -688,6 +688,7 @@ export default class DatePicker extends React.Component {
       // stop the input from auto opening onFocus
       // close the popper
       // setFocus to the input
+      // allow input auto opening onFocus
       event.preventDefault();
       this.setState(
         {
@@ -695,7 +696,10 @@ export default class DatePicker extends React.Component {
         },
         () => {
           this.setOpen(false);
-          setTimeout(this.setFocus); // return focus to the input
+          setTimeout(() => {
+            this.setFocus();
+            this.setState({ preventFocus: false });
+          });
         }
       );
     }

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -136,6 +136,7 @@ describe("DatePicker", () => {
 
     defer(() => {
       expect(datePicker.calendar).to.not.exist;
+      expect(datePicker.state.preventFocus).to.be.false;
       expect(document.activeElement).to.equal(div.querySelector("input"));
       done();
     });


### PR DESCRIPTION
Return the preventFocus state to false after closing the calendar popper with Escape key. This issue prevented the calendar popper to open on the following navigations to the input with the keyboard.

It solves #2146 