### PR TITLE
Add current year class for year picker - Feature #2341

### DIFF
--- a/src/year.jsx
+++ b/src/year.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { getYear } from "./date_utils";
+import { getYear, newDate } from "./date_utils";
 import * as utils from "./date_utils";
 import classnames from "classnames";
 
@@ -51,7 +51,8 @@ export default class Year extends React.Component {
         (minDate || maxDate) && utils.isYearDisabled(y, this.props),
       "react-datepicker__year-text--keyboard-selected": this.isKeyboardSelected(
         y
-      )
+      ),
+      "react-datepicker__year-text--today": y === getYear(newDate()),
     });
   };
 

--- a/test/year_picker_test.js
+++ b/test/year_picker_test.js
@@ -46,6 +46,16 @@ describe("YearPicker", () => {
     expect(year).to.equal(utils.getYear(date).toString());
   });
 
+  it("should has current year class when element of array equal of current year", () => {
+    const date = new Date();
+    const yearComponent = mount(<Year date={date} />);
+    const year = yearComponent
+      .find(".react-datepicker__year-text--today")
+      .at(0)
+      .text();
+    expect(year).to.equal(utils.getYear(date).toString());
+  });
+
   it("should return disabled class if current date is out of bound of minDate and maxdate", () => {
     const yearComponent = mount(
       <Year


### PR DESCRIPTION
Feature for #2341 I've noticed that this behavior wasn't implemented.
I've added logic to highlight current year.
I do not add specific class postfix and used `--today` postfix similar to days (`react-datepicker__year-text--today`).
Corresponding behavior has been covered with a test.

Maybe #2341 needs to add a new class to highlight current year? As for me, it is usable to use --today postfix.