### PR TITLE
fix(Layout): Fix Input Time input width being cut off

### DIFF
--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -44,7 +44,7 @@
 
   &[data-placement^="bottom"] {
     margin-top: $datepicker__triangle-size + 2px;
-    
+
     .react-datepicker__triangle {
       @extend %triangle-arrow-up;
     }
@@ -60,7 +60,7 @@
 
   &[data-placement^="top"] {
     margin-bottom: $datepicker__triangle-size + 2px;
-    
+
     .react-datepicker__triangle {
       @extend %triangle-arrow-down;
     }
@@ -68,7 +68,7 @@
 
   &[data-placement^="right"] {
     margin-left: $datepicker__triangle-size;
-    
+
     .react-datepicker__triangle {
       left: auto;
       right: 42px;
@@ -77,7 +77,7 @@
 
   &[data-placement^="left"] {
     margin-right: $datepicker__triangle-size;
-    
+
     .react-datepicker__triangle {
       left: 42px;
       right: auto;
@@ -254,7 +254,7 @@
       display: inline-block;
       margin-left: 10px;
       input {
-        width: 85px;
+        width: auto;
       }
       input[type="time"]::-webkit-inner-spin-button,
       input[type="time"]::-webkit-outer-spin-button {


### PR DESCRIPTION
Gents, a quick fix with this one, a well-shot photo will speak more words than I ever could type in here, so here are the screenshots 

# The problem
<img width="457" alt="Screen Shot 2021-02-13 at 1 51 06 AM" src="https://user-images.githubusercontent.com/11737572/107844017-f30de800-6d9d-11eb-899c-ee6aa3f225ea.png">

# The solution
<img width="524" alt="Screen Shot 2021-02-13 at 1 51 26 AM" src="https://user-images.githubusercontent.com/11737572/107844022-fd2fe680-6d9d-11eb-889f-c54cd6af8cd6.png">


🙇🏼 