### PR TITLE
docs: order of "Getting setup" in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,11 +25,11 @@ Start reading our code, and you'll get the hang of it. We optimize for readabili
 Local development configuration is pretty snappy. Here's how to get set up:
 
 1. Install/use node >=11.10.1
-2. Run `yarn link` from project root
-3. Run `cd docs-site && yarn link react-datepicker`
-4. Run `yarn build` from project root (at least the first time, this will get you the `dist` directory that holds the code that will be linked to)
-5. Run `yarn install` from project root
-6. Run `yarn start` from project root
-7. Open new terminal window
-8. After each JS change run `yarn build:js` in project root
-9. After each SCSS change run `yarn run css:dev && yarn run css:modules:dev` in project root
+1. Run `yarn link` from project root
+1. Run `cd docs-site && yarn link react-datepicker`
+1. Run `yarn install` from project root
+1. Run `yarn build` from project root (at least the first time, this will get you the `dist` directory that holds the code that will be linked to)
+1. Run `yarn start` from project root
+1. Open new terminal window
+1. After each JS change run `yarn build:js` in project root
+1. After each SCSS change run `yarn run css:dev && yarn run css:modules:dev` in project root


### PR DESCRIPTION
The `yarn install` shall precede `yarn build`, that's all...

Oh, and using ordinals in markdown ordered list is not needed, it just needs to be number, so I changed the ordinals to `1.` everywhere, it is easier to maintain -- there is no need to reorder when changed.