### PR TITLE
border bottom right time section

### DIFF
--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -285,6 +285,7 @@
   .react-datepicker__time {
     position: relative;
     background: white;
+    border-bottom-right-radius: 0.3rem;
 
     .react-datepicker__time-box {
       width: 85px;


### PR DESCRIPTION
Fix for rendering issue on time section:
Bug visible on Chrome: Version 81.0.4044.138 (Official Build) (64-bit)

![image](https://user-images.githubusercontent.com/1413475/84129916-7a020800-aa3a-11ea-9eb5-28b8456334c4.png)
