### PR TITLE
Add property to show specific year item number for year picker - Feature #2331

### DIFF
--- a/docs-site/src/components/Examples/index.js
+++ b/docs-site/src/components/Examples/index.js
@@ -42,6 +42,7 @@ import Portal from "../../examples/portal";
 import PortalById from "../../examples/portalById";
 import TabIndex from "../../examples/tabIndex";
 import YearDropdown from "../../examples/yearDropdown";
+import YearItemNumber from "../../examples/yearItemNumber";
 import MonthDropdown from "../../examples/monthDropdown";
 import MonthDropdownShort from "../../examples/monthDropdownShort";
 import MonthYearDropdown from "../../examples/monthYearDropdown";
@@ -375,6 +376,10 @@ export default class exampleComponents extends React.Component {
     {
       title: "Year select dropdown",
       component: YearSelectDropdown
+    },
+    {
+      title: "Year item number",
+      component: YearItemNumber
     }
   ];
 

--- a/docs-site/src/examples/yearItemNumber.js
+++ b/docs-site/src/examples/yearItemNumber.js
@@ -1,0 +1,12 @@
+() => {
+  const [startDate, setStartDate] = useState(new Date());
+  return (
+    <DatePicker
+      selected={startDate}
+      onChange={date => setStartDate(date)}
+      showYearPicker
+      dateFormat="yyyy"
+      yearItemNumber={9}
+    />
+  );
+};

--- a/docs/datepicker.md
+++ b/docs/datepicker.md
@@ -86,5 +86,7 @@ General datepicker component.
 | `value`                      | `string`                       |                 |                                            |
 | `weekLabel`                  | `string`                       |                 |                                            |
 | `withPortal`                 | `bool`                         | `false`         |                                            |
-| `wrapperClassName`           | `string`                       |                 |                                            |
+| `wrapperClassName`           | `string`                       |                 
+|                                            |
+| `yearItemNumber`             | `number`                       | `12`            |                                            |
 | `yearDropdownItemNumber`     | `number`                       |                 |                                            |

--- a/docs/index.md
+++ b/docs/index.md
@@ -131,4 +131,5 @@
 |`weekLabel`|`string`|||
 |`withPortal`|`bool`|`false`||
 |`wrapperClassName`|`string`|||
+|`yearItemNumber`|`number`|`12`||
 |`yearDropdownItemNumber`|`number`|||

--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -39,7 +39,8 @@ import {
   getEffectiveMaxDate,
   addZero,
   isValid,
-  getYearsPeriod
+  getYearsPeriod,
+  DEFAULT_YEAR_ITEM_NUMBER
 } from "./date_utils";
 
 const DROPDOWN_FOCUS_CLASSNAMES = [
@@ -67,7 +68,8 @@ export default class Calendar extends React.Component {
       nextYearButtonLabel: "Next Year",
       previousMonthButtonLabel: "Previous Month",
       nextMonthButtonLabel: "Next Month",
-      customTimeInput: null
+      customTimeInput: null,
+      yearItemNumber: DEFAULT_YEAR_ITEM_NUMBER
     };
   }
 
