### PR TITLE
Copy generated css module to file with filename format CRA expects

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,9 +128,9 @@
     "build": "cross-env NODE_ENV=production run-p build:** && run-p css:**",
     "build-dev": "cross-env NODE_ENV=development run-p build:** && run-p css:**",
     "css:prod": "node-sass --output-style compressed src/stylesheets/datepicker.scss > dist/react-datepicker.min.css",
-    "css:modules:prod": "node-sass --output-style compressed src/stylesheets/datepicker-cssmodules.scss > dist/react-datepicker-cssmodules.min.css",
+    "css:modules:prod": "node-sass --output-style compressed src/stylesheets/datepicker-cssmodules.scss | tee dist/react-datepicker-cssmodules.min.css dist/react-datepicker-min.module.css",
     "css:dev": "node-sass --output-style expanded src/stylesheets/datepicker.scss > dist/react-datepicker.css",
-    "css:modules:dev": "node-sass --output-style expanded src/stylesheets/datepicker-cssmodules.scss > dist/react-datepicker-cssmodules.css",
+    "css:modules:dev": "node-sass --output-style expanded src/stylesheets/datepicker-cssmodules.scss | tee dist/react-datepicker-cssmodules.css dist/react-datepicker.module.css",
     "build:js": "rollup -c",
     "js:dev": "rollup -cw"
   },


### PR DESCRIPTION
As described in #2343, applications created with Create-React-App do not recognize CSS modules unless the module's filename is in the format ```filename.module.css```.

This PR changes the scripts `css:modules:prod` and `css:modules:dev` in `package.json` from redirecting the output of node-sass to a file to instead piping to tee and then to two files, one with the original filename and one with the CRA recognized filename.

**Original**
"css:modules:prod": "node-sass --output-style compressed src/stylesheets/datepicker-cssmodules.scss **> dist/react-datepicker-cssmodules.min.css"**

**New**
"css:modules:prod": "node-sass --output-style compressed src/stylesheets/datepicker-cssmodules.scss **| tee dist/react-datepicker-cssmodules.min.css dist/react-datepicker-min.module.css"**