### PR TITLE
Support latest react version

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,8 +106,8 @@
     "webpack-hot-middleware": "^2.25.0"
   },
   "peerDependencies": {
-    "react": "^16.9.0",
-    "react-dom": "^16.9.0"
+    "react": "^16.9.0 || ^17.0.1",
+    "react-dom": "^16.9.0 || ^17.0.1"
   },
   "dependencies": {
     "classnames": "^2.2.6",


### PR DESCRIPTION
Support using the latest version of react and react-dom as peer dependencies. This solves peer dependecy conflicts when using react-datepicker as a third party in other npm packages, with the latest version of react/react-dom as peer dependcies