### PR TITLE
Add closeOnScroll prop

### DIFF
--- a/docs-site/src/components/Examples/index.js
+++ b/docs-site/src/components/Examples/index.js
@@ -72,6 +72,8 @@ import QuarterPicker from "../../examples/quarterPicker";
 import RangeQuarterPicker from "../../examples/rangeQuarterPicker";
 import OnCalendarChangeStateCallbacks from "../../examples/onCalendarOpenStateCallbacks";
 import CustomTimeInput from "../../examples/customTimeInput";
+import CloseOnScroll from "../../examples/closeOnScroll";
+import CloseOnScrollCallback from "../../examples/closeOnScrollCallback";
 
 import "./style.scss";
 import "react-datepicker/dist/react-datepicker.css";
@@ -308,6 +310,14 @@ export default class exampleComponents extends React.Component {
     {
       title: "Don't hide calendar on date selection",
       component: DontCloseOnSelect
+    },
+    {
+      title: "Close on scroll",
+      component: CloseOnScroll
+    },
+    {
+      title: "Close on scroll callback",
+      component: CloseOnScrollCallback
     },
     {
       title: "Custom header",

--- a/docs-site/src/examples/closeOnScroll.js
+++ b/docs-site/src/examples/closeOnScroll.js
@@ -1,0 +1,10 @@
+() => {
+  const [startDate, setStartDate] = useState(new Date());
+  return (
+    <DatePicker
+      closeOnScroll={true}
+      selected={startDate}
+      onChange={date => setStartDate(date)}
+    />
+  );
+};

--- a/docs-site/src/examples/closeOnScrollCallback.js
+++ b/docs-site/src/examples/closeOnScrollCallback.js
@@ -1,0 +1,10 @@
+() => {
+  const [startDate, setStartDate] = useState(new Date());
+  return (
+    <DatePicker
+      closeOnScroll={e => e.target === document}
+      selected={startDate}
+      onChange={date => setStartDate(date)}
+    />
+  );
+};

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -124,6 +124,7 @@ export default class DatePicker extends React.Component {
     calendarContainer: PropTypes.func,
     children: PropTypes.node,
     chooseDayAriaLabelPrefix: PropTypes.string,
+    closeOnScroll: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
     className: PropTypes.string,
     customInput: PropTypes.element,
     customInputRef: PropTypes.string,
@@ -255,6 +256,10 @@ export default class DatePicker extends React.Component {
     this.state = this.calcInitialState();
   }
 
+  componentDidMount() {
+    window.addEventListener("scroll", this.onScroll, true);
+  }
+
   componentDidUpdate(prevProps, prevState) {
     if (
       prevProps.inline &&
@@ -293,6 +298,7 @@ export default class DatePicker extends React.Component {
 
   componentWillUnmount() {
     this.clearPreventFocusTimeout();
+    window.removeEventListener("scroll", this.onScroll, true);
   }
 
   getPreSelection = () =>
@@ -719,6 +725,25 @@ export default class DatePicker extends React.Component {
 
   clear = () => {
     this.onClearClick();
+  };
+
+  onScroll = event => {
+    if (
+      typeof this.props.closeOnScroll === "boolean" &&
+      this.props.closeOnScroll
+    ) {
+      if (
+        event.target === document ||
+        event.target === document.documentElement ||
+        event.target === document.body
+      ) {
+        this.setOpen(false);
+      }
+    } else if (typeof this.props.closeOnScroll === "function") {
+      if (this.props.closeOnScroll(event)) {
+        this.setOpen(false);
+      }
+    }
   };
 
   renderCalendar = () => {

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -1298,4 +1298,42 @@ describe("DatePicker", () => {
         .prop("ariaLabelPrefix")
     ).to.equal(weekAriaLabelPrefix);
   });
+
+  it("should close the calendar after scrolling", () => {
+    var datePicker = TestUtils.renderIntoDocument(<DatePicker closeOnScroll />);
+    var dateInput = datePicker.input;
+    TestUtils.Simulate.focus(ReactDOM.findDOMNode(dateInput));
+    expect(datePicker.state.open).to.be.true;
+    datePicker.onScroll({ target: document });
+    expect(datePicker.state.open).to.be.false;
+  });
+
+  it("should not close the calendar after scrolling", () => {
+    var datePicker = TestUtils.renderIntoDocument(<DatePicker closeOnScroll />);
+    var dateInput = datePicker.input;
+    TestUtils.Simulate.focus(ReactDOM.findDOMNode(dateInput));
+    datePicker.onScroll({ target: "something" });
+    expect(datePicker.state.open).to.be.true;
+  });
+
+  it("should close the calendar after scrolling", () => {
+    var datePicker = TestUtils.renderIntoDocument(
+      <DatePicker closeOnScroll={() => true} />
+    );
+    var dateInput = datePicker.input;
+    TestUtils.Simulate.focus(ReactDOM.findDOMNode(dateInput));
+    expect(datePicker.state.open).to.be.true;
+    datePicker.onScroll();
+    expect(datePicker.state.open).to.be.false;
+  });
+
+  it("should not close the calendar after scrolling", () => {
+    var datePicker = TestUtils.renderIntoDocument(
+      <DatePicker closeOnScroll={() => false} />
+    );
+    var dateInput = datePicker.input;
+    TestUtils.Simulate.focus(ReactDOM.findDOMNode(dateInput));
+    datePicker.onScroll();
+    expect(datePicker.state.open).to.be.true;
+  });
 });


### PR DESCRIPTION
Add closeOnScroll prop to enable. The prop accepts either a boolean or a function. If true, the datepicker will be closed when the document is scrolled. If function, then it executes the function to see whether the datepicker should be closed or not.