### PR TITLE
Update react & react-dom peer-dep to support 17.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "date-fns": "^2.0.1",
     "prop-types": "^15.7.2",
     "react-onclickoutside": "^6.10.0",
-    "react-popper": "^1.3.4"
+    "react-popper": "^1.3.8"
   },
   "scripts": {
     "eslint": "eslint --ext .js,.jsx src test",

--- a/package.json
+++ b/package.json
@@ -106,8 +106,8 @@
     "webpack-hot-middleware": "^2.25.0"
   },
   "peerDependencies": {
-    "react": "^16.9.0",
-    "react-dom": "^16.9.0"
+    "react": "^16.9.0 || ^17",
+    "react-dom": "^16.9.0 || ^17"
   },
   "dependencies": {
     "classnames": "^2.2.6",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "classnames": "^2.2.6",
     "date-fns": "^2.0.1",
     "prop-types": "^15.7.2",
-    "react-onclickoutside": "^6.9.0",
+    "react-onclickoutside": "^6.10.0",
     "react-popper": "^1.3.4"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7893,7 +7893,7 @@ react-onclickoutside@^6.10.0:
   resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.10.0.tgz#05abb592575b08b4d129003494056b9dff46eeeb"
   integrity sha512-7i2L3ef+0ILXpL6P+Hg304eCQswh4jl3ynwR71BSlMU49PE2uk31k8B2GkP6yE9s2D4jTGKnzuSpzWxu4YxfQQ==
 
-react-popper@^1.3.4:
+react-popper@^1.3.8:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-1.3.8.tgz#d4de26cb51bbbdd9aacd8436ddb8d5784b2d389d"
   integrity sha512-v4urgRZHjruyxWiwebAQtfLrzzjebCgimPrNUJ/bM2a1udgn+5/4t207nWPpjl8CDFYM2T0vcCSy5DAEd7dUGQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -7866,10 +7866,10 @@ react-is@^16.13.1, react-is@^16.8.1, react-is@^16.8.6:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-onclickoutside@^6.9.0:
-  version "6.9.0"
-  resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.9.0.tgz#a54bc317ae8cf6131a5d78acea55a11067f37a1f"
-  integrity sha512-8ltIY3bC7oGhj2nPAvWOGi+xGFybPNhJM0V1H8hY/whNcXgmDeaeoCMPPd8VatrpTsUWjb/vGzrmu6SrXVty3A==
+react-onclickoutside@^6.10.0:
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.10.0.tgz#05abb592575b08b4d129003494056b9dff46eeeb"
+  integrity sha512-7i2L3ef+0ILXpL6P+Hg304eCQswh4jl3ynwR71BSlMU49PE2uk31k8B2GkP6yE9s2D4jTGKnzuSpzWxu4YxfQQ==
 
 react-popper@^1.3.4:
   version "1.3.7"


### PR DESCRIPTION
This will only fix the peer-dependencies of this package.

~Installing this package will still fail with react@17 and npm@7. We still depend on react-onclickoutside, which also needs to be updated to support peer-dependencies of react@17.~ https://github.com/Pomax/react-onclickoutside/issues/346 (done)

react-popper@1 doesn't support react@17 either, so this is also blocked by the react-popper@2 upgrade #2686 .

Addresses #2677 