### PR TITLE
Fix Popper CSS warnings

### DIFF
--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -43,7 +43,7 @@
   z-index: 1;
 
   &[data-placement^="bottom"] {
-    margin-top: $datepicker__triangle-size + 2px;
+    padding-top: $datepicker__triangle-size + 2px;
 
     .react-datepicker__triangle {
       @extend %triangle-arrow-up;
@@ -59,7 +59,7 @@
   }
 
   &[data-placement^="top"] {
-    margin-bottom: $datepicker__triangle-size + 2px;
+    padding-bottom: $datepicker__triangle-size + 2px;
 
     .react-datepicker__triangle {
       @extend %triangle-arrow-down;
@@ -67,7 +67,7 @@
   }
 
   &[data-placement^="right"] {
-    margin-left: $datepicker__triangle-size;
+    padding-left: $datepicker__triangle-size;
 
     .react-datepicker__triangle {
       left: auto;
@@ -76,7 +76,7 @@
   }
 
   &[data-placement^="left"] {
-    margin-right: $datepicker__triangle-size;
+    padding-right: $datepicker__triangle-size;
 
     .react-datepicker__triangle {
       left: 42px;


### PR DESCRIPTION
As detailed in #3009, `Popper` complains about `margin-*` statements in the CSS for the pop-up date selector. Changing these to `padding-*` calls silenced the error and gave the same visual effect in my testing.

I'm not sure how to write a test for this, but I'm happy to do so if anyone can point me in the right direction.

Closes #3009