### PR TITLE
Add selected class for year picker - Feature #2162

### DIFF
--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -364,7 +364,8 @@
 }
 
 .react-datepicker__month,
-.react-datepicker__quarter {
+.react-datepicker__quarter,
+.react-datepicker__year-container-text {
   &--selected,
   &--in-selecting-range,
   &--in-range {

--- a/src/year.jsx
+++ b/src/year.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { getYear } from "./date_utils";
 import * as utils from "./date_utils";
+import classnames from "classnames";
 
 export default class Year extends React.Component {
   static propTypes = {
@@ -40,7 +41,10 @@ export default class Year extends React.Component {
           onClick={ev => {
             this.onYearClick(ev, y);
           }}
-          className="react-datepicker__year-container-text"
+          className={classnames("react-datepicker__year-container-text", {
+            "react-datepicker__year-container-text--selected":
+              y === getYear(date)
+          })}
           key={y}
         >
           {y}

--- a/test/year_picker_test.js
+++ b/test/year_picker_test.js
@@ -43,7 +43,6 @@ describe("YearPicker", () => {
       .find(".react-datepicker__year-container-text--selected")
       .at(0)
       .text();
-    // expect(utils.getYear(date)).to.equal(selectedYear);
     expect(year).to.equal(utils.getYear(date).toString());
   });
 });

--- a/test/year_picker_test.js
+++ b/test/year_picker_test.js
@@ -5,6 +5,7 @@ import Year from "../src/year";
 import TestUtils from "react-dom/test-utils";
 import ReactDOM from "react-dom";
 import InputTimeComponent from "../src/inputTime";
+import * as utils from "../src/date_utils";
 
 describe("YearPicker", () => {
   let sandbox;
@@ -33,5 +34,16 @@ describe("YearPicker", () => {
       .at(1);
     firstYearDiv.simulate("click");
     expect(onYearChangeSpy.called).to.be.true;
+  });
+
+  it("should has selected class when element of array equal of choosen year", () => {
+    const date = new Date("2015-06-01");
+    const yearComponent = mount(<Year date={date} />);
+    const year = yearComponent
+      .find(".react-datepicker__year-container-text--selected")
+      .at(0)
+      .text();
+    // expect(utils.getYear(date)).to.equal(selectedYear);
+    expect(year).to.equal(utils.getYear(date).toString());
   });
 });


### PR DESCRIPTION
Feature for [#2162](https://github.com/Hacker0x01/react-datepicker/issues/2162) I've noticed that this behavior wasn't implemented. 
Added some logic to add class.
Added class name to styles the same way as for months.
Covered with a test.

Also, I noticed this issue [#2167](https://github.com/Hacker0x01/react-datepicker/issues/2167) I think I could check this. Maybe #2167 needs to add a new prop to choose where to show selected year(beginning or end of the calendar) ?