### PR TITLE
Fix border radius issues

### DIFF
--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -644,7 +644,7 @@ export default class Calendar extends React.Component {
   };
 
   renderDefaultHeader = ({ monthDate, i }) => (
-    <div className="react-datepicker__header">
+    <div className={`react-datepicker__header ${this.props.showTimeSelect ? 'react-datepicker__header--has-time-select' : ''}`}>
       {this.renderCurrentMonth(monthDate)}
       <div
         className={`react-datepicker__header__dropdown react-datepicker__header__dropdown--${this.props.dropdownMode}`}
@@ -863,6 +863,7 @@ export default class Calendar extends React.Component {
           monthRef={this.state.monthContainer}
           injectTimes={this.props.injectTimes}
           locale={this.props.locale}
+          showTimeSelectOnly={this.props.showTimeSelectOnly}
         />
       );
     }

--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -27,12 +27,9 @@
     border-left: 0;
   }
 
-  .react-datepicker__time {
-    border-radius: 0.3rem;
-  }
-
-  .react-datepicker__time-box {
-    border-radius: 0.3rem;
+  .react-datepicker__time, .react-datepicker__time-box {
+    border-bottom-left-radius: 0.3rem;
+    border-bottom-right-radius: 0.3rem;
   }
 }
 
@@ -92,7 +89,6 @@
   background-color: $datepicker__background-color;
   border-bottom: 1px solid $datepicker__border-color;
   border-top-left-radius: $datepicker__border-radius;
-  border-top-right-radius: $datepicker__border-radius;
   padding-top: 8px;
   position: relative;
 
@@ -100,6 +96,14 @@
     padding-bottom: 8px;
     padding-left: 5px;
     padding-right: 5px;
+
+    &:not(&--only) {
+      border-top-left-radius: 0;
+    }
+  }
+
+  &:not(&--has-time-select) {
+    border-top-right-radius: $datepicker__border-radius;
   }
 }
 
@@ -163,7 +167,7 @@
     right: 10px;
     border-left-color: $datepicker__muted-color;
     &--with-time:not(&--with-today-button) {
-      right: 80px;
+      right: 95px;
     }
 
     &:hover {
@@ -291,6 +295,7 @@
       overflow-x: hidden;
       margin: 0 auto;
       text-align: center;
+      border-bottom-right-radius: 0.3rem;
       ul.react-datepicker__time-list {
         list-style: none;
         margin: 0;

--- a/src/time.jsx
+++ b/src/time.jsx
@@ -46,7 +46,8 @@ export default class Time extends React.Component {
     locale: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.shape({ locale: PropTypes.object })
-    ])
+    ]),
+    showTimeSelectOnly: PropTypes.bool
   };
 
   state = {
@@ -189,7 +190,7 @@ export default class Time extends React.Component {
         }`}
       >
         <div
-          className="react-datepicker__header react-datepicker__header--time"
+          className={`react-datepicker__header react-datepicker__header--time ${this.props.showTimeSelectOnly ? 'react-datepicker__header--time--only' : ''}`}
           ref={header => {
             this.header = header;
           }}

--- a/test/calendar_test.js
+++ b/test/calendar_test.js
@@ -1446,4 +1446,18 @@ describe("Calendar", function() {
       );
     });
   });
+
+  describe("showTimeSelect", () => {
+    it("should not contain the time select classname in header by default", () => {
+      const calendar = getCalendar();
+      const header = calendar.find(".react-datepicker__header--has-time-select");
+      expect(header).to.have.length(0);
+    });
+
+    it("should contain the time select classname in header if enabled", () => {
+      const calendar = getCalendar({ showTimeSelect: true });
+      const header = calendar.find(".react-datepicker__header--has-time-select");
+      expect(header).to.have.length(1);
+    });
+  });
 });

--- a/test/timepicker_test.js
+++ b/test/timepicker_test.js
@@ -113,6 +113,35 @@ describe("TimePicker", () => {
     expect(getInputString()).to.equal("February 28, 2018 9:53 AM");
   });
 
+  it("should not contain the time only classname in header by default", () => {
+    const timePicker = TestUtils.renderIntoDocument(
+      <DatePicker
+        open
+        showTimeSelect
+      />
+    );
+    const header = TestUtils.scryRenderedDOMComponentsWithClass(
+      timePicker,
+      "react-datepicker__header--time--only"
+    );
+    expect(header).to.have.length(0);
+  });
+
+  it("should contain the time only classname in header if enabled", () => {
+    const timePicker = TestUtils.renderIntoDocument(
+      <DatePicker
+        open
+        showTimeSelect
+        showTimeSelectOnly
+      />
+    );
+    const header = TestUtils.scryRenderedDOMComponentsWithClass(
+      timePicker,
+      "react-datepicker__header--time--only"
+    );
+    expect(header).to.have.length(1);
+  });
+
   function setManually(string) {
     TestUtils.Simulate.focus(datePicker.input);
     TestUtils.Simulate.change(datePicker.input, { target: { value: string } });


### PR DESCRIPTION
- Fix border radius issues when using date + time and time only
- Fix next month button position for date + time

Screenshots of the issue I changed the `$datepicker__background-color` to red to better highlight problems.
<img width="770" alt="Screen Shot 2020-07-22 at 6 00 00 PM" src="https://user-images.githubusercontent.com/6496667/88243525-838bac00-cc45-11ea-843d-dbbb59c48a0e.png">

<img width="289" alt="Screen Shot 2020-07-22 at 5 59 05 PM" src="https://user-images.githubusercontent.com/6496667/88243529-86869c80-cc45-11ea-96dc-1ca70d77af5a.png">