### PR TITLE
Fix crash with non-standard time intervals (#2169, #2262)

### DIFF
--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -174,7 +174,7 @@ export function setTime(date, { hour = 0, minute = 0, second = 0 }) {
   return setHours(setMinutes(setSeconds(date, second), minute), hour);
 }
 
-export { setMonth, setYear, setQuarter };
+export { setMinutes, setHours, setMonth, setQuarter, setYear };
 
 // ** Date Getters **
 

--- a/test/timepicker_test.js
+++ b/test/timepicker_test.js
@@ -113,6 +113,19 @@ describe("TimePicker", () => {
     expect(getInputString()).to.equal("February 28, 2018 9:53 AM");
   });
 
+  it("should handle 90 min time intervals", () => {
+    renderDatePicker("July 13, 2020 2:59 PM", {
+      timeIntervals: 90,
+      showTimeSelect: true
+    });
+    expect(getInputString()).to.equal("July 13, 2020 2:59 PM");
+
+    ReactDOM.findDOMNode(datePicker.input).focus();
+
+    setManually("July 13, 2020 3:00 PM");
+    expect(getInputString()).to.equal("July 13, 2020 3:00 PM");
+  });
+
   it("should not contain the time only classname in header by default", () => {
     const timePicker = TestUtils.renderIntoDocument(
       <DatePicker


### PR DESCRIPTION
Centers the list of times on the nearest time before or equal to the active time, regardless of its hour.

Previously the code would try to center the list of times on the nearest time within the same hour. With time intervals larger than one hour, sometimes there would be no valid candidates, and the `calcCenterPosition` function would crash.

This change does a more simple comparison, and there should now always be a valid ref to a "center" list item.

Fixes #2169, #2262