### PR TITLE
add & call 'monthClassName' to use its value

### DIFF
--- a/src/month.jsx
+++ b/src/month.jsx
@@ -14,6 +14,7 @@ export default class Month extends React.Component {
     disabledKeyboardNavigation: PropTypes.bool,
     day: PropTypes.instanceOf(Date).isRequired,
     dayClassName: PropTypes.func,
+    monthClassName: PropTypes.func,
     endDate: PropTypes.instanceOf(Date),
     orderInDisplay: PropTypes.number,
     excludeDates: PropTypes.array,
@@ -235,8 +236,10 @@ export default class Month extends React.Component {
   };
 
   getMonthClassNames = m => {
-    const { day, startDate, endDate, selected, minDate, maxDate, preSelection } = this.props;
+    const { day, startDate, endDate, selected, minDate, maxDate, preSelection, monthClassName } = this.props;
+    const _monthClassName = monthClassName ? monthClassName(date) : undefined;
     return classnames(
+      _monthClassName,
       "react-datepicker__month-text",
       `react-datepicker__month-${m}`,
       {

--- a/src/month.jsx
+++ b/src/month.jsx
@@ -236,10 +236,8 @@ export default class Month extends React.Component {
   };
 
   getMonthClassNames = m => {
-    const { day, startDate, endDate, selected, minDate, maxDate, preSelection, monthClassName } = this.props;
-    const _monthClassName = monthClassName ? monthClassName(date) : undefined;
+    const { day, startDate, endDate, selected, minDate, maxDate, preSelection } = this.props;
     return classnames(
-      _monthClassName,
       "react-datepicker__month-text",
       `react-datepicker__month-${m}`,
       {
@@ -382,14 +380,19 @@ export default class Month extends React.Component {
 
   getClassNames = () => {
     const {
+      day,
       selectingDate,
       selectsStart,
       selectsEnd,
       showMonthYearPicker,
-      showQuarterYearPicker
+      showQuarterYearPicker,
+      monthClassName
     } = this.props;
+    const _monthClassName = monthClassName ? monthClassName(day) : undefined;
+
     return classnames(
       "react-datepicker__month",
+      _monthClassName,
       {
         "react-datepicker__month--selecting-range":
           selectingDate && (selectsStart || selectsEnd)

--- a/test/month_test.js
+++ b/test/month_test.js
@@ -40,6 +40,13 @@ describe("Month", () => {
     });
   }
 
+  it("should apply className returned from passed monthClassName prop function", () => {
+    const className = "customClassName";
+    const monthClassNameFunc = date => className;
+    const month = shallow(<Month day={utils.newDate()} monthClassName={monthClassNameFunc} />);
+    expect(month.hasClass(className)).to.equal(true);
+  });
+
   it("should have the month CSS class", () => {
     const month = shallow(<Month day={utils.newDate()} />);
     expect(month.hasClass("react-datepicker__month")).to.equal(true);


### PR DESCRIPTION
The prop monthClassName was been already passed by its parent,
the calendar component, but it wasn't used at any time. fix #2407 