### PR TITLE
upgrade react-popper to v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,11 +110,12 @@
     "react-dom": "^16.9.0 || ^17"
   },
   "dependencies": {
+    "@popperjs/core": "^2.0.0",
     "classnames": "^2.2.6",
     "date-fns": "^2.0.1",
     "prop-types": "^15.7.2",
     "react-onclickoutside": "^6.10.0",
-    "react-popper": "^1.3.8"
+    "react-popper": "^2.0.0"
   },
   "scripts": {
     "eslint": "eslint --ext .js,.jsx src test",

--- a/src/popper_component.jsx
+++ b/src/popper_component.jsx
@@ -11,13 +11,12 @@ export default class PopperComponent extends React.Component {
   static get defaultProps() {
     return {
       hidePopper: true,
-      popperModifiers: {
-        preventOverflow: {
-          enabled: true,
-          escapeWithReference: true,
-          boundariesElement: "viewport"
-        }
-      },
+      popperModifiers: [
+        {
+          name: "preventOverflow",
+          options: {},
+        },
+      ],
       popperProps: {},
       popperPlacement: "bottom-start"
     };


### PR DESCRIPTION
react-popper v1 depends on popper.js while the newer versions (v2.*) use @popperjs/core. In our projects we rely on react-popper v2 and currently this version conflict causes double import of those libraries into our bundle.  This pr makes sure a current, non-deprecated version of packages are used and reduces the bundle bloat for people who use @popperjs/core in their projects