### PR TITLE
add function of back current month in custom header

### DIFF
--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -267,6 +267,12 @@ export default class Calendar extends React.Component {
     );
   };
 
+  backCurrentMonth = () => {
+    this.setState({ date: new Date() },
+      () => this.handleMonthChange(this.state.date)
+    );
+  };
+
   handleDayClick = (day, event, monthSelectedIn) =>
     this.props.onSelect(day, event, monthSelectedIn);
 
@@ -672,6 +678,7 @@ export default class Calendar extends React.Component {
           increaseMonth: this.increaseMonth,
           decreaseYear: this.decreaseYear,
           increaseYear: this.increaseYear,
+          backCurrentMonth: this.backCurrentMonth,
           prevMonthButtonDisabled,
           nextMonthButtonDisabled,
           prevYearButtonDisabled,


### PR DESCRIPTION
when using react datepicker and this custom header function, you cannot be back current month easily.
For example, when you selected 09/06/1995, and want to back current year and month,  you need to chose them by using pull down of custom header or make like this code.

```js
const months = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]

const handleBackCurrentMonth = (
    changeYear,
    changeMonth
  ) => {
    const now = new Date()
    const yearValue = now.getFullYear()
    const monthValue = months[now.getMonth()]
    changeYear(yearValue)
    changeMonth(monthValue - 1)
  }
```
※ `changeYear` and `changeMonth` function is custom header fucntion

It would be great if there is default function of back current month in custom header.