### PR TITLE
fix autofocus on selected day when inline prop is true

### DIFF
--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -98,6 +98,7 @@ export default class Calendar extends React.Component {
     includeDates: PropTypes.array,
     includeTimes: PropTypes.array,
     injectTimes: PropTypes.array,
+    inline: PropTypes.bool,
     locale: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.shape({ locale: PropTypes.object })
@@ -791,6 +792,7 @@ export default class Calendar extends React.Component {
             highlightDates={this.props.highlightDates}
             selectingDate={this.state.selectingDate}
             includeDates={this.props.includeDates}
+            inline={this.props.inline}
             fixedHeight={this.props.fixedHeight}
             filterDate={this.props.filterDate}
             preSelection={this.props.preSelection}

--- a/src/day.jsx
+++ b/src/day.jsx
@@ -26,6 +26,7 @@ export default class Day extends React.Component {
     dayClassName: PropTypes.func,
     endDate: PropTypes.instanceOf(Date),
     highlightDates: PropTypes.instanceOf(Map),
+    inline: PropTypes.bool,
     month: PropTypes.number,
     onClick: PropTypes.func,
     onMouseEnter: PropTypes.func,
@@ -277,8 +278,8 @@ export default class Day extends React.Component {
       !prevProps.isInputFocused &&
       this.isSameDay(this.props.preSelection)
     ) {
-      // there is currently no activeElement
-      if (!document.activeElement || document.activeElement === document.body) {
+      // there is currently no activeElement and not inline
+      if ((!document.activeElement || document.activeElement === document.body) && !this.props.inline) {
         shouldFocusDay = true;
       }
       // the activeElement is in the container, and it is another instance of Day
@@ -294,6 +295,7 @@ export default class Day extends React.Component {
 
     shouldFocusDay && this.dayEl.current.focus({ preventScroll: true });
   };
+
   render = () => (
     <div
       ref={this.dayEl}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -813,6 +813,7 @@ export default class DatePicker extends React.Component {
         includeDates={this.props.includeDates}
         includeTimes={this.props.includeTimes}
         injectTimes={this.props.injectTimes}
+        inline={this.props.inline}
         peekNextMonth={this.props.peekNextMonth}
         showMonthDropdown={this.props.showMonthDropdown}
         showPreviousMonths={this.props.showPreviousMonths}

--- a/src/month.jsx
+++ b/src/month.jsx
@@ -23,6 +23,7 @@ export default class Month extends React.Component {
     formatWeekNumber: PropTypes.func,
     highlightDates: PropTypes.instanceOf(Map),
     includeDates: PropTypes.array,
+    inline: PropTypes.bool,
     locale: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.shape({ locale: PropTypes.object })
@@ -151,6 +152,7 @@ export default class Month extends React.Component {
           maxDate={this.props.maxDate}
           excludeDates={this.props.excludeDates}
           includeDates={this.props.includeDates}
+          inline={this.props.inline}
           highlightDates={this.props.highlightDates}
           selectingDate={this.props.selectingDate}
           filterDate={this.props.filterDate}
@@ -262,7 +264,7 @@ export default class Month extends React.Component {
 
   getTabIndex = (m) => {
     const preSelectedMonth = utils.getMonth(this.props.preSelection);
-    const tabIndex = 
+    const tabIndex =
       !this.props.disabledKeyboardNavigation && m === preSelectedMonth
         ? "0"
         : "-1";

--- a/src/week.jsx
+++ b/src/week.jsx
@@ -23,6 +23,7 @@ export default class Week extends React.Component {
     formatWeekNumber: PropTypes.func,
     highlightDates: PropTypes.instanceOf(Map),
     includeDates: PropTypes.array,
+    inline: PropTypes.bool,
     locale: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.shape({ locale: PropTypes.object })
@@ -129,6 +130,7 @@ export default class Week extends React.Component {
             handleOnKeyDown={this.props.handleOnKeyDown}
             isInputFocused={this.props.isInputFocused}
             containerRef={this.props.containerRef}
+            inline={this.props.inline}
           />
         );
       })

--- a/test/day_test.js
+++ b/test/day_test.js
@@ -1,6 +1,8 @@
 import React from "react";
 import Day from "../src/day";
-import { shallow } from "enzyme";
+import { mount, shallow } from "enzyme";
+import defer from "lodash/defer";
+import sinon from "sinon";
 import {
   getDayOfWeekCode,
   newDate,
@@ -682,6 +684,40 @@ describe("Day", () => {
         excludeDates: [selectingDate]
       });
       expect(shallowDay.hasClass(rangeDayClassName)).to.be.false;
+    });
+  });
+  
+  describe("focus", () => {
+    let sandbox;
+    beforeEach(function() {
+      sandbox = sinon.createSandbox()
+    });
+    afterEach(function() {
+      sandbox.restore();
+    });
+    
+    it("should apply focus to the preselected day", () => {
+      const day = newDate();
+      const dayInstance = mount(<Day day={day} preSelection={day} />).instance();
+      
+      sandbox.spy(dayInstance.dayEl.current, "focus");
+      dayInstance.componentDidMount();
+      defer(() => {
+        expect(dayInstance.dayEl.current.focus.calledOnce).to.equal(true);
+        done();
+      });
+    });
+  
+    it("should not apply focus to the preselected day if inline", () => {
+      const day = newDate();
+      const dayInstance = mount(<Day day={day} preSelection={day} inline />).instance();
+    
+      sandbox.spy(dayInstance.dayEl.current, "focus");
+      dayInstance.componentDidMount();
+      defer(() => {
+        expect(dayInstance.dayEl.current.focus.calledOnce).to.equal(false);
+        done();
+      });
     });
   });
 });


### PR DESCRIPTION
This fixes a big issue we were having -- the inline DatePicker at the bottom of our home page was grabbing focus upon page load.  This caused an accessibility issue where, if the user pressed the Tab key, they were unexpectedly on the footer instead of on the first clickable link.  

I made this a very narrow fix to only change the one line in day.jsx that was causing the issue, but it required a lot of prop drilling to get down to it.  I added a couple of unit tests to test when inline=false and =true.