### PR TITLE
Display custom header when monthsShown prop is bigger than 1

### DIFF
--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -671,10 +671,6 @@ export default class Calendar extends React.Component {
   renderCustomHeader = (headerArgs = {}) => {
     const { monthDate, i } = headerArgs;
 
-    if (i !== 0 && i !== undefined) {
-      return null;
-    }
-
     const prevMonthButtonDisabled = monthDisabledBefore(
       this.state.date,
       this.props
@@ -707,6 +703,7 @@ export default class Calendar extends React.Component {
       >
         {this.props.renderCustomHeader({
           ...this.state,
+          customHeaderCount: i,
           changeMonth: this.changeMonth,
           changeYear: this.changeYear,
           decreaseMonth: this.decreaseMonth,

--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -672,6 +672,11 @@ export default class Calendar extends React.Component {
   renderCustomHeader = (headerArgs = {}) => {
     const { monthDate, i } = headerArgs;
 
+    if (this.props.showTimeSelect &&
+      (this.state.monthContainer || this.props.showTimeSelectOnly)) {
+        return null;
+    }
+
     const prevMonthButtonDisabled = monthDisabledBefore(
       this.state.date,
       this.props

--- a/test/calendar_test.js
+++ b/test/calendar_test.js
@@ -271,6 +271,7 @@ describe("Calendar", function() {
       getCalendar({ renderCustomHeader });
 
       const match = {
+        customHeaderCount: 0,
         changeMonth: sinon.match.func,
         changeYear: sinon.match.func,
         date: sinon.match.instanceOf(Date),
@@ -490,6 +491,20 @@ describe("Calendar", function() {
       const selected = utils.newDate(calendar.state().date);
 
       expect(utils.getYear(selected)).to.be.equal(2017);
+    });
+
+    it("should render custom headers according to monthsShown prop", () => {
+      const twoMonthsCalendar = getCalendar({
+        renderCustomHeader,
+        monthsShown: 2
+      });
+      expect(twoMonthsCalendar.find(".react-datepicker__header--custom")).to.have.length(2);
+
+      const fourMonthsCalendar = getCalendar({
+        renderCustomHeader,
+        monthsShown: 4
+      });
+      expect(fourMonthsCalendar.find(".react-datepicker__header--custom")).to.have.length(4);
     });
   });
 


### PR DESCRIPTION
Custom header now gets rendered for every month when monthsShown prop > 1;

Introduced customerHeaderCount prop to be able to conditionally render and adapt content in custom header, e.g. manipulate the displayed month value based on the date and customHeaderCount props

fixes #2351