### PR TITLE
Fix keyboard navigation in inline version

### DIFF
--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -99,6 +99,7 @@ export default class Calendar extends React.Component {
     includeTimes: PropTypes.array,
     injectTimes: PropTypes.array,
     inline: PropTypes.bool,
+    shouldFocusDayInline: PropTypes.bool,
     locale: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.shape({ locale: PropTypes.object })
@@ -798,6 +799,7 @@ export default class Calendar extends React.Component {
             selectingDate={this.state.selectingDate}
             includeDates={this.props.includeDates}
             inline={this.props.inline}
+            shouldFocusDayInline={this.props.shouldFocusDayInline}
             fixedHeight={this.props.fixedHeight}
             filterDate={this.props.filterDate}
             preSelection={this.props.preSelection}

--- a/src/day.jsx
+++ b/src/day.jsx
@@ -27,6 +27,7 @@ export default class Day extends React.Component {
     endDate: PropTypes.instanceOf(Date),
     highlightDates: PropTypes.instanceOf(Map),
     inline: PropTypes.bool,
+    shouldFocusDayInline: PropTypes.bool,
     month: PropTypes.number,
     onClick: PropTypes.func,
     onMouseEnter: PropTypes.func,
@@ -281,8 +282,14 @@ export default class Day extends React.Component {
       this.isSameDay(this.props.preSelection)
     ) {
       // there is currently no activeElement and not inline
-      if ((!document.activeElement || document.activeElement === document.body) && !this.props.inline) {
+      if ((!document.activeElement || document.activeElement === document.body)) {
         shouldFocusDay = true;
+      }
+      // inline version:
+      // do not focus on initial render to prevent autoFocus issue
+      // focus after month has changed via keyboard
+      if (this.props.inline && !this.props.shouldFocusDayInline) {
+        shouldFocusDay = false;
       }
       // the activeElement is in the container, and it is another instance of Day
       if (

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -334,7 +334,10 @@ export default class DatePicker extends React.Component {
       // transforming highlighted days (perhaps nested array)
       // to flat Map for faster access in day.jsx
       highlightDates: getHightLightDaysMap(this.props.highlightDates),
-      focused: false
+      focused: false,
+      // used to focus day in inline version after month has changed, but not on
+      // initial render
+      shouldFocusDayInline: false
     };
   };
 
@@ -712,6 +715,22 @@ export default class DatePicker extends React.Component {
         this.setSelected(newSelection);
       }
       this.setPreSelection(newSelection);
+      // need to figure out whether month has changed to focus day in inline version
+      if (this.props.inline) {
+        const prevMonth = getMonth(copy);
+        const newMonth = getMonth(newSelection);
+        const prevYear = getYear(copy);
+        const newYear = getYear(newSelection);
+
+        if (prevMonth !== newMonth || prevYear !== newYear) {
+          // month has changed
+          this.setState({ shouldFocusDayInline: true })
+        }
+        else {
+          // month hasn't changed
+          this.setState({ shouldFocusDayInline: false })
+        }
+      }
     }
   };
 
@@ -815,6 +834,7 @@ export default class DatePicker extends React.Component {
         includeTimes={this.props.includeTimes}
         injectTimes={this.props.injectTimes}
         inline={this.props.inline}
+        shouldFocusDayInline={this.state.shouldFocusDayInline}
         peekNextMonth={this.props.peekNextMonth}
         showMonthDropdown={this.props.showMonthDropdown}
         showPreviousMonths={this.props.showPreviousMonths}

--- a/src/month.jsx
+++ b/src/month.jsx
@@ -24,6 +24,7 @@ export default class Month extends React.Component {
     highlightDates: PropTypes.instanceOf(Map),
     includeDates: PropTypes.array,
     inline: PropTypes.bool,
+    shouldFocusDayInline: PropTypes.bool,
     locale: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.shape({ locale: PropTypes.object })
@@ -155,6 +156,7 @@ export default class Month extends React.Component {
           excludeDates={this.props.excludeDates}
           includeDates={this.props.includeDates}
           inline={this.props.inline}
+          shouldFocusDayInline={this.props.shouldFocusDayInline}
           highlightDates={this.props.highlightDates}
           selectingDate={this.props.selectingDate}
           filterDate={this.props.filterDate}

--- a/src/week.jsx
+++ b/src/week.jsx
@@ -24,6 +24,7 @@ export default class Week extends React.Component {
     highlightDates: PropTypes.instanceOf(Map),
     includeDates: PropTypes.array,
     inline: PropTypes.bool,
+    shouldFocusDayInline: PropTypes.bool,
     locale: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.shape({ locale: PropTypes.object })
@@ -133,6 +134,7 @@ export default class Week extends React.Component {
             isInputFocused={this.props.isInputFocused}
             containerRef={this.props.containerRef}
             inline={this.props.inline}
+            shouldFocusDayInline={this.props.shouldFocusDayInline}
             monthShowsDuplicateDaysEnd={this.props.monthShowsDuplicateDaysEnd}
             monthShowsDuplicateDaysStart={this.props.monthShowsDuplicateDaysStart}
           />

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -1489,4 +1489,68 @@ describe("DatePicker", () => {
       expect(months.first().props().monthShowsDuplicateDaysEnd).to.be.false;
     })
   })
+
+  describe("shouldFocusDayInline state", () => {
+    const dateFormat = "yyyy-MM-dd";
+
+    it("should not be updated when navigating with ArrowRight key without changing displayed month", () => {
+      const datePickerInline = TestUtils.renderIntoDocument(
+        <DatePicker
+          selected={utils.newDate("2020-11-15")}
+          dateFormat={dateFormat}
+          inline
+        />
+      );
+      TestUtils.Simulate.keyDown(
+        getSelectedDayNode(datePickerInline),
+        getKey("ArrowRight")
+      );
+      expect(datePickerInline.state.shouldFocusDayInline).to.be.false;
+    });
+
+    it("should be set to true when changing displayed month with ArrowRight key", () => {
+      const datePickerInline = TestUtils.renderIntoDocument(
+        <DatePicker
+          selected={utils.newDate("2020-11-30")}
+          dateFormat={dateFormat}
+          inline
+        />
+      );
+      TestUtils.Simulate.keyDown(
+        getSelectedDayNode(datePickerInline),
+        getKey("ArrowRight")
+      );
+      expect(datePickerInline.state.shouldFocusDayInline).to.be.true;
+    });
+
+    it("should be set to true when changing displayed month with PageDown key", () => {
+      const datePickerInline = TestUtils.renderIntoDocument(
+        <DatePicker
+          selected={utils.newDate("2020-11-15")}
+          dateFormat={dateFormat}
+          inline
+        />
+      );
+      TestUtils.Simulate.keyDown(
+        getSelectedDayNode(datePickerInline),
+        getKey("PageDown")
+      );
+      expect(datePickerInline.state.shouldFocusDayInline).to.be.true;
+    });
+
+    it("should be set to true when changing displayed month with End key", () => {
+      const datePickerInline = TestUtils.renderIntoDocument(
+        <DatePicker
+          selected={utils.newDate("2020-11-15")}
+          dateFormat={dateFormat}
+          inline
+        />
+      );
+      TestUtils.Simulate.keyDown(
+        getSelectedDayNode(datePickerInline),
+        getKey("End")
+      );
+      expect(datePickerInline.state.shouldFocusDayInline).to.be.true;
+    });
+  });
 });


### PR DESCRIPTION
When the autoFocus issue of the inline version was fixed in v3.3.0 ([this commit](https://github.com/Hacker0x01/react-datepicker/commit/d09a14dc3d7e61d59069cd51acc9e78bc822524e)), the keyboard navigation stopped working after switching between months with ArrowLeft/Right/Up/Down, PageUp/Down, End/Home keys.

With this PR the autoFocus issue remains fixed, but keyboard navigation got restored

fixes #2578