### PR TITLE
fix(date_utils): fixing navigation on yearpicker

### DIFF
--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -550,12 +550,9 @@ export function yearDisabledBefore(day, { minDate, includeDates } = {}) {
 
 export function yearsDisabledBefore(day, { minDate } = {}) {
   const previousYear = getStartOfYear(subYears(day, 12));
-  const { startPeriod, endPeriod } = getYearsPeriod(previousYear);
+  const { endPeriod } = getYearsPeriod(previousYear);
   const minDateYear = minDate && getYear(minDate);
-  return (
-    (minDateYear && (minDateYear < startPeriod || minDateYear > endPeriod)) ||
-    false
-  );
+  return (minDateYear && minDateYear > endPeriod) || false;
 }
 
 export function yearDisabledAfter(day, { maxDate, includeDates } = {}) {
@@ -572,12 +569,9 @@ export function yearDisabledAfter(day, { maxDate, includeDates } = {}) {
 
 export function yearsDisabledAfter(day, { maxDate } = {}) {
   const nextYear = addYears(day, 12);
-  const { startPeriod, endPeriod } = getYearsPeriod(nextYear);
+  const { startPeriod } = getYearsPeriod(nextYear);
   const maxDateYear = maxDate && getYear(maxDate);
-  return (
-    (maxDateYear && (maxDateYear < startPeriod || maxDateYear > endPeriod)) ||
-    false
-  );
+  return (maxDateYear && maxDateYear < startPeriod) || false;
 }
 
 export function getEffectiveMinDate({ minDate, includeDates }) {

--- a/test/date_utils_test.js
+++ b/test/date_utils_test.js
@@ -754,6 +754,12 @@ describe("date_utils", function() {
       const maxDate = newDate("2018-04-01");
       expect(yearsDisabledAfter(day, { maxDate })).to.be.false;
     });
+
+    it("should return false if max date is in a next period year", () => {
+      const day = newDate("1996-08-08 00:00:00");
+      const maxDate = newDate("2020-08-08 00:00:00");
+      expect(yearsDisabledAfter(day, { maxDate })).to.be.false;
+    });
   });
 
   describe("yearsDisabledBefore", () => {
@@ -770,6 +776,12 @@ describe("date_utils", function() {
     it("should return false if min date is in the previous period year", () => {
       const day = newDate("2016-03-19");
       const minDate = newDate("2004-03-29");
+      expect(yearsDisabledBefore(day, { minDate })).to.be.false;
+    });
+
+    it("should return false if min date is in a previous period year", () => {
+      const day = newDate("2044-08-08 00:00:00");
+      const minDate = newDate("2020-08-08 00:00:00");
       expect(yearsDisabledBefore(day, { minDate })).to.be.false;
     });
   });


### PR DESCRIPTION
When using the yearpicker the navigation is disappearing while clicking on next. The user can´t get to the initial state.

