### PR TITLE
Prevent class name 'undefined' when clearButtonClassName is not provided

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -967,14 +967,14 @@ export default class DatePicker extends React.Component {
       isClearable,
       selected,
       clearButtonTitle,
-      clearButtonClassName,
+      clearButtonClassName = "",
       ariaLabelClose = "Close",
     } = this.props;
     if (isClearable && selected != null) {
       return (
         <button
           type="button"
-          className={`react-datepicker__close-icon ${clearButtonClassName}`}
+          className={`react-datepicker__close-icon ${clearButtonClassName}`.trim()}
           aria-label={ariaLabelClose}
           onClick={this.onClearClick}
           title={clearButtonTitle}

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -403,14 +403,26 @@ describe("DatePicker", () => {
   });
 
   it("should customize the className attribute on the clear button if clearButtonClassName is supplied", () => {
-    const datePicker = TestUtils.renderIntoDocument(
-        <DatePicker
-            selected={utils.newDate("2021-04-15")}
-            isClearable
-            clearButtonClassName="customized-close-icon"
-        />
+    let datePicker = TestUtils.renderIntoDocument(
+      <DatePicker
+          selected={utils.newDate("2021-04-15")}
+          isClearable
+      />
     );
-    const clearButtonClass = TestUtils.findRenderedDOMComponentWithClass(
+    let clearButtonClass = TestUtils.findRenderedDOMComponentWithClass(
+        datePicker,
+        "react-datepicker__close-icon"
+    ).getAttribute("class");
+    expect(clearButtonClass).to.equal("react-datepicker__close-icon");
+
+    datePicker = TestUtils.renderIntoDocument(
+      <DatePicker
+          selected={utils.newDate("2021-04-15")}
+          isClearable
+          clearButtonClassName="customized-close-icon"
+      />
+    );
+    clearButtonClass = TestUtils.findRenderedDOMComponentWithClass(
         datePicker,
         "react-datepicker__close-icon"
     ).getAttribute("class");


### PR DESCRIPTION
This fixes a most likely unwanted side effect that was introduced in https://github.com/Hacker0x01/react-datepicker/commit/f5402da72c25d2c40c9bd576f136a8ca19a36ffa.

When `clearButtonClassName` is not provided, the current code renders "undefined" as a class name of the clear button. This fix makes sure that the extra class name is only added if it was provided.