### PR TITLE
fix: display default header in additional months

### DIFF
--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -739,7 +739,7 @@ export default class Calendar extends React.Component {
 
   renderHeader = headerArgs => {
     switch (true) {
-      case this.props.renderCustomHeader !== undefined:
+      case this.props.renderCustomHeader !== undefined && headerArgs.i === 0:
         return this.renderCustomHeader(headerArgs);
       case this.props.showMonthYearPicker ||
         this.props.showQuarterYearPicker ||


### PR DESCRIPTION
This is a quick fix to test things out manually on my end, I'll clean up related code and update automated tests shortly.

Related to #1721