### PR TITLE
fix: attempt to validate dates when minTime and maxTime props are

### DIFF
--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -37,6 +37,8 @@ import {
   yearsDisabledBefore,
   getEffectiveMinDate,
   getEffectiveMaxDate,
+  getEffectiveMinDateTime,
+  getEffectiveMaxDateTime,
   addZero,
   isValid,
   getYearsPeriod,
@@ -242,9 +244,9 @@ export default class Calendar extends React.Component {
   };
 
   getDateInView = () => {
-    const { preSelection, selected, openToDate } = this.props;
-    const minDate = getEffectiveMinDate(this.props);
-    const maxDate = getEffectiveMaxDate(this.props);
+    const { preSelection, selected, openToDate, minTime, maxTime } = this.props;
+    const minDate = minTime ? getEffectiveMinDateTime(this.props) : getEffectiveMinDate(this.props);
+    const maxDate = maxTime ? getEffectiveMaxDateTime(this.props) : getEffectiveMaxDate(this.props);
     const current = newDate();
     const initialDate = openToDate || selected || preSelection;
     if (initialDate) {

--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -310,6 +310,14 @@ export function isDayInRange(day, startDate, endDate) {
   return valid;
 }
 
+export function isDateTimeInRange(date, startDate, endDate) {
+  try {
+    return isWithinInterval(date, { start: startDate, end: endDate })
+  } catch (err) {
+    return false
+  }
+}
+
 // *** Diffing ***
 
 export function getDaysDiff(date1, date2) {
@@ -602,6 +610,32 @@ export function getEffectiveMaxDate({ maxDate, includeDates }) {
   } else {
     return maxDate;
   }
+}
+
+export function getEffectiveMinDateTime({ minTime, includeTimes }) {
+  if (!minTime && !includeTimes) {
+    return null
+  }
+  if (minTime && !includeTimes) {
+    return minTime
+  }
+  if (includeTimes && minTime) {
+    return includeTimes.find((dateTime) => isBefore(minTime, dateTime)) || minTime
+  }
+  return min(includeTimes);
+}
+
+export function getEffectiveMaxDateTime({ maxTime, includeTimes }) {
+  if (!maxTime && !includeTimes) {
+    return null
+  }
+  if (maxTime && !includeTimes) {
+    return maxTime
+  }
+  if(includeTimes && maxTime) {
+    return includeTimes.find((dateTime) => isBefore(maxTime, dateTime)) || maxTime
+  }
+  return max(includeTimes)
 }
 
 export function getHightLightDaysMap(

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -23,8 +23,11 @@ import {
   subYears,
   isDayDisabled,
   isDayInRange,
+  isDateTimeInRange,
   getEffectiveMinDate,
   getEffectiveMaxDate,
+  getEffectiveMinDateTime,
+  getEffectiveMaxDateTime,
   parseDate,
   safeDateFormat,
   getHightLightDaysMap,
@@ -322,8 +325,12 @@ export default class DatePicker extends React.Component {
 
   calcInitialState = () => {
     const defaultPreSelection = this.getPreSelection();
-    const minDate = getEffectiveMinDate(this.props);
-    const maxDate = getEffectiveMaxDate(this.props);
+    const minDate = this.props.minTime
+      ? getEffectiveMinDateTime(this.props)
+      : getEffectiveMinDate(this.props);
+    const maxDate = this.props.maxTime
+      ? getEffectiveMaxDateTime(this.props)
+      : getEffectiveMaxDate(this.props);
     const boundedPreSelection =
       minDate && isBefore(defaultPreSelection, minDate)
         ? minDate
@@ -554,9 +561,18 @@ export default class DatePicker extends React.Component {
   setPreSelection = date => {
     const hasMinDate = typeof this.props.minDate !== "undefined";
     const hasMaxDate = typeof this.props.maxDate !== "undefined";
+    const hasMinTime = typeof this.props.minTime !== "undefined";
+    const hasMaxTime = typeof this.props.maxTime !== "undefined";
+
     let isValidDateSelection = true;
     if (date) {
-      if (hasMinDate && hasMaxDate) {
+      if (hasMinTime && hasMaxTime) {
+        isValidDateSelection = isDateTimeInRange(
+          date,
+          this.props.minTime,
+          this.props.maxTime
+        );
+      } else if (hasMinDate && hasMaxDate) {
         isValidDateSelection = isDayInRange(
           date,
           this.props.minDate,

--- a/test/date_utils_test.js
+++ b/test/date_utils_test.js
@@ -18,10 +18,13 @@ import {
   yearDisabledAfter,
   getEffectiveMinDate,
   getEffectiveMaxDate,
+  getEffectiveMinDateTime,
+  getEffectiveMaxDateTime,
   addZero,
   isTimeDisabled,
   isTimeInDisabledRange,
   isDayInRange,
+  isDateTimeInRange,
   parseDate,
   isMonthinRange,
   isQuarterInRange,
@@ -537,6 +540,59 @@ describe("date_utils", function() {
     });
   });
 
+  describe("getEffectiveMinDateTime", () => {
+    it("should return null by default", () => {
+      expect(getEffectiveMinDateTime({})).to.not.exist;
+    });
+
+    it("should return the min date time", () => {
+      const minTime = newDate("2016-03-30 12:20:15");
+      const result = getEffectiveMinDateTime({ minTime });
+      assert(isEqual(minTime, result));
+    });
+
+    it("should return the minimum include date and time", () => {
+      const date1 = newDate("2016-03-30 12:20:15");
+      const date2 = newDate("2016-03-30 12:19:00");
+      const includeTimes = [date1, date2];
+      assert(isEqual(getEffectiveMinDateTime({ includeTimes }), date2));
+    });
+
+    it("should return the minimum include date satisfying the min date", () => {
+      const minTime = newDate("2016-03-31 15:00:00");
+      const date1 = newDate("2016-03-31 14:59:00");
+      const date2 = newDate("2016-03-31 15:01:00");
+      const includeTimes = [date1, date2];
+      assert(isEqual(getEffectiveMinDateTime({ minTime, includeTimes }), date2));
+    });
+  });
+
+  describe("getEffectiveMaxDateTime", () => {
+    it("should return null by default", () => {
+      expect(getEffectiveMaxDateTime({})).to.not.exist;
+    });
+
+    it("should return the max date", () => {
+      const maxTime = newDate("2016-03-30 12:20:15");
+      assert(isEqual(getEffectiveMaxDateTime({ maxTime }), maxTime));
+    });
+
+    it("should return the maximum include date and time", () => {
+      const date1 = newDate("2016-03-30 12:20:00");
+      const date2 = newDate("2016-03-30 12:20:10");
+      const includeTimes = [date1, date2];
+      assert(isEqual(getEffectiveMaxDateTime({ includeTimes }), date2));
+    });
+
+    it("should return the maximum include date satisfying the max date", () => {
+      const maxTime = newDate("2016-03-31 00:00:00");
+      const date1 = newDate("2016-03-31 00:01:00");
+      const date2 = newDate("2016-03-31 00:35:00");
+      const includeTimes = [date1, date2];
+      assert(isEqual(getEffectiveMaxDateTime({ maxTime, includeTimes }), date1));
+    });
+  });
+
   describe("addZero", () => {
     it("should return the same number if greater than 10", () => {
       const input = 11;
@@ -666,6 +722,36 @@ describe("date_utils", function() {
       const startDate = newDate("2016-02-15 09:40");
       const endDate = newDate("2016-01-15 08:40");
       expect(isDayInRange(day, startDate, endDate)).to.be.false;
+    });
+  });
+
+  describe("isDateTimeInRange", () => {
+    it("should tell if day and time is in range", () => {
+      const date = newDate("2016-02-14 10:25");
+      const startDate = newDate("2016-02-14 09:40");
+      const endDate = newDate("2016-02-14 10:27");
+      expect(isDateTimeInRange(date, startDate, endDate)).to.be.true;
+    });
+
+    it("should tell if day and time is in range of many days", () => {
+      const date = newDate("2016-02-15 10:25");
+      const startDate = newDate("2016-02-14 09:40");
+      const endDate = newDate("2016-02-17 10:27");
+      expect(isDateTimeInRange(date, startDate, endDate)).to.be.true;
+    });
+
+    it("should tell if day is not in range", () => {
+      const date = newDate("2016-02-14 10:28");
+      const startDate = newDate("2016-02-14 09:40");
+      const endDate = newDate("2016-02-14 10:27");
+      expect(isDateTimeInRange(date, startDate, endDate)).to.be.false;
+    });
+
+    it("should not throw exception if end date is before start date", () => {
+      const date = newDate("2016-02-14 10:28");
+      const startDate = newDate("2016-02-14 09:40");
+      const endDate = newDate("2016-02-14 08:00");
+      expect(isDateTimeInRange(date, startDate, endDate)).to.be.false;
     });
   });
 


### PR DESCRIPTION
specified

I'm trying to address #2720 (https://github.com/Hacker0x01/react-datepicker/issues/2720). The value of the input should be reverted to date AND time that is within allowed constraints. This already happens for `maxDate` and `minDate` properties so it should be consistent for times as well.

However I am not able to pinpoint in the code where this normalization
occurs. When user presses enter or blurs the input, the value should
revert. I've tried adding validation code to parts where I thought this
occured but I am having no such luck.