@@ -151,6 +153,7 @@ export default class Calendar extends React.Component {
     formatWeekDay: PropTypes.func,
     withPortal: PropTypes.bool,
     weekLabel: PropTypes.string,
+    yearItemNumber: PropTypes.number,
     yearDropdownItemNumber: PropTypes.number,
     setOpen: PropTypes.func,
     shouldCloseOnSelect: PropTypes.bool,
@@ -393,7 +396,7 @@ export default class Calendar extends React.Component {
   decreaseYear = () => {
     this.setState(
       ({ date }) => ({
-        date: subYears(date, this.props.showYearPicker ? 12 : 1)
+        date: subYears(date, this.props.showYearPicker ? this.props.yearItemNumber : 1)
       }),
       () => this.handleYearChange(this.state.date)
     );
@@ -473,7 +476,7 @@ export default class Calendar extends React.Component {
   increaseYear = () => {
     this.setState(
       ({ date }) => ({
-        date: addYears(date, this.props.showYearPicker ? 12 : 1)
+        date: addYears(date, this.props.showYearPicker ? this.props.yearItemNumber : 1)
       }),
       () => this.handleYearChange(this.state.date)
     );
@@ -721,8 +724,8 @@ export default class Calendar extends React.Component {
 
   renderYearHeader = () => {
     const { date } = this.state;
-    const { showYearPicker } = this.props;
-    const { startPeriod, endPeriod } = getYearsPeriod(date);
+    const { showYearPicker, yearItemNumber } = this.props;
+    const { startPeriod, endPeriod } = getYearsPeriod(date, yearItemNumber);
     return (
       <div className="react-datepicker__header react-datepicker-year-header">
         {showYearPicker ? `${startPeriod} - ${endPeriod}` : getYear(date)}

--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -56,6 +56,8 @@ import parse from "date-fns/parse";
 import parseISO from "date-fns/parseISO";
 import longFormatters from "date-fns/esm/_lib/format/longFormatters";
 
+export const DEFAULT_YEAR_ITEM_NUMBER = 12;
+
 // This RegExp catches symbols escaped by quotes, and also
 // sequences of symbols P, p, and the combinations like `PPPPPPPppppp`
 var longFormattingTokensRegExp = /P+p+|P+|p+|''|'(''|[^'])+('|$)|./g;
@@ -548,9 +550,9 @@ export function yearDisabledBefore(day, { minDate, includeDates } = {}) {
   );
 }
 
-export function yearsDisabledBefore(day, { minDate } = {}) {
-  const previousYear = getStartOfYear(subYears(day, 12));
-  const { endPeriod } = getYearsPeriod(previousYear);
+export function yearsDisabledBefore(day, { minDate, yearItemNumber = DEFAULT_YEAR_ITEM_NUMBER } = {}) {
+  const previousYear = getStartOfYear(subYears(day, yearItemNumber));
+  const { endPeriod } = getYearsPeriod(previousYear, yearItemNumber);
   const minDateYear = minDate && getYear(minDate);
   return (minDateYear && minDateYear > endPeriod) || false;
 }
@@ -567,9 +569,9 @@ export function yearDisabledAfter(day, { maxDate, includeDates } = {}) {
   );
 }
 
-export function yearsDisabledAfter(day, { maxDate } = {}) {
-  const nextYear = addYears(day, 12);
-  const { startPeriod } = getYearsPeriod(nextYear);
+export function yearsDisabledAfter(day, { maxDate, yearItemNumber = DEFAULT_YEAR_ITEM_NUMBER } = {}) {
+  const nextYear = addYears(day, yearItemNumber);
+  const { startPeriod } = getYearsPeriod(nextYear, yearItemNumber);
   const maxDateYear = maxDate && getYear(maxDate);
   return (maxDateYear && maxDateYear < startPeriod) || false;
 }
@@ -668,8 +670,8 @@ export function addZero(i) {
   return i < 10 ? `0${i}` : `${i}`;
 }
 
-export function getYearsPeriod(date) {
-  const endPeriod = Math.ceil(getYear(date) / 12) * 12;
-  const startPeriod = endPeriod - 11;
+export function getYearsPeriod(date, yearItemNumber = DEFAULT_YEAR_ITEM_NUMBER) {
+  const endPeriod = Math.ceil(getYear(date) / yearItemNumber) * yearItemNumber;
+  const startPeriod = endPeriod - (yearItemNumber - 1);
   return { startPeriod, endPeriod };
 }

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -32,7 +32,8 @@ import {
   getMonth,
   registerLocale,
   setDefaultLocale,
-  getDefaultLocale
+  getDefaultLocale,
+  DEFAULT_YEAR_ITEM_NUMBER
 } from "./date_utils";
 import onClickOutside from "react-onclickoutside";
 
@@ -102,6 +103,7 @@ export default class DatePicker extends React.Component {
       nextYearButtonLabel: "Next Year",
       timeInputLabel: "Time",
       enableTabLoop: true,
+      yearItemNumber: DEFAULT_YEAR_ITEM_NUMBER,
 
       renderDayContents(date) {
         return date;
@@ -211,6 +213,7 @@ export default class DatePicker extends React.Component {
     weekLabel: PropTypes.string,
     withPortal: PropTypes.bool,
     portalId: PropTypes.string,
+    yearItemNumber: PropTypes.number,
     yearDropdownItemNumber: PropTypes.number,
     shouldCloseOnSelect: PropTypes.bool,
     showTimeInput: PropTypes.bool,
@@ -846,6 +849,7 @@ export default class DatePicker extends React.Component {
         timeCaption={this.props.timeCaption}
         className={this.props.calendarClassName}
         container={this.props.calendarContainer}
+        yearItemNumber={this.props.yearItemNumber}
         yearDropdownItemNumber={this.props.yearDropdownItemNumber}
         previousMonthButtonLabel={this.props.previousMonthButtonLabel}
         nextMonthButtonLabel={this.props.nextMonthButtonLabel}

--- a/src/year.jsx
+++ b/src/year.jsx
@@ -13,7 +13,8 @@ export default class Year extends React.Component {
     selected: PropTypes.object,
     inline: PropTypes.bool,
     maxDate: PropTypes.instanceOf(Date),
-    minDate: PropTypes.instanceOf(Date)
+    minDate: PropTypes.instanceOf(Date),
+    yearItemNumber: PropTypes.number
   };
 
   constructor(props) {
@@ -57,8 +58,8 @@ export default class Year extends React.Component {
 
   render() {
     const yearsList = [];
-    const { date } = this.props;
-    const { startPeriod, endPeriod } = utils.getYearsPeriod(date);
+    const { date, yearItemNumber } = this.props;
+    const { startPeriod, endPeriod } = utils.getYearsPeriod(date, yearItemNumber);
 
     for (let y = startPeriod; y <= endPeriod; y++) {
       yearsList.push(

--- a/test/calendar_test.js
+++ b/test/calendar_test.js
@@ -1184,6 +1184,32 @@ describe("Calendar", function() {
       decreaseYear();
       assert.equal(utils.getYear(calendar.state.date), 1981);
     });
+
+    it("calls increaseYear for custom year item number when next year button clicked", () => {
+      let calendar = TestUtils.renderIntoDocument(
+        <Calendar
+          dateFormat={DATE_FORMAT}
+          showYearPicker
+          yearItemNumber={10}
+        />
+      );
+      calendar.state.date = utils.parseDate("09/28/1993", DATE_FORMAT);
+      calendar.increaseYear();
+      assert.equal(utils.getYear(calendar.state.date), 2003);
+    });
+  
+    it("calls decreaseYear for custom year item number when previous year button clicked", () => {
+      let calendar = TestUtils.renderIntoDocument(
+        <Calendar
+          dateFormat={DATE_FORMAT}
+          showYearPicker
+          yearItemNumber={10}
+        />
+      );
+      calendar.state.date = utils.parseDate("09/28/1993", DATE_FORMAT);
+      calendar.decreaseYear();
+      assert.equal(utils.getYear(calendar.state.date), 1983);
+    });
   });
 
   describe("when showMonthYearPicker is enabled", () => {

--- a/test/date_utils_test.js
+++ b/test/date_utils_test.js
@@ -730,11 +730,18 @@ describe("date_utils", function() {
   });
 
   describe("getYearsPeriod", () => {
-    it("should get start and end of 11 years period", () => {
+    it("should get start and end of default 11 years period", () => {
       const date = newDate("2000-01-01");
       const { startPeriod, endPeriod } = getYearsPeriod(date);
       expect(startPeriod).to.be.eq(1993);
       expect(endPeriod).to.be.eq(2004);
+    });
+
+    it("should get start and end of custom 8 years period", () => {
+      const date = newDate("2000-01-01");
+      const { startPeriod, endPeriod } = getYearsPeriod(date, 9);
+      expect(startPeriod).to.be.eq(1999);
+      expect(endPeriod).to.be.eq(2007);
     });
   });
 

--- a/test/year_picker_test.js
+++ b/test/year_picker_test.js
@@ -24,6 +24,21 @@ describe("YearPicker", () => {
     expect(component).to.exist;
   });
 
+  it("should show year picker component with default year item number", () => {
+    const yearComponent = mount(<Year date={new Date()} />);
+    const yearItems = yearComponent
+      .find(".react-datepicker__year-text");
+    expect(yearItems.length).to.be.eq(utils.DEFAULT_YEAR_ITEM_NUMBER);
+  });
+
+  it("should show year picker component with specific year item number", () => {
+    const yearItemNumber = 9;
+    const yearComponent = mount(<Year date={new Date()} yearItemNumber={yearItemNumber} />);
+    const yearItems = yearComponent
+      .find(".react-datepicker__year-text");
+    expect(yearItems.length).to.be.eq(yearItemNumber);
+  });
+
   it("should change the year when clicked on any option in the picker", () => {
     const onYearChangeSpy = sinon.spy();
     const yearComponent = mount(


### PR DESCRIPTION
Feature for #2331 I've noticed that this behavior wasn't implemented.
Instead of implementing NxM year values grid, I just changed magic constants for year periods to provided property. Using this property and changing CSS it is easy to show NxM year values grid.
I've added property `yearItemNumber` to show specific number of year items.
Corresponding behavior has been covered with tests.
Example provided.