### PR TITLE
Add monthDate to renderCustomHeader render props function

### DIFF
--- a/docs-site/src/components/Examples/index.js
+++ b/docs-site/src/components/Examples/index.js
@@ -64,6 +64,7 @@ import CalendarContainer from "../../examples/calendarContainer";
 import RawChange from "../../examples/rawChange";
 import DontCloseOnSelect from "../../examples/dontCloseOnSelect";
 import RenderCustomHeader from "../../examples/renderCustomHeader";
+import RenderCustomHeaderTwoMonths from "../../examples/renderCustomHeaderTwoMonths";
 import RenderCustomDay from "../../examples/renderCustomDay";
 import TimeInput from "../../examples/timeInput";
 import StrictParsing from "../../examples/strictParsing";
@@ -143,6 +144,10 @@ export default class exampleComponents extends React.Component {
     {
       title: "Custom header",
       component: RenderCustomHeader,
+    },
+    {
+      title: "Custom header with two months displayed",
+      component: RenderCustomHeaderTwoMonths,
     },
     {
       title: "Custom Day",

--- a/docs-site/src/examples/renderCustomHeaderTwoMonths.js
+++ b/docs-site/src/examples/renderCustomHeaderTwoMonths.js
@@ -1,0 +1,57 @@
+() => {
+  const [startDate, setStartDate] = useState(new Date());
+  return (
+    <DatePicker
+      renderCustomHeader={({
+        monthDate,
+        customHeaderCount,
+        decreaseMonth,
+        increaseMonth,
+      }) => (
+        <div>
+          <button
+            aria-label="Previous Month"
+            className={
+              "react-datepicker__navigation react-datepicker__navigation--previous"
+            }
+            style={customHeaderCount === 1 ? { visibility: "hidden" } : null}
+            onClick={decreaseMonth}
+          >
+            <span
+              className={
+                "react-datepicker__navigation-icon react-datepicker__navigation-icon--previous"
+              }
+            >
+              {"<"}
+            </span>
+          </button>
+          <span className="react-datepicker__current-month">
+            {monthDate.toLocaleString("en-US", {
+              month: "long",
+              year: "numeric",
+            })}
+          </span>
+          <button
+            aria-label="Next Month"
+            className={
+              "react-datepicker__navigation react-datepicker__navigation--next"
+            }
+            style={customHeaderCount === 0 ? { visibility: "hidden" } : null}
+            onClick={increaseMonth}
+          >
+            <span
+              className={
+                "react-datepicker__navigation-icon react-datepicker__navigation-icon--next"
+              }
+            >
+              {">"}
+            </span>
+          </button>
+        </div>
+      )}
+      selected={startDate}
+      onChange={(date) => setStartDate(date)}
+      monthsShown={2}
+    />
+  );
+};

--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -358,8 +358,12 @@ export default class Calendar extends React.Component {
   };
 
   header = (date = this.state.date) => {
-    const startOfWeek = getStartOfWeek(date, this.props.locale, this.props.calendarStartDay);
-    
+    const startOfWeek = getStartOfWeek(
+      date,
+      this.props.locale,
+      this.props.calendarStartDay
+    );
+
     const dayNames = [];
     if (this.props.showWeekNumbers) {
       dayNames.push(
@@ -739,6 +743,7 @@ export default class Calendar extends React.Component {
         {this.props.renderCustomHeader({
           ...this.state,
           customHeaderCount: i,
+          monthDate,
           changeMonth: this.changeMonth,
           changeYear: this.changeYear,
           decreaseMonth: this.decreaseMonth,

--- a/test/calendar_test.js
+++ b/test/calendar_test.js
@@ -507,6 +507,34 @@ describe("Calendar", function () {
       ).to.have.length(4);
     });
 
+    it("should set monthDate prop correctly when rendering custom headers", () => {
+      const renderMonthDateInCustomHeader = ({ monthDate }) => (
+        <div className="customheader-monthdate">{`${monthDate.getFullYear()}-${monthDate.getMonth()}-${monthDate.getDate()}`}</div>
+      );
+      const twoMonthsCalendar = getCalendar({
+        renderCustomHeader: renderMonthDateInCustomHeader,
+        monthsShown: 2,
+      });
+
+      const firstDate = new Date();
+      const secondDate = utils.addMonths(new Date(), 1);
+      const firstDateInCustomHeader = twoMonthsCalendar
+        .find(".customheader-monthdate")
+        .at(0)
+        .text();
+      const secondDateInCustomHeader = twoMonthsCalendar
+        .find(".customheader-monthdate")
+        .at(1)
+        .text();
+
+      expect(firstDateInCustomHeader).to.equal(
+        `${firstDate.getFullYear()}-${firstDate.getMonth()}-${firstDate.getDate()}`
+      );
+      expect(secondDateInCustomHeader).to.equal(
+        `${secondDate.getFullYear()}-${secondDate.getMonth()}-${secondDate.getDate()}`
+      );
+    });
+
     it("should render custom header with show time select", function () {
       const calendar = mount(
         <Calendar


### PR DESCRIPTION
When rendering a custom header and displaying more than one month, like this, it becomes possible to sync the month displayed in header and in calendar

fixes #2981