### PR TITLE
Day: custom day rendering options

### DIFF
--- a/docs-site/src/examples/renderCustomDay.js
+++ b/docs-site/src/examples/renderCustomDay.js
@@ -1,7 +1,7 @@
 () => {
   const [startDate, setStartDate] = useState(new Date());
-  const renderDayContents = (day, date) => {
-    const tooltipText = `Tooltip for date: ${date}`;
+  const renderDayContents = (day, date, props) => {
+    const tooltipText = `Tooltip for date: ${date}${props.disabled ? ' (disabled)' : ''}`;
     return <span title={tooltipText}>{getDate(date)}</span>;
   };
   return (

--- a/src/day.jsx
+++ b/src/day.jsx
@@ -298,6 +298,24 @@ export default class Day extends React.Component {
     shouldFocusDay && this.dayEl.current.focus({ preventScroll: true });
   };
 
+  getRenderDayContentsProps = () => {
+    return {
+      disabled: this.isDisabled(),
+      excluded: this.isExcluded(),
+      selected: this.isSameDay(this.props.selected),
+      keyboardSelected: this.isKeyboardSelected(),
+      rangeStart: this.isRangeStart(),
+      rangeSnd: this.isRangeEnd(),
+      inRange: this.isInRange(),
+      inSelectingRange: this.isInSelectingRange(),
+      selectingRangeStart: this.isSelectingRangeStart(),
+      selectingRangeEnd: this.isSelectingRangeEnd(),
+      today: this.isSameDay(newDate()),
+      weekend: this.isWeekend(),
+      outsideMonth: this.isOutsideMonth()
+    };
+  }
+
   renderDayContents = () => {
     if(this.isOutsideMonth()) {
       if(this.props.monthShowsDuplicateDaysEnd && getDate(this.props.day) < 10) return null;
@@ -305,7 +323,7 @@ export default class Day extends React.Component {
     }
 
     return this.props.renderDayContents
-    ? this.props.renderDayContents(getDate(this.props.day), this.props.day)
+    ? this.props.renderDayContents(getDate(this.props.day), this.props.day, this.getRenderDayContentsProps())
     : getDate(this.props.day);
   }
 

--- a/test/day_test.js
+++ b/test/day_test.js
@@ -39,8 +39,9 @@ describe("Day", () => {
 
     it("should render custom day contents", () => {
       const day = newDate();
-      function renderDayContents(day, date) {
+      function renderDayContents(day, date, options) {
         const tooltipText = `Tooltip for date: ${date}`;
+        expect(options).to.be.an('object');
         return <span title={tooltipText}>{getDate(date)}</span>;
       }
       const shallowDay = renderDay(day, { renderDayContents });


### PR DESCRIPTION
Hi, firstly thank you for your amazing work on this datepicker! 😄

This PR introduces an extra parameter to the day `renderDayContents` prop, which allows passing down internal information about the give day. It uses the same names (after converting to JS rather than CSS convention) as the class names.

I found CSS selectors were getting pretty convoluted when I wanted to change styling of the day contents depending on these properties, and thought it could be useful if they were simply passed down into `renderDayContents`.

- The appropriate test has been updated to verify that an object is passed as a third parameter
- The `renderDayContents` example has been updated to show this information being used, though understand this might not be the best example to show the functionality
- This should not be breaking

Please let me know what you think about this. Am willing to help do further work to get it in. Thanks!!