### PR TITLE
Update onChangeRaw and onSelect - Fixes #1951

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -455,6 +455,9 @@ export default class DatePicker extends React.Component {
       );
       return this.preventFocusTimeout;
     });
+    // if (this.props.onChangeRaw) {
+    //   this.props.onChangeRaw(event);
+    // }
     this.setSelected(date, event, false, monthSelectedIn);
     if (!this.props.shouldCloseOnSelect || this.props.showTimeSelect) {
       this.setPreSelection(date);
@@ -501,9 +504,8 @@ export default class DatePicker extends React.Component {
       this.props.onChange(changedDate, event);
     }
 
-    this.props.onSelect(changedDate, event);
-
     if (!keepInput) {
+      this.props.onSelect(changedDate, event);
       this.setState({ inputValue: null });
     }
   };

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -455,9 +455,9 @@ export default class DatePicker extends React.Component {
       );
       return this.preventFocusTimeout;
     });
-    // if (this.props.onChangeRaw) {
-    //   this.props.onChangeRaw(event);
-    // }
+    if (this.props.onChangeRaw) {
+      this.props.onChangeRaw(event);
+    }
     this.setSelected(date, event, false, monthSelectedIn);
     if (!this.props.shouldCloseOnSelect || this.props.showTimeSelect) {
       this.setPreSelection(date);

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -526,6 +526,7 @@ describe("DatePicker", () => {
         selected={m}
         onChange={callback}
         onInputError={onInputErrorCallback}
+        dateFormat="yyyy-MM-dd"
         {...opts}
       />
     );
@@ -684,7 +685,7 @@ describe("DatePicker", () => {
     });
     TestUtils.Simulate.change(data.nodeInput, {
       target: {
-        value: utils.formatDate(utils.subDays(minDate, 2), data.testFormat)
+        value: utils.formatDate(utils.subDays(minDate, 1), data.testFormat)
       }
     });
     TestUtils.Simulate.keyDown(data.nodeInput, getKey("Enter"));
@@ -697,7 +698,7 @@ describe("DatePicker", () => {
     });
     TestUtils.Simulate.change(data.nodeInput, {
       target: {
-        value: utils.formatDate(utils.addDays(maxDate, 2), data.testFormat)
+        value: utils.formatDate(utils.addDays(maxDate, 1), data.testFormat)
       }
     });
     TestUtils.Simulate.keyDown(data.nodeInput, getKey("Enter"));

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -684,7 +684,7 @@ describe("DatePicker", () => {
     });
     TestUtils.Simulate.change(data.nodeInput, {
       target: {
-        value: utils.formatDate(utils.subDays(minDate, 1), data.testFormat)
+        value: utils.formatDate(utils.subDays(minDate, 2), data.testFormat)
       }
     });
     TestUtils.Simulate.keyDown(data.nodeInput, getKey("Enter"));
@@ -697,7 +697,7 @@ describe("DatePicker", () => {
     });
     TestUtils.Simulate.change(data.nodeInput, {
       target: {
-        value: utils.formatDate(utils.addDays(maxDate, 1), data.testFormat)
+        value: utils.formatDate(utils.addDays(maxDate, 2), data.testFormat)
       }
     });
     TestUtils.Simulate.keyDown(data.nodeInput, getKey("Enter"));
@@ -943,22 +943,49 @@ describe("DatePicker", () => {
       utils.formatDate(datePicker.prop("selected"), "yyyy-MM-dd")
     ).to.equal("1982-12-30");
   });
-  it("should invoke provided onChangeRaw function on manual input change", () => {
+  it("should invoke provided onChangeRaw function and should not invoke provided onSelect function on manual input change", () => {
     const inputValue = "test";
     const onChangeRawSpy = sandbox.spy();
+    const onSelectSpy = sandbox.spy();
     const datePicker = TestUtils.renderIntoDocument(
       <DatePicker
         selected={utils.newDate()}
         onChange={sandbox.spy()}
         onChangeRaw={onChangeRawSpy}
+        onSelect={onSelectSpy}
       />
     );
     expect(onChangeRawSpy.called).to.be.false;
+    expect(onSelectSpy.called).to.be.false;
     const input = ReactDOM.findDOMNode(datePicker.input);
     input.value = inputValue;
     TestUtils.Simulate.change(input);
     expect(onChangeRawSpy.calledOnce).to.be.true;
     expect(onChangeRawSpy.args[0][0].target.value).to.equal(inputValue);
+    expect(onSelectSpy.called).to.be.false;
+  });
+  it("should invoke provided onChangeRaw and onSelect functions when clicking a day on the calendar", () => {
+    const onChangeRawSpy = sandbox.spy();
+    const onSelectSpy = sandbox.spy();
+    const datePicker = TestUtils.renderIntoDocument(
+      <DatePicker
+        selected={utils.newDate()}
+        onChange={sandbox.spy()}
+        onChangeRaw={onChangeRawSpy}
+        onSelect={onSelectSpy}
+      />
+    );
+    expect(onChangeRawSpy.called).to.be.false;
+    expect(onSelectSpy.called).to.be.false;
+    const input = ReactDOM.findDOMNode(datePicker.input);
+    TestUtils.Simulate.focus(ReactDOM.findDOMNode(input));
+    const day = TestUtils.scryRenderedComponentsWithType(
+      datePicker.calendar,
+      Day
+    )[0];
+    TestUtils.Simulate.click(ReactDOM.findDOMNode(day));
+    expect(onChangeRawSpy.calledOnce).to.be.true;
+    expect(onSelectSpy.calledOnce).to.be.true;
   });
   it("should allow onChangeRaw to prevent a change", () => {
     const onChangeRaw = e => e.target.value > "2" && e.preventDefault();

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -526,7 +526,7 @@ describe("DatePicker", () => {
         selected={m}
         onChange={callback}
         onInputError={onInputErrorCallback}
-        dateFormat="yyyy-MM-dd"
+        dateFormat={testFormat}
         {...opts}
       />
     );


### PR DESCRIPTION
1. Updates the onChangeRaw callback such that it fires on all changes, including when a date is selected from the calendar. It would be useful to users if there was a callback that fires on every change. For example, I am performing date validation for user error messaging and it's necessary to perform that validation on every change. 

2. Updates the onSelect callback so it only fires for a calendar date selection. Currently, onSelect and onChange fire on the same events. It would be helpful to differentiate the two. This change also matches the behavior to the docs.

Fixes #1951