### PR TITLE
Set .react-datepicker-popper to maximum z-index

### DIFF
--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -42,7 +42,7 @@
 }
 
 .react-datepicker-popper {
-  z-index: 1;
+  z-index: 2147483647;
 
   &[data-placement^="bottom"] {
     margin-top: $datepicker__triangle-size + 2px;


### PR DESCRIPTION
There's no real use cases where the date picker should be underneath any other element, so let's just set it to the maximum value to squash any problems.