### PR TITLE
Render popper in a Portal by Id to avoid overflow of parent

### DIFF
--- a/docs-site/src/components/Example/index.js
+++ b/docs-site/src/components/Example/index.js
@@ -25,13 +25,14 @@ export default class CodeExampleComponent extends React.Component {
   }
 
   render() {
-    const { title, component } = this.props.example;
+    const { title, description, component } = this.props.example;
     return (
       <div
         id={`example-${slugify(title, { lower: true })}`}
         className="example"
       >
         <h2 className="example__heading">{title}</h2>
+        {description && <p>{description}</p>}
         <div className="row">
           <LiveProvider
             code={component.trim()}

--- a/docs-site/src/components/Examples/examples.scss
+++ b/docs-site/src/components/Examples/examples.scss
@@ -105,6 +105,10 @@
       padding-left: 0;
     }
   }
+  &#example-portal-by-id {
+    position: relative;
+    overflow: hidden;
+  }
 }
 
 .red-border {

--- a/docs-site/src/components/Examples/index.js
+++ b/docs-site/src/components/Examples/index.js
@@ -39,6 +39,7 @@ import ClearInput from "../../examples/clearInput";
 import OnBlurCallbacks from "../../examples/onBlurCallbacks";
 import ConfigurePopper from "../../examples/configurePopper";
 import Portal from "../../examples/portal";
+import PortalById from "../../examples/portalById";
 import TabIndex from "../../examples/tabIndex";
 import YearDropdown from "../../examples/yearDropdown";
 import MonthDropdown from "../../examples/monthDropdown";
@@ -220,6 +221,12 @@ export default class exampleComponents extends React.Component {
     {
       title: "Portal version",
       component: Portal
+    },
+    {
+      title: "Portal by id",
+      description:
+        "If the provided portalId cannot be found in the dom, one will be created by default with that id.",
+      component: PortalById
     },
     {
       title: "Inline portal version",

--- a/docs-site/src/examples/portalById.js
+++ b/docs-site/src/examples/portalById.js
@@ -1,0 +1,10 @@
+() => {
+  const [startDate, setStartDate] = useState(new Date());
+  return (
+    <DatePicker
+      selected={startDate}
+      onChange={date => setStartDate(date)}
+      portalId="root-portal"
+    />
+  );
+};

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -207,6 +207,7 @@ export default class DatePicker extends React.Component {
     value: PropTypes.string,
     weekLabel: PropTypes.string,
     withPortal: PropTypes.bool,
+    portalId: PropTypes.string,
     yearDropdownItemNumber: PropTypes.number,
     shouldCloseOnSelect: PropTypes.bool,
     showTimeInput: PropTypes.bool,
@@ -914,6 +915,7 @@ export default class DatePicker extends React.Component {
         className={this.props.popperClassName}
         wrapperClassName={this.props.wrapperClassName}
         hidePopper={!this.isCalendarOpen()}
+        portalId={this.props.portalId}
         popperModifiers={this.props.popperModifiers}
         targetComponent={
           <div className="react-datepicker__input-container">

--- a/src/popper_component.jsx
+++ b/src/popper_component.jsx
@@ -3,6 +3,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Manager, Reference, Popper, placements } from "react-popper";
 import TabLoop from "./tab_loop";
+import Portal from "./portal";
 
 export const popperPlacementPositions = placements;
 
@@ -33,7 +34,8 @@ export default class PopperComponent extends React.Component {
     popperProps: PropTypes.object,
     targetComponent: PropTypes.element,
     enableTabLoop: PropTypes.bool,
-    popperOnKeyDown: PropTypes.func
+    popperOnKeyDown: PropTypes.func,
+    portalId: PropTypes.string
   };
 
   render() {
@@ -47,7 +49,8 @@ export default class PopperComponent extends React.Component {
       popperProps,
       targetComponent,
       enableTabLoop,
-      popperOnKeyDown
+      popperOnKeyDown,
+      portalId
     } = this.props;
 
     let popper;
@@ -78,6 +81,10 @@ export default class PopperComponent extends React.Component {
 
     if (this.props.popperContainer) {
       popper = React.createElement(this.props.popperContainer, {}, popper);
+    }
+
+    if (portalId && !hidePopper) {
+      popper = <Portal portalId={portalId}>{popper}</Portal>;
     }
 
     const wrapperClasses = classnames(

--- a/src/portal.jsx
+++ b/src/portal.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import PropTypes from "prop-types";
+import ReactDOM from "react-dom";
+
+export default class Portal extends React.Component {
+  static propTypes = {
+    children: PropTypes.any,
+    portalId: PropTypes.string
+  };
+
+  constructor(props) {
+    super(props);
+    this.el = document.createElement("div");
+  }
+
+  componentDidMount() {
+    this.portalRoot = document.getElementById(this.props.portalId);
+    if (!this.portalRoot) {
+      this.portalRoot = document.createElement("div");
+      this.portalRoot.setAttribute("id", this.props.portalId);
+      document.body.appendChild(this.portalRoot);
+    }
+    this.portalRoot.appendChild(this.el);
+  }
+
+  componentWillUnmount() {
+    this.portalRoot.removeChild(this.el);
+  }
+
+  render() {
+    return ReactDOM.createPortal(this.props.children, this.el);
+  }
+}


### PR DESCRIPTION
Using createPortal from ReactDOM the popper is added in a portal and displayed outside of Root Element in order to avoid overflow

Docs added

Unit tests are not added because when unit testing the portal is rendered inside by default