### PR TITLE
Bugfix: Not setting focus to selected day on page load for inline calendar

### DIFF
--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -98,6 +98,7 @@ export default class Calendar extends React.Component {
     includeDates: PropTypes.array,
     includeTimes: PropTypes.array,
     injectTimes: PropTypes.array,
+    inline: PropTypes.bool,
     locale: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.shape({ locale: PropTypes.object })
@@ -791,6 +792,7 @@ export default class Calendar extends React.Component {
             highlightDates={this.props.highlightDates}
             selectingDate={this.state.selectingDate}
             includeDates={this.props.includeDates}
+            inline={this.props.inline}
             fixedHeight={this.props.fixedHeight}
             filterDate={this.props.filterDate}
             preSelection={this.props.preSelection}

--- a/src/day.jsx
+++ b/src/day.jsx
@@ -26,6 +26,7 @@ export default class Day extends React.Component {
     dayClassName: PropTypes.func,
     endDate: PropTypes.instanceOf(Date),
     highlightDates: PropTypes.instanceOf(Map),
+    inline: PropTypes.bool,
     month: PropTypes.number,
     onClick: PropTypes.func,
     onMouseEnter: PropTypes.func,
@@ -277,8 +278,8 @@ export default class Day extends React.Component {
       !prevProps.isInputFocused &&
       this.isSameDay(this.props.preSelection)
     ) {
-      // there is currently no activeElement
-      if (!document.activeElement || document.activeElement === document.body) {
+      // there is currently no activeElement and not inline
+      if ((!document.activeElement || document.activeElement === document.body) && !this.props.inline) {
         shouldFocusDay = true;
       }
       // the activeElement is in the container, and it is another instance of Day

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -813,6 +813,7 @@ export default class DatePicker extends React.Component {
         includeDates={this.props.includeDates}
         includeTimes={this.props.includeTimes}
         injectTimes={this.props.injectTimes}
+        inline={this.props.inline}
         peekNextMonth={this.props.peekNextMonth}
         showMonthDropdown={this.props.showMonthDropdown}
         showPreviousMonths={this.props.showPreviousMonths}

--- a/src/month.jsx
+++ b/src/month.jsx
@@ -22,6 +22,7 @@ export default class Month extends React.Component {
     formatWeekNumber: PropTypes.func,
     highlightDates: PropTypes.instanceOf(Map),
     includeDates: PropTypes.array,
+    inline: PropTypes.bool,
     locale: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.shape({ locale: PropTypes.object })
@@ -151,6 +152,7 @@ export default class Month extends React.Component {
           excludeDates={this.props.excludeDates}
           includeDates={this.props.includeDates}
           highlightDates={this.props.highlightDates}
+          inline={this.props.inline}
           selectingDate={this.props.selectingDate}
           filterDate={this.props.filterDate}
           preSelection={this.props.preSelection}
@@ -261,7 +263,7 @@ export default class Month extends React.Component {
 
   getTabIndex = (m) => {
     const preSelectedMonth = utils.getMonth(this.props.preSelection);
-    const tabIndex = 
+    const tabIndex =
       !this.props.disabledKeyboardNavigation && m === preSelectedMonth
         ? "0"
         : "-1";

--- a/src/week.jsx
+++ b/src/week.jsx
@@ -23,6 +23,7 @@ export default class Week extends React.Component {
     formatWeekNumber: PropTypes.func,
     highlightDates: PropTypes.instanceOf(Map),
     includeDates: PropTypes.array,
+    inline: PropTypes.bool,
     locale: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.shape({ locale: PropTypes.object })
@@ -129,6 +130,7 @@ export default class Week extends React.Component {
             handleOnKeyDown={this.props.handleOnKeyDown}
             isInputFocused={this.props.isInputFocused}
             containerRef={this.props.containerRef}
+            inline={this.props.inline}
           />
         );
       })


### PR DESCRIPTION
This is a bug fix.  Our calendar is displayed inline, and we need to set the selected date when our upon page load.  However, since the user at this point has not done anything, document.activeElement === document.body, and the selected day is getting focus due to handleFocusDay() in day.jsx.
I tried to make this as low-impact a fix as possible, but it still required a lot of prop drilling.