### PR TITLE
Feature hide duplicate days

### DIFF
--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -761,6 +761,8 @@ export default class Calendar extends React.Component {
       var monthsToAdd = i - this.props.monthSelectedIn;
       var monthDate = addMonths(fromMonthDate, monthsToAdd);
       var monthKey = `month-${i}`;
+      var monthShowsDuplicateDaysEnd = i < (this.props.monthsShown - 1);
+      var monthShowsDuplicateDaysStart = i > 0;
       monthList.push(
         <div
           key={monthKey}
@@ -818,6 +820,8 @@ export default class Calendar extends React.Component {
             showQuarterYearPicker={this.props.showQuarterYearPicker}
             isInputFocused={this.props.isInputFocused}
             containerRef={this.containerRef}
+            monthShowsDuplicateDaysEnd={monthShowsDuplicateDaysEnd}
+            monthShowsDuplicateDaysStart={monthShowsDuplicateDaysStart}
           />
         </div>
       );

--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -274,8 +274,10 @@ export default class Calendar extends React.Component {
     );
   };
 
-  handleDayClick = (day, event, monthSelectedIn) =>
+  handleDayClick = (day, event, monthSelectedIn) => {
     this.props.onSelect(day, event, monthSelectedIn);
+    this.props.setPreSelection && this.props.setPreSelection(day);
+  }   
 
   handleDayMouseEnter = day => {
     this.setState({ selectingDate: day });

--- a/src/day.jsx
+++ b/src/day.jsx
@@ -42,7 +42,9 @@ export default class Day extends React.Component {
     containerRef: PropTypes.oneOfType([
       PropTypes.func,
       PropTypes.shape({ current: PropTypes.instanceOf(Element) })
-    ])
+    ]),
+    monthShowsDuplicateDaysEnd: PropTypes.bool,
+    monthShowsDuplicateDaysStart: PropTypes.bool
   };
 
   componentDidMount() {
@@ -296,6 +298,17 @@ export default class Day extends React.Component {
     shouldFocusDay && this.dayEl.current.focus({ preventScroll: true });
   };
 
+  renderDayContents = () => {
+    if(this.isOutsideMonth()) {
+      if(this.props.monthShowsDuplicateDaysEnd && getDate(this.props.day) < 10) return null;
+      if(this.props.monthShowsDuplicateDaysStart && getDate(this.props.day) > 20) return null;
+    }
+
+    return this.props.renderDayContents
+    ? this.props.renderDayContents(getDate(this.props.day), this.props.day)
+    : getDate(this.props.day);
+  }
+
   render = () => (
     <div
       ref={this.dayEl}
@@ -308,9 +321,7 @@ export default class Day extends React.Component {
       role="button"
       aria-disabled={this.isDisabled()}
     >
-      {this.props.renderDayContents
-        ? this.props.renderDayContents(getDate(this.props.day), this.props.day)
-        : getDate(this.props.day)}
+      {this.renderDayContents()}
     </div>
   );
 }

--- a/src/month.jsx
+++ b/src/month.jsx
@@ -57,7 +57,9 @@ export default class Month extends React.Component {
     containerRef: PropTypes.oneOfType([
       PropTypes.func,
       PropTypes.shape({ current: PropTypes.instanceOf(Element) })
-    ])
+    ]),
+    monthShowsDuplicateDaysEnd: PropTypes.bool,
+    monthShowsDuplicateDaysStart: PropTypes.bool
   };
 
   MONTH_REFS = Array(12).fill().map(() => React.createRef());
@@ -172,6 +174,8 @@ export default class Month extends React.Component {
           handleOnKeyDown={this.props.handleOnKeyDown}
           isInputFocused={this.props.isInputFocused}
           containerRef={this.props.containerRef}
+          monthShowsDuplicateDaysEnd={this.props.monthShowsDuplicateDaysEnd}
+          monthShowsDuplicateDaysStart={this.props.monthShowsDuplicateDaysStart}
         />
       );
 

