### PR TITLE
Show links to examples and scroll an example to the top

### DIFF
--- a/docs-site/src/components/Examples/index.js
+++ b/docs-site/src/components/Examples/index.js
@@ -406,11 +406,10 @@ export default class exampleComponents extends React.Component {
       <>
         <h1>Examples</h1>
         <ul className="examples__navigation">
-          {this.examples.map((example, index) => (
-            <li className="examples__navigation-item" key={`link-${index}`}>
+          {this.examples.map(example => (
+            <li className="examples__navigation-item" key={`link-${example.title}`}>
               <a
                 href={`#example-${slugify(example.title, { lower: true })}`}
-                title="something"
                 onClick={e =>
                   this.handleAnchorClick(
                     e,
@@ -424,8 +423,8 @@ export default class exampleComponents extends React.Component {
           ))}
         </ul>
         <div className="examples">
-          {this.examples.map((example, index) => (
-            <CodeExampleComponent key={index} example={example} />
+          {this.examples.map((example) => (
+            <CodeExampleComponent key={example.title} example={example} />
           ))}
         </div>
       </>

--- a/docs-site/src/components/Examples/index.js
+++ b/docs-site/src/components/Examples/index.js
@@ -398,7 +398,7 @@ export default class exampleComponents extends React.Component {
     window.history.replaceState(null, document.title, `#${id}`);
     document
       .getElementById(id)
-      .scrollIntoView({ behavior: "smooth", block: "center" });
+      .scrollIntoView({ behavior: "smooth", block: "start" });
   };
 
   render() {

--- a/docs-site/src/components/Examples/index.js
+++ b/docs-site/src/components/Examples/index.js
@@ -395,6 +395,7 @@ export default class exampleComponents extends React.Component {
 
   handleAnchorClick = (e, id) => {
     e.preventDefault();
+    window.history.replaceState(null, document.title, `#${id}`);
     document
       .getElementById(id)
       .scrollIntoView({ behavior: "smooth", block: "center" });
@@ -409,6 +410,7 @@ export default class exampleComponents extends React.Component {
             <li className="examples__navigation-item" key={`link-${index}`}>
               <a
                 href={`#example-${slugify(example.title, { lower: true })}`}
+                title="something"
                 onClick={e =>
                   this.handleAnchorClick(
                     e,


### PR DESCRIPTION
Hello! This is an awesome project, and recently I wanted to suggest its use, with an example from the docs site. Unfortunately, there was no easy way to share a link to a particular example, and I instead manually created `https://reactdatepicker.com/#example-input-time` after looking into the markup.

I notice that anchor click behavior is overridden in order to animate the scroll. This looks really clean, but we lose the shareable links. With [`window.history.replaceState`](https://developer.mozilla.org/en-US/docs/Web/API/History/replaceState) we can update the address bar without causing a page refresh. And using `replaceState` instead of `pushState`, we don't clutter browser history when the user navigates between examples.

Additionally, I noticed that when scrolling an element we choose to scroll it to the middle of the page. When scrolling to really large examples, for example "Custom Header" (notice how I wanted to share a particular example just then hehe), it scrolls to the middle even on a large screen and all you see is code. I changed this to scroll an element to the start of the page.

Lastly, it is generally [discouraged to use array index as keys](https://medium.com/@robinpokorny/index-as-a-key-is-an-anti-pattern-e0349aece318) for React components, and while the exact implementation in `Examples/index.js` should not be impacted by the side-effects it is still an anti-pattern. There is an ES Lint rule for this [`react/no-array-index-key`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-array-index-key.md) which can be added, though I have not explored that for the scope of this PR.

Here is a gif showing all of the above changes - scrolling to the middle, updating the url bar, and no history cluttering.

Let me know what you think! 🤗 

![](http://g.recordit.co/hPOzvAImN0.gif)