### PR TITLE
Added link to docs for popper component

### DIFF
--- a/docs-site/src/components/Examples/index.js
+++ b/docs-site/src/components/Examples/index.js
@@ -118,7 +118,12 @@ export default class exampleComponents extends React.Component {
     },
     {
       title: "Configure Popper Properties",
-      component: ConfigurePopper
+      component: ConfigurePopper,
+      description: (
+        <div>Full docs for the popper can be found at{" "}
+          <a href="https://popper.js.org" target="_blank" rel="noopener noreferrer">popper.js.org</a>
+        </div>
+      )
     },
     {
       title: "Custom input",


### PR DESCRIPTION
Had a hard time figuring out what the props were for the popper stuff until I discovered popper was a separate component.  So, I added a description that contains a link to the documentation for the popper.