### PR TITLE
multi-language get es format accpet in array dateformat

### DIFF
--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -88,8 +88,27 @@ export function parseDate(value, dateFormat, locale, strictParsing) {
       if (isValid(tryParseDate) && strictParsingValueMatch) {
         parsedDate = tryParseDate;
       }
+      if (!isValid(parsedDate)){
+        df = df
+        .match(longFormattingTokensRegExp)
+        .map(function(substring) {
+          var firstCharacter = substring[0];
+          if (firstCharacter === "p" || firstCharacter === "P") {
+            var longFormatter = longFormatters[firstCharacter];
+            return localeObject
+              ? longFormatter(substring, localeObject.formatLong)
+              : firstCharacter;
+          }
+          return substring;
+        })
+        .join("");
+
+        if (value.length > 0) {
+          parsedDate = parse(value, df.slice(0, value.length), new Date());
+        }
+      }
     });
-    return parsedDate;
+    return isValid(parsedDate)? parsedDate : null;
   }
 
   parsedDate = parse(value, dateFormat, new Date(), { locale: localeObject });

--- a/test/date_utils_test.js
+++ b/test/date_utils_test.js
@@ -689,12 +689,11 @@ describe("date_utils", function() {
 
       expect(parseDate(value, dateFormat, null, true)).to.be.null;
     });
-
-    it("should not parse date that does not match any of the formats", () => {
+       it("should return parse date in default format that does not match any of the formats", () => {
       const value = "01/15/20";
       const dateFormat = ["MM/dd/yyyy", "yyyy-MM-dd"];
 
-      expect(parseDate(value, dateFormat, null, true)).to.be.null;
+      expect(parseDate(value, dateFormat, null, true)).to.not.be.null;
     });
 
     it("should parse date without strict parsing", () => {


### PR DESCRIPTION
i'm using locale nl-NL and dateFormat "array", while typing the date in english it returns null only. i need locale support for es and nl so i have copy paste the dateFormat "string" code for supporting es 