### PR TITLE
Fixing wrong weekNumber by using getIsoWeek

### DIFF
--- a/docs-site/src/examples/weekNumbers.js
+++ b/docs-site/src/examples/weekNumbers.js
@@ -4,6 +4,7 @@
     <DatePicker
       selected={startDate}
       onChange={date => setStartDate(date)}
+      locale="en-GB"
       showWeekNumbers
     />
   );

--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -18,7 +18,6 @@ import getMinutes from "date-fns/getMinutes";
 import getHours from "date-fns/getHours";
 import getDay from "date-fns/getDay";
 import getDate from "date-fns/getDate";
-import dfgetWeek from "date-fns/getWeek";
 import getISOWeek from "date-fns/getISOWeek";
 import getMonth from "date-fns/getMonth";
 import getQuarter from "date-fns/getQuarter";

--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -19,6 +19,7 @@ import getHours from "date-fns/getHours";
 import getDay from "date-fns/getDay";
 import getDate from "date-fns/getDate";
 import dfgetWeek from "date-fns/getWeek";
+import getISOWeek from "date-fns/getISOWeek";
 import getMonth from "date-fns/getMonth";
 import getQuarter from "date-fns/getQuarter";
 import getYear from "date-fns/getYear";
@@ -197,7 +198,7 @@ export function getWeek(date, locale) {
   let localeObj =
     (locale && getLocaleObject(locale)) ||
     (getDefaultLocale() && getLocaleObject(getDefaultLocale()));
-  return dfgetWeek(date, localeObj ? { locale: localeObj } : null);
+  return getISOWeek(date, localeObj ? { locale: localeObj } : null);
 }
 
 export function getDayOfWeekCode(day, locale) {

--- a/src/week.jsx
+++ b/src/week.jsx
@@ -81,7 +81,7 @@ export default class Week extends React.Component {
     if (this.props.formatWeekNumber) {
       return this.props.formatWeekNumber(date);
     }
-    return utils.getWeek(date, this.props.locale);
+    return utils.getWeek(date);
   };
 
   renderDays = () => {

--- a/test/date_utils_test.js
+++ b/test/date_utils_test.js
@@ -29,7 +29,7 @@ import {
   getYearsPeriod,
   yearsDisabledAfter,
   yearsDisabledBefore,
-  getYear
+  getWeek
 } from "../src/date_utils";
 import setMinutes from "date-fns/setMinutes";
 import setHours from "date-fns/setHours";
@@ -845,6 +845,23 @@ describe("date_utils", function() {
       const day = newDate("2044-08-08 00:00:00");
       const minDate = newDate("2020-08-08 00:00:00");
       expect(yearsDisabledBefore(day, { minDate })).to.be.false;
+    });
+  });
+
+  describe("week", () => {
+    it("should return the first 2021 year week", () => {
+      const first2021Day = new Date("2021-01-01");
+      assert(getWeek(first2021Day) === 53);
+    });
+
+    it("should return the 4 2021 year week", () => {
+      const date = new Date("2021-01-18");
+      assert(getWeek(date) === 3);
+    });
+
+    it("should return the first 2022 year week", () => {
+      const first2022Day = new Date("2022-01-01");
+      assert(getWeek(first2022Day) === 52);
     });
   });
 });


### PR DESCRIPTION
The current `showWeekNumbers` return wrong result because (from `getWeek` date-fns function).

Example : 

`console.log(dfgetWeek(new Date())); // 2, it's wrong, want 1`
`console.log(dfgetWeek(new Date('2020-01-01'))); // 1, it's wrong, want 53`

We need to use `getISOWeek` function for return iso result : 

`console.log(getISOWeek(new Date())); // 1, good`
`console.log(getISOWeek(new Date('2020-01-01'))); // 53, good`

From #2572 