--- a/src/week.jsx
+++ b/src/week.jsx
@@ -50,7 +50,9 @@ export default class Week extends React.Component {
     containerRef: PropTypes.oneOfType([
       PropTypes.func,
       PropTypes.shape({ current: PropTypes.instanceOf(Element) })
-    ])
+    ]),
+    monthShowsDuplicateDaysEnd: PropTypes.bool,
+    monthShowsDuplicateDaysStart: PropTypes.bool
   };
 
   handleDayClick = (day, event) => {
@@ -131,6 +133,8 @@ export default class Week extends React.Component {
             isInputFocused={this.props.isInputFocused}
             containerRef={this.props.containerRef}
             inline={this.props.inline}
+            monthShowsDuplicateDaysEnd={this.props.monthShowsDuplicateDaysEnd}
+            monthShowsDuplicateDaysStart={this.props.monthShowsDuplicateDaysStart}
           />
         );
       })

--- a/test/day_test.js
+++ b/test/day_test.js
@@ -481,6 +481,36 @@ describe("Day", () => {
       const shallowDay = renderDay(day, { month: getMonth(day) + 1 });
       expect(shallowDay.hasClass(className)).to.equal(true);
     });
+
+    it("should hide days outside month at end when duplicates", () => {
+      const day = newDate("2020-12-02");
+      const wrapper = mount(<Day day={day} month={getMonth(day)-1} monthShowsDuplicateDaysEnd />);
+      expect(wrapper.text()).to.be.empty;
+    });
+
+    it("should show days outside month at end when not duplicates", () => {
+      const day = newDate("2020-12-02");
+      const wrapper = mount(<Day day={day} month={getMonth(day)-1} />);
+      expect(wrapper.text()).to.equal(day.getDate().toString());
+    });
+
+    it("should hide days outside month at start when duplicates", () => {
+      const day = newDate("2020-10-30");
+      const wrapper = mount(<Day day={day} month={getMonth(day)+1} monthShowsDuplicateDaysStart />);
+      expect(wrapper.text()).to.be.empty;
+    });
+
+    it("should show days outside month at start when not duplicates", () => {
+      const day = newDate("2020-10-30");
+      const wrapper = mount(<Day day={day} month={getMonth(day)+1} />);
+      expect(wrapper.text()).to.equal(day.getDate().toString());
+    });
+
+    it("should show days in month when duplicates at start/end", () => {
+      const day = newDate("2020-11-15");
+      const wrapper = mount(<Day day={day} month={getMonth(day)} monthShowsDuplicateDaysStart monthShowsDuplicateDaysEnd />);
+      expect(wrapper.text()).to.equal(day.getDate().toString());
+    });
   });
 
   describe("disabled", () => {


### PR DESCRIPTION
This PR does two things. 

1. Solves #2284 . As described in issue, keyboard focus does not update in inline version. By updating preSelection date when changing date by click the keyboard date and selected date will be in sync.
Before:
![before](https://user-images.githubusercontent.com/25366540/95587414-4f54aa00-0a42-11eb-8c7c-1801b2f2609b.gif)
After:
![after](https://user-images.githubusercontent.com/25366540/95587773-d013a600-0a42-11eb-9581-efa4e8313443.gif)

2. While solving 1, i broke a the test: "should not switch months in inline mode when a day is clicked". After looking into it i saw that the test is not actually testing if the month is switched or not. But i found the case interesting. Firstly, i mean that in default inline case, if you click on a outside-month day, it should change month (and it currently does). Secondly believe it should be the case if its multiple months shown. The current version will switch between months when clicking on an outside-month day (the inline design of two months is another issue): 
![before](https://user-images.githubusercontent.com/25366540/95590842-d99f0d00-0a46-11eb-8fe1-84525dffcc92.gif)
My take on a solution: Why show duplicate days at all when viewing multiple months?
![after](https://user-images.githubusercontent.com/25366540/95591256-59c57280-0a47-11eb-931c-2cf6ad7fbc17.gif)
This also effects non-inline version: 
<img width="440" alt="Screenshot 2020-10-09 at 15 53 22" src="https://user-images.githubusercontent.com/25366540/95591448-9a24f080-0a47-11eb-8edf-d26124c52106.png">
