### PR TITLE
Upgrade react-popper to v2.x

### DIFF
--- a/docs-site/config-overrides.js
+++ b/docs-site/config-overrides.js
@@ -3,14 +3,15 @@ const ModuleScopePlugin = require("react-dev-utils/ModuleScopePlugin");
 
 module.exports = function override(config, env) {
   config.resolve.alias["react-datepicker"] = path.resolve(__dirname, "..");
+  config.resolve.alias["react"] = path.resolve(__dirname, "node_modules/react");
   //do stuff with the webpack config...
   config.module.rules.push({
     test: /\.js/,
     include: path.resolve(__dirname, "src/examples"),
-    use: "raw-loader"
+    use: "raw-loader",
   });
   config.resolve.plugins = config.resolve.plugins.filter(
-    plugin => !(plugin instanceof ModuleScopePlugin)
+    (plugin) => !(plugin instanceof ModuleScopePlugin)
   );
   // Enable it, so that our custom .eslintrc for the examples will work
   for (let i = 0; i < config.module.rules.length; i++) {

--- a/docs-site/src/examples/configurePopper.js
+++ b/docs-site/src/examples/configurePopper.js
@@ -3,20 +3,25 @@
   return (
     <DatePicker
       selected={startDate}
-      onChange={date => setStartDate(date)}
+      onChange={(date) => setStartDate(date)}
       popperClassName="some-custom-class"
       popperPlacement="top-end"
-      popperModifiers={{
-        offset: {
-          enabled: true,
-          offset: "5px, 10px"
+      popperModifiers={[
+        {
+          name: "offset",
+          options: {
+            offset: [5, 10],
+          },
         },
-        preventOverflow: {
-          enabled: true,
-          escapeWithReference: false,
-          boundariesElement: "viewport"
-        }
-      }}
+        {
+          name: "preventOverflow",
+          options: {
+            rootBoundary: "viewport",
+            tether: false,
+            altAxis: true,
+          },
+        },
+      ]}
     />
   );
 };

--- a/package.json
+++ b/package.json
@@ -110,11 +110,12 @@
     "react-dom": "^16.9.0 || ^17"
   },
   "dependencies": {
+    "@popperjs/core": "^2.9.2",
     "classnames": "^2.2.6",
     "date-fns": "^2.0.1",
     "prop-types": "^15.7.2",
     "react-onclickoutside": "^6.10.0",
-    "react-popper": "^1.3.8"
+    "react-popper": "^2.2.5"
   },
   "scripts": {
     "eslint": "eslint --ext .js,.jsx src test",

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -35,7 +35,7 @@ import {
   registerLocale,
   setDefaultLocale,
   getDefaultLocale,
-  DEFAULT_YEAR_ITEM_NUMBER
+  DEFAULT_YEAR_ITEM_NUMBER,
 } from "./date_utils";
 import onClickOutside from "react-onclickoutside";
 
@@ -114,7 +114,7 @@ export default class DatePicker extends React.Component {
       focusSelectedMonth: false,
       showPopperArrow: true,
       excludeScrollbar: true,
-      customTimeInput: null
+      customTimeInput: null,
     };
   }
 
@@ -161,7 +161,7 @@ export default class DatePicker extends React.Component {
     isClearable: PropTypes.bool,
     locale: PropTypes.oneOfType([
       PropTypes.string,
-      PropTypes.shape({ locale: PropTypes.object })
+      PropTypes.shape({ locale: PropTypes.object }),
     ]),
     maxDate: PropTypes.instanceOf(Date),
     minDate: PropTypes.instanceOf(Date),
@@ -187,7 +187,7 @@ export default class DatePicker extends React.Component {
     placeholderText: PropTypes.string,
     popperContainer: PropTypes.func,
     popperClassName: PropTypes.string, // <PopperComponent/> props
-    popperModifiers: PropTypes.object, // <PopperComponent/> props
+    popperModifiers: PropTypes.arrayOf(PropTypes.object), // <PopperComponent/> props
     popperPlacement: PropTypes.oneOf(popperPlacementPositions), // <PopperComponent/> props
     popperProps: PropTypes.object,
     preventOpenOnFocus: PropTypes.bool,
@@ -242,11 +242,11 @@ export default class DatePicker extends React.Component {
     clearButtonClassName: PropTypes.string,
     previousMonthButtonLabel: PropTypes.oneOfType([
       PropTypes.string,
-      PropTypes.node
+      PropTypes.node,
     ]),
     nextMonthButtonLabel: PropTypes.oneOfType([
       PropTypes.string,
-      PropTypes.node
+      PropTypes.node,
     ]),
     previousYearButtonLabel: PropTypes.string,
     nextYearButtonLabel: PropTypes.string,
@@ -261,7 +261,7 @@ export default class DatePicker extends React.Component {
     excludeScrollbar: PropTypes.bool,
     enableTabLoop: PropTypes.bool,
     customTimeInput: PropTypes.element,
-    weekAriaLabelPrefix: PropTypes.string
+    weekAriaLabelPrefix: PropTypes.string,
   };
 
   constructor(props) {
@@ -288,7 +288,7 @@ export default class DatePicker extends React.Component {
     }
     if (prevProps.highlightDates !== this.props.highlightDates) {
       this.setState({
-        highlightDates: getHightLightDaysMap(this.props.highlightDates)
+        highlightDates: getHightLightDaysMap(this.props.highlightDates),
       });
     }
     if (
@@ -345,7 +345,7 @@ export default class DatePicker extends React.Component {
       focused: false,
       // used to focus day in inline version after month has changed, but not on
       // initial render
-      shouldFocusDayInline: false
+      shouldFocusDayInline: false,
     };
   };
 
@@ -377,13 +377,13 @@ export default class DatePicker extends React.Component {
           open && this.state.open
             ? this.state.preSelection
             : this.calcInitialState().preSelection,
-        lastPreSelectChange: PRESELECT_CHANGE_VIA_NAVIGATE
+        lastPreSelectChange: PRESELECT_CHANGE_VIA_NAVIGATE,
       },
       () => {
         if (!open) {
           this.setState(
-            prev => ({
-              focused: skipSetBlur ? prev.focused : false
+            (prev) => ({
+              focused: skipSetBlur ? prev.focused : false,
             }),
             () => {
               !skipSetBlur && this.setBlur();
@@ -402,7 +402,7 @@ export default class DatePicker extends React.Component {
       ? this.state.open && !this.props.disabled && !this.props.readOnly
       : this.props.open;
 
-  handleFocus = event => {
+  handleFocus = (event) => {
     if (!this.state.preventFocus) {
       this.props.onFocus(event);
       if (!this.props.preventOpenOnFocus && !this.props.readOnly) {
@@ -426,7 +426,7 @@ export default class DatePicker extends React.Component {
     this.cancelFocusInput();
   };
 
-  handleBlur = event => {
+  handleBlur = (event) => {
     if (!this.state.open || this.props.withPortal || this.props.showTimeInput) {
       this.props.onBlur(event);
     }
@@ -434,7 +434,7 @@ export default class DatePicker extends React.Component {
     this.setState({ focused: false });
   };
 
-  handleCalendarClickOutside = event => {
+  handleCalendarClickOutside = (event) => {
     if (!this.props.inline) {
       this.setOpen(false);
     }
@@ -457,7 +457,7 @@ export default class DatePicker extends React.Component {
     }
     this.setState({
       inputValue: event.target.value,
-      lastPreSelectChange: PRESELECT_CHANGE_VIA_INPUT
+      lastPreSelectChange: PRESELECT_CHANGE_VIA_INPUT,
     });
     const date = parseDate(
       event.target.value,
@@ -515,12 +515,12 @@ export default class DatePicker extends React.Component {
           changedDate = setTime(changedDate, {
             hour: getHours(this.props.selected),
             minute: getMinutes(this.props.selected),
-            second: getSeconds(this.props.selected)
+            second: getSeconds(this.props.selected),
           });
         }
         if (!this.props.inline) {
           this.setState({
-            preSelection: changedDate
+            preSelection: changedDate,
           });
         }
         if (!this.props.focusSelectedMonth) {
@@ -555,7 +555,7 @@ export default class DatePicker extends React.Component {
   };
 
   // When checking preSelection via min/maxDate, times need to be manipulated via startOfDay/endOfDay
-  setPreSelection = date => {
+  setPreSelection = (date) => {
     const hasMinDate = typeof this.props.minDate !== "undefined";
     const hasMaxDate = typeof this.props.maxDate !== "undefined";
     let isValidDateSelection = true;
@@ -570,30 +570,34 @@ export default class DatePicker extends React.Component {
         );
       } else if (hasMinDate) {
         const minDateStartOfDay = startOfDay(this.props.minDate);
-        isValidDateSelection = isAfter(date, minDateStartOfDay) || isEqual(dateStartOfDay, minDateStartOfDay);
+        isValidDateSelection =
+          isAfter(date, minDateStartOfDay) ||
+          isEqual(dateStartOfDay, minDateStartOfDay);
       } else if (hasMaxDate) {
         const maxDateEndOfDay = endOfDay(this.props.maxDate);
-        isValidDateSelection = isBefore(date, maxDateEndOfDay) || isEqual(dateStartOfDay, maxDateEndOfDay);
+        isValidDateSelection =
+          isBefore(date, maxDateEndOfDay) ||
+          isEqual(dateStartOfDay, maxDateEndOfDay);
       }
     }
     if (isValidDateSelection) {
       this.setState({
-        preSelection: date
+        preSelection: date,
       });
     }
   };
 
-  handleTimeChange = time => {
+  handleTimeChange = (time) => {
     const selected = this.props.selected
       ? this.props.selected
       : this.getPreSelection();
     let changedDate = setTime(selected, {
       hour: getHours(time),
-      minute: getMinutes(time)
+      minute: getMinutes(time),
     });
 
     this.setState({
-      preSelection: changedDate
+      preSelection: changedDate,
     });
 
     this.props.onChange(changedDate);
@@ -614,7 +618,7 @@ export default class DatePicker extends React.Component {
     this.props.onInputClick();
   };
 
-  onInputKeyDown = event => {
+  onInputKeyDown = (event) => {
     this.props.onKeyDown(event);
     const eventKey = event.key;
 
@@ -672,7 +676,7 @@ export default class DatePicker extends React.Component {
   };
 
   // keyDown events passed down to day.jsx
-  onDayKeyDown = event => {
+  onDayKeyDown = (event) => {
     this.props.onKeyDown(event);
     const eventKey = event.key;
 
@@ -737,11 +741,10 @@ export default class DatePicker extends React.Component {
 
         if (prevMonth !== newMonth || prevYear !== newYear) {
           // month has changed
-          this.setState({ shouldFocusDayInline: true })
-        }
-        else {
+          this.setState({ shouldFocusDayInline: true });
+        } else {
           // month hasn't changed
-          this.setState({ shouldFocusDayInline: false })
+          this.setState({ shouldFocusDayInline: false });
         }
       }
     }
@@ -749,7 +752,7 @@ export default class DatePicker extends React.Component {
 
   // handle generic key down events in the popper that do not adjust or select dates
   // ex: while focusing prev and next month buttons
-  onPopperKeyDown = event => {
+  onPopperKeyDown = (event) => {
     const eventKey = event.key;
     if (eventKey === "Escape") {
       // close the popper and refocus the input
@@ -760,7 +763,7 @@ export default class DatePicker extends React.Component {
       event.preventDefault();
       this.setState(
         {
-          preventFocus: true
+          preventFocus: true,
         },
         () => {
           this.setOpen(false);
@@ -773,7 +776,7 @@ export default class DatePicker extends React.Component {
     }
   };
 
-  onClearClick = event => {
+  onClearClick = (event) => {
     if (event) {
       if (event.preventDefault) {
         event.preventDefault();
@@ -787,7 +790,7 @@ export default class DatePicker extends React.Component {
     this.onClearClick();
   };
 
-  onScroll = event => {
+  onScroll = (event) => {
     if (
       typeof this.props.closeOnScroll === "boolean" &&
       this.props.closeOnScroll
@@ -812,7 +815,7 @@ export default class DatePicker extends React.Component {
     }
     return (
       <WrappedCalendar
-        ref={elem => {
+        ref={(elem) => {
           this.calendar = elem;
         }}
         locale={this.props.locale}
@@ -919,7 +922,7 @@ export default class DatePicker extends React.Component {
 
   renderDateInput = () => {
     const className = classnames(this.props.className, {
-      [outsideClickIgnoreClass]: this.state.open
+      [outsideClickIgnoreClass]: this.state.open,
     });
 
     const customInput = this.props.customInput || <input type="text" />;
@@ -932,7 +935,7 @@ export default class DatePicker extends React.Component {
         : safeDateFormat(this.props.selected, this.props);
 
     return React.cloneElement(customInput, {
-      [customInputRef]: input => {
+      [customInputRef]: (input) => {
         this.input = input;
       },
       value: inputValue,
@@ -965,7 +968,7 @@ export default class DatePicker extends React.Component {
       selected,
       clearButtonTitle,
       clearButtonClassName,
-      ariaLabelClose = "Close"
+      ariaLabelClose = "Close",
     } = this.props;
     if (isClearable && selected != null) {
       return (

--- a/src/popper_component.jsx
+++ b/src/popper_component.jsx
@@ -1,7 +1,8 @@
 import classnames from "classnames";
 import React from "react";
 import PropTypes from "prop-types";
-import { Manager, Reference, Popper, placements } from "react-popper";
+import { Manager, Reference, Popper } from "react-popper";
+import { placements } from "@popperjs/core/lib";
 import TabLoop from "./tab_loop";
 import Portal from "./portal";
 
@@ -11,15 +12,9 @@ export default class PopperComponent extends React.Component {
   static get defaultProps() {
     return {
       hidePopper: true,
-      popperModifiers: {
-        preventOverflow: {
-          enabled: true,
-          escapeWithReference: true,
-          boundariesElement: "viewport"
-        }
-      },
+      popperModifiers: [],
       popperProps: {},
-      popperPlacement: "bottom-start"
+      popperPlacement: "bottom-start",
     };
   }
 
@@ -28,14 +23,14 @@ export default class PopperComponent extends React.Component {
     wrapperClassName: PropTypes.string,
     hidePopper: PropTypes.bool,
     popperComponent: PropTypes.element,
-    popperModifiers: PropTypes.object, // <datepicker/> props
+    popperModifiers: PropTypes.arrayOf(PropTypes.object), // <datepicker/> props
     popperPlacement: PropTypes.oneOf(popperPlacementPositions), // <datepicker/> props
     popperContainer: PropTypes.func,
     popperProps: PropTypes.object,
     targetComponent: PropTypes.element,
     enableTabLoop: PropTypes.bool,
     popperOnKeyDown: PropTypes.func,
-    portalId: PropTypes.string
+    portalId: PropTypes.string,
   };
 
   render() {
@@ -50,7 +45,7 @@ export default class PopperComponent extends React.Component {
       targetComponent,
       enableTabLoop,
       popperOnKeyDown,
-      portalId
+      portalId,
     } = this.props;
 
     let popper;

--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -506,12 +506,15 @@
 
   &--down-arrow {
     @extend %triangle-arrow-down;
-    border-top-color: $datepicker__muted-color;
     float: right;
     margin-left: 20px;
     top: 8px;
     position: relative;
     border-width: $datepicker__navigation-size;
+
+    &::after {
+      border-top-color: $datepicker__muted-color;
+    }
   }
 }
 

--- a/src/stylesheets/mixins.scss
+++ b/src/stylesheets/mixins.scss
@@ -1,9 +1,10 @@
 %triangle-arrow {
-  margin-left: -$datepicker__triangle-size;
+  margin-left: -$datepicker__triangle-size / 2;
   position: absolute;
+  width: 0;
 
-  &,
-  &::before {
+  &::before,
+  &::after {
     box-sizing: content-box;
     position: absolute;
     border: $datepicker__triangle-size solid transparent;
@@ -12,12 +13,16 @@
     width: 1px;
   }
 
-  &::before {
+  &::before,
+  &::after {
     content: "";
     z-index: -1;
     border-width: $datepicker__triangle-size;
 
     left: -$datepicker__triangle-size;
+  }
+
+  &::before {
     border-bottom-color: $datepicker__border-color;
   }
 }
@@ -28,10 +33,14 @@
   top: 0;
   margin-top: -$datepicker__triangle-size;
 
-  &,
-  &::before {
+  &::before,
+  &::after {
     border-top: none;
     border-bottom-color: $datepicker__background-color;
+  }
+
+  &::after {
+    top: 0;
   }
 
   &::before {
@@ -46,10 +55,14 @@
   bottom: 0;
   margin-bottom: -$datepicker__triangle-size;
 
-  &,
-  &::before {
+  &::before,
+  &::after {
     border-bottom: none;
     border-top-color: #fff;
+  }
+
+  &::after {
+    bottom: 0;
   }
 
   &::before {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1040,7 +1040,7 @@
     "@babel/plugin-transform-react-jsx-development" "^7.12.17"
     "@babel/plugin-transform-react-pure-annotations" "^7.12.1"
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.13.8", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.13.8", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4":
   version "7.13.9"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.9.tgz#97dbe2116e2630c489f22e0656decd60aaa1fcee"
   integrity sha512-aY2kU+xgJ3dJ1eU6FMB9EH8dIe8dmusF1xEku52joLvw6eAFN0AI+WxCLDnpev2LEejWBAy2sBvBOBAjI3zmvA==
@@ -1092,14 +1092,6 @@
     js-yaml "^3.13.1"
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
-
-"@hypnosphi/create-react-context@^0.3.1":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@hypnosphi/create-react-context/-/create-react-context-0.3.1.tgz#f8bfebdc7665f5d426cba3753e0e9c7d3154d7c6"
-  integrity sha512-V1klUed202XahrWJLLOT3EXNeCpFHCcJntdFGI15ntCwau+jfT386w7OFTMaCqOgXUH1fa0w/I1oZs+i/Rfr0A==
-  dependencies:
-    gud "^1.0.0"
-    warning "^4.0.3"
 
 "@istanbuljs/schema@^0.1.2":
   version "0.1.2"
@@ -1171,6 +1163,11 @@
     node-gyp "^7.1.0"
     puka "^1.0.1"
     read-package-json-fast "^2.0.1"
+
+"@popperjs/core@^2.9.2":
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.2.tgz#adea7b6953cbb34651766b0548468e743c6a2353"
+  integrity sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==
 
 "@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.8.1":
   version "1.8.1"
@@ -3160,7 +3157,7 @@ deep-eql@^3.0.1:
   dependencies:
     type-detect "^4.0.0"
 
-deep-equal@^1.0.1, deep-equal@^1.1.1:
+deep-equal@^1.0.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.1.1.tgz#b5c98c942ceffaf7cb051e24e1434a25a2e6076a"
   integrity sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==
@@ -4843,11 +4840,6 @@ growl@1.10.5:
   version "1.10.5"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
   integrity sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
-
-gud@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
-  integrity sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==
 
 gzip-size@^6.0.0:
   version "6.0.0"
@@ -7722,11 +7714,6 @@ pluralize@^1.2.1:
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-1.2.1.tgz#d1a21483fd22bb41e58a12fa3421823140897c45"
   integrity sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=
 
-popper.js@^1.14.4:
-  version "1.16.1"
-  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1.tgz#2a223cb3dc7b6213d740e40372be40de43e65b1b"
-  integrity sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==
-
 portfinder@^1.0.26:
   version "1.0.26"
   resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.26.tgz#475658d56ca30bed72ac7f1378ed350bd1b64e70"
@@ -7872,7 +7859,7 @@ prop-types-exact@^1.2.0:
     object.assign "^4.1.0"
     reflect.ownkeys "^0.2.0"
 
-prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -8055,15 +8042,20 @@ react-docgen@^5.3.0:
     node-dir "^0.1.10"
     strip-indent "^3.0.0"
 
-react-dom@^16.9.0:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.14.0.tgz#7ad838ec29a777fb3c75c3a190f661cf92ab8b89"
-  integrity sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==
+react-dom@16.9.0:
+  version "16.9.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.9.0.tgz#5e65527a5e26f22ae3701131bcccaee9fb0d3962"
+  integrity sha512-YFT2rxO9hM70ewk9jq0y6sQk8cL02xm4+IzYBz75CQGlClQQ1Bxq0nhHF6OtSbit+AIahujJgb/CPRibFkMNJQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.19.1"
+    scheduler "^0.15.0"
+
+react-fast-compare@^3.0.1:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
+  integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
 react-is@^16.13.1, react-is@^16.8.1, react-is@^16.8.6:
   version "16.13.1"
@@ -8075,17 +8067,12 @@ react-onclickoutside@^6.10.0:
   resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.10.0.tgz#05abb592575b08b4d129003494056b9dff46eeeb"
   integrity sha512-7i2L3ef+0ILXpL6P+Hg304eCQswh4jl3ynwR71BSlMU49PE2uk31k8B2GkP6yE9s2D4jTGKnzuSpzWxu4YxfQQ==
 
-react-popper@^1.3.8:
-  version "1.3.11"
-  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-1.3.11.tgz#a2cc3f0a67b75b66cfa62d2c409f9dd1fcc71ffd"
-  integrity sha512-VSA/bS+pSndSF2fiasHK/PTEEAyOpX60+H5EPAjoArr8JGm+oihu4UbrqcEBpQibJxBVCpYyjAX7abJ+7DoYVg==
+react-popper@^2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.2.5.tgz#1214ef3cec86330a171671a4fbcbeeb65ee58e96"
+  integrity sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==
   dependencies:
-    "@babel/runtime" "^7.1.2"
-    "@hypnosphi/create-react-context" "^0.3.1"
-    deep-equal "^1.1.1"
-    popper.js "^1.14.4"
-    prop-types "^15.6.1"
-    typed-styles "^0.0.7"
+    react-fast-compare "^3.0.1"
     warning "^4.0.2"
 
 react-proxy@^1.1.7:
@@ -8701,6 +8688,14 @@ sass-loader@^10.0.3:
     neo-async "^2.6.2"
     schema-utils "^3.0.0"
     semver "^7.3.2"
+
+scheduler@^0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.15.0.tgz#6bfcf80ff850b280fed4aeecc6513bc0b4f17f8e"
+  integrity sha512-xAefmSfN6jqAa7Kuq7LIJY0bwAPG3xlCj0HMEBQk1lxYiDKZscY2xJ5U/61ZTrYbmNQbXa+gc7czPkVo11tnCg==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
 
 scheduler@^0.19.1:
   version "0.19.1"
@@ -9883,11 +9878,6 @@ type@^2.0.0:
   resolved "https://registry.yarnpkg.com/type/-/type-2.0.0.tgz#5f16ff6ef2eb44f260494dae271033b29c09a9c3"
   integrity sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==
 
-typed-styles@^0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/typed-styles/-/typed-styles-0.0.7.tgz#93392a008794c4595119ff62dde6809dbc40a3d9"
-  integrity sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q==
-
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
@@ -10118,7 +10108,7 @@ void-elements@^2.0.0:
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"
   integrity sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=
 
-warning@^4.0.2, warning@^4.0.3:
+warning@^4.0.2:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
   integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==


### PR DESCRIPTION
This PR updates `react-popper` to its latest version while addressing the visual regressions the update caused. This required special care to the display of the arrow.

There's a lot of noise coming from the linting defined as a precommit hook, sorry about that.

This PR should also fix #2653 by setting an alias for react in the docs, see `docs-site/config-overrides.js`.

Thanks to @czabaj  and his PR #2686 that was the starting point of this PR.

