### PR TITLE
Replace fill method with different syntax for IE compatibility

### DIFF
--- a/src/month.jsx
+++ b/src/month.jsx
@@ -62,7 +62,7 @@ export default class Month extends React.Component {
     monthShowsDuplicateDaysStart: PropTypes.bool
   };
 
-  MONTH_REFS = Array(12).fill().map(() => React.createRef());
+  MONTH_REFS = [...Array(12)].map(() => React.createRef());
 
   isDisabled = date => utils.isDayDisabled(date, this.props);
 


### PR DESCRIPTION
Fixed bug introduced in version 3.2.0 (PR #2389).
The fill method was used, but it is not supported in IE.
The method was removed and replaced with different syntax that gets transpiled and works in IE.

Fixes #2577