### PR TITLE
Year change day selection - Fixes #2170

### DIFF
--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -284,6 +284,8 @@ export default class Calendar extends React.Component {
     if (this.props.onYearChange) {
       this.props.onYearChange(date);
     }
+
+    this.props.setPreSelection && this.props.setPreSelection(date);
   };
 
   handleMonthChange = date => {


### PR DESCRIPTION
When a year change was initiated via the Year `select` dropdown, the date would not be focused in the calendar. This meant that keyboard users would be stranded in the calendar header, unable to tab to the date.

This change uses Dan Diaz’s work on `handleMonthChange` (#2097) to give the same functionality to `handleYearChange` and restore keyboard accessibility.