### PR TITLE
remove inline check for keyboard selected

### DIFF
--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -92,7 +92,6 @@ export default class Calendar extends React.Component {
     includeDates: PropTypes.array,
     includeTimes: PropTypes.array,
     injectTimes: PropTypes.array,
-    inline: PropTypes.bool,
     locale: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.shape({ locale: PropTypes.object })
@@ -750,7 +749,6 @@ export default class Calendar extends React.Component {
             highlightDates={this.props.highlightDates}
             selectingDate={this.state.selectingDate}
             includeDates={this.props.includeDates}
-            inline={this.props.inline}
             fixedHeight={this.props.fixedHeight}
             filterDate={this.props.filterDate}
             preSelection={this.props.preSelection}

--- a/src/day.jsx
+++ b/src/day.jsx
@@ -26,7 +26,6 @@ export default class Day extends React.Component {
     dayClassName: PropTypes.func,
     endDate: PropTypes.instanceOf(Date),
     highlightDates: PropTypes.instanceOf(Map),
-    inline: PropTypes.bool,
     month: PropTypes.number,
     onClick: PropTypes.func,
     onMouseEnter: PropTypes.func,

--- a/src/day.jsx
+++ b/src/day.jsx
@@ -26,7 +26,8 @@ export default class Day extends React.Component {
     dayClassName: PropTypes.func,
     endDate: PropTypes.instanceOf(Date),
     highlightDates: PropTypes.instanceOf(Map),
-    inline: PropTypes.bool,
+    
+    : PropTypes.bool,
     month: PropTypes.number,
     onClick: PropTypes.func,
     onMouseEnter: PropTypes.func,
@@ -80,7 +81,6 @@ export default class Day extends React.Component {
 
   isKeyboardSelected = () =>
     !this.props.disabledKeyboardNavigation &&
-    !this.props.inline &&
     !this.isSameDay(this.props.selected) &&
     this.isSameDay(this.props.preSelection);
 

--- a/src/day.jsx
+++ b/src/day.jsx
@@ -26,8 +26,7 @@ export default class Day extends React.Component {
     dayClassName: PropTypes.func,
     endDate: PropTypes.instanceOf(Date),
     highlightDates: PropTypes.instanceOf(Map),
-    
-    : PropTypes.bool,
+    inline: PropTypes.bool,
     month: PropTypes.number,
     onClick: PropTypes.func,
     onMouseEnter: PropTypes.func,

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -758,7 +758,6 @@ export default class DatePicker extends React.Component {
         includeDates={this.props.includeDates}
         includeTimes={this.props.includeTimes}
         injectTimes={this.props.injectTimes}
-        inline={this.props.inline}
         peekNextMonth={this.props.peekNextMonth}
         showMonthDropdown={this.props.showMonthDropdown}
         showPreviousMonths={this.props.showPreviousMonths}

--- a/src/month.jsx
+++ b/src/month.jsx
@@ -22,7 +22,6 @@ export default class Month extends React.Component {
     formatWeekNumber: PropTypes.func,
     highlightDates: PropTypes.instanceOf(Map),
     includeDates: PropTypes.array,
-    inline: PropTypes.bool,
     locale: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.shape({ locale: PropTypes.object })
@@ -142,7 +141,6 @@ export default class Month extends React.Component {
           maxDate={this.props.maxDate}
           excludeDates={this.props.excludeDates}
           includeDates={this.props.includeDates}
-          inline={this.props.inline}
           highlightDates={this.props.highlightDates}
           selectingDate={this.props.selectingDate}
           filterDate={this.props.filterDate}

--- a/src/week.jsx
+++ b/src/week.jsx
@@ -23,7 +23,6 @@ export default class Week extends React.Component {
     formatWeekNumber: PropTypes.func,
     highlightDates: PropTypes.instanceOf(Map),
     includeDates: PropTypes.array,
-    inline: PropTypes.bool,
     locale: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.shape({ locale: PropTypes.object })
@@ -113,7 +112,6 @@ export default class Week extends React.Component {
             maxDate={this.props.maxDate}
             excludeDates={this.props.excludeDates}
             includeDates={this.props.includeDates}
-            inline={this.props.inline}
             highlightDates={this.props.highlightDates}
             selectingDate={this.props.selectingDate}
             filterDate={this.props.filterDate}

--- a/test/day_test.js
+++ b/test/day_test.js
@@ -87,7 +87,7 @@ describe("Day", () => {
       expect(shallowDay.hasClass(className)).to.equal(false);
     });
 
-    it("should not apply the keyboard-selected class if in inline mode", () => {
+    it("should apply the keyboard-selected class if in inline mode", () => {
       const day = newDate();
       const selected = addDays(day, 1);
       const shallowDay = renderDay(day, {

--- a/test/day_test.js
+++ b/test/day_test.js
@@ -95,7 +95,7 @@ describe("Day", () => {
         preSelection: day,
         inline: true
       });
-      expect(shallowDay.hasClass(className)).to.equal(false);
+      expect(shallowDay.hasClass(className)).to.equal(true);
     });
   });
 


### PR DESCRIPTION
When using an inline date picker, you can navigate the days with the keyboard but they do not style correctly so it doesn't appear that it is working