### PR TITLE
Fix for accessibility issue 'Elements that have scrollable content should be accessible by keyboard' for scrollable time panel 

### DIFF
--- a/src/time.jsx
+++ b/src/time.jsx
@@ -164,6 +164,7 @@ export default class Time extends React.Component {
             this.centerLi = li;
           }
         }}
+        tabIndex="0"
       >
         {formatDate(time, format, this.props.locale)}
       </li>
@@ -199,7 +200,7 @@ export default class Time extends React.Component {
                 this.list = list;
               }}
               style={height ? { height } : {}}
-              tabIndex='0'
+              tabIndex="0"
             >
               {this.renderTimes()}
             </ul>

--- a/src/time.jsx
+++ b/src/time.jsx
@@ -199,6 +199,7 @@ export default class Time extends React.Component {
                 this.list = list;
               }}
               style={height ? { height } : {}}
+              tabIndex='0'
             >
               {this.renderTimes()}
             </ul>


### PR DESCRIPTION
Fixed 'Elements that have scrollable content should be accessible by keyboard' WCAG violation for the scrollable time panel.
Before the fix "axe" chrome plugin was showing the following error: 

![image](https://user-images.githubusercontent.com/2556875/100968268-5a284880-3574-11eb-814f-0d81b91aef32.png)

After the fix "axe" chrome plugin was not showing "Elements that have scrollable content should be accessible by keyboard" and it is possible to scroll time panel
<img width="1401" alt="Screen Shot 2020-12-03 at 16 12 03" src="https://user-images.githubusercontent.com/2556875/100976153-77fcaa00-3582-11eb-8f46-88c7cd8abf6a.png">

I have followed the recommendation from dequeuniversity: 
https://dequeuniversity.com/rules/axe/4.0/scrollable-region-focusable?application=AxeChrome