### PR TITLE
Feature/add four column month display layout flag for month picker

### DIFF
--- a/docs-site/src/components/Examples/index.js
+++ b/docs-site/src/components/Examples/index.js
@@ -69,6 +69,7 @@ import MonthPicker from "../../examples/monthPicker";
 import YearPicker from "../../examples/yearPicker";
 import monthPickerFullName from "../../examples/monthPickerFullName";
 import monthPickerTwoColumns from "../../examples/monthPickerTwoColumns";
+import monthPickerFourColumns from "../../examples/monthPickerFourColumns";
 import RangeMonthPicker from "../../examples/rangeMonthPicker";
 import QuarterPicker from "../../examples/quarterPicker";
 import RangeQuarterPicker from "../../examples/rangeQuarterPicker";
@@ -276,6 +277,10 @@ export default class exampleComponents extends React.Component {
     {
       title: "Month Picker Two Columns Layout",
       component: monthPickerTwoColumns
+    },
+    {
+      title: "Month Picker Four Columns Layout",
+      component: monthPickerFourColumns
     },
     {
       title: "Month dropdown",

--- a/docs-site/src/examples/monthPickerFourColumns.js
+++ b/docs-site/src/examples/monthPickerFourColumns.js
@@ -1,0 +1,13 @@
+() => {
+  const [startDate, setStartDate] = useState(new Date());
+  return (
+    <DatePicker
+      selected={startDate}
+      onChange={date => setStartDate(date)}
+      dateFormat="MM/yyyy"
+      showMonthYearPicker
+      showFullMonthYearPicker
+      showFourColumnMonthYearPicker
+    />
+  );
+};

--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -122,6 +122,7 @@ export default class Calendar extends React.Component {
     showMonthYearPicker: PropTypes.bool,
     showFullMonthYearPicker: PropTypes.bool,
     showTwoColumnMonthYearPicker: PropTypes.bool,
+    showFourColumnMonthYearPicker: PropTypes.bool,
     showYearPicker: PropTypes.bool,
     showQuarterYearPicker: PropTypes.bool,
     showTimeSelectOnly: PropTypes.bool,
@@ -820,6 +821,9 @@ export default class Calendar extends React.Component {
             showFullMonthYearPicker={this.props.showFullMonthYearPicker}
             showTwoColumnMonthYearPicker={
               this.props.showTwoColumnMonthYearPicker
+            }
+            showFourColumnMonthYearPicker={
+              this.props.showFourColumnMonthYearPicker
             }
             showYearPicker={this.props.showYearPicker}
             showQuarterYearPicker={this.props.showQuarterYearPicker}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -92,6 +92,7 @@ export default class DatePicker extends React.Component {
       showMonthYearPicker: false,
       showFullMonthYearPicker: false,
       showTwoColumnMonthYearPicker: false,
+      showFourColumnMonthYearPicker: false,
       showYearPicker: false,
       showQuarterYearPicker: false,
       strictParsing: false,
@@ -223,6 +224,7 @@ export default class DatePicker extends React.Component {
     showMonthYearPicker: PropTypes.bool,
     showFullMonthYearPicker: PropTypes.bool,
     showTwoColumnMonthYearPicker: PropTypes.bool,
+    showFourColumnMonthYearPicker: PropTypes.bool,
     showYearPicker: PropTypes.bool,
     showQuarterYearPicker: PropTypes.bool,
     showTimeSelect: PropTypes.bool,
@@ -892,6 +894,7 @@ export default class DatePicker extends React.Component {
         showMonthYearPicker={this.props.showMonthYearPicker}
         showFullMonthYearPicker={this.props.showFullMonthYearPicker}
         showTwoColumnMonthYearPicker={this.props.showTwoColumnMonthYearPicker}
+        showFourColumnMonthYearPicker={this.props.showFourColumnMonthYearPicker}
         showYearPicker={this.props.showYearPicker}
         showQuarterYearPicker={this.props.showQuarterYearPicker}
         showPopperArrow={this.props.showPopperArrow}

--- a/src/month.jsx
+++ b/src/month.jsx
@@ -51,6 +51,7 @@ export default class Month extends React.Component {
     showMonthYearPicker: PropTypes.bool,
     showFullMonthYearPicker: PropTypes.bool,
     showTwoColumnMonthYearPicker: PropTypes.bool,
+    showFourColumnMonthYearPicker: PropTypes.bool,
     showQuarterYearPicker: PropTypes.bool,
     handleOnKeyDown: PropTypes.func,
     isInputFocused: PropTypes.bool,
@@ -324,8 +325,14 @@ export default class Month extends React.Component {
     const {
       showFullMonthYearPicker,
       showTwoColumnMonthYearPicker,
+      showFourColumnMonthYearPicker,
       locale
     } = this.props;
+    const monthsFourColumns = [
+      [0, 1, 2, 3],
+      [4, 5, 6, 7],
+      [8, 9, 10, 11]
+    ];
     const monthsThreeColumns = [
       [0, 1, 2],
       [3, 4, 5],
@@ -340,7 +347,9 @@ export default class Month extends React.Component {
       [8, 9],
       [10, 11]
     ];
-    const monthLayout = showTwoColumnMonthYearPicker
+    const monthLayout = showFourColumnMonthYearPicker ?
+      monthsFourColumns :
+      showTwoColumnMonthYearPicker
       ? monthsTwoColumns
       : monthsThreeColumns;
     return monthLayout.map((month, i) => (


### PR DESCRIPTION
Add a flag to allow month pickers to show in a **four column** month display layout

This is just **four column** version of https://github.com/Hacker0x01/react-datepicker/pull/2157