### PR TITLE
Fix start of week not using the registered locale

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -116,7 +116,7 @@ export default class DatePicker extends React.Component {
       showPopperArrow: true,
       excludeScrollbar: true,
       customTimeInput: null,
-      calendarStartDay: 0,
+      calendarStartDay: undefined,
     };
   }
 

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -1,9 +1,10 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import TestUtils from "react-dom/test-utils";
+import { enUS, enGB } from "date-fns/locale";
 import { mount } from "enzyme";
 import defer from "lodash/defer";
-import DatePicker from "../src/index.jsx";
+import DatePicker, { registerLocale } from "../src/index.jsx";
 import Day from "../src/day";
 import WeekNumber from "../src/week_number";
 import TestWrapper from "./test_wrapper.jsx";
@@ -1772,5 +1773,39 @@ describe("DatePicker", () => {
       );
       expect(datePickerInline.state.shouldFocusDayInline).to.be.true;
     });
+  });
+
+  it("should show the correct start of week for GB locale", () => {
+    registerLocale("gb", enGB);
+
+    var datePicker = mount(<DatePicker locale="gb" />);
+    const dateInput = datePicker.instance().input;
+    const dateInputWrapper = datePicker.find("input");
+    const focusSpy = sandbox.spy(dateInput, "focus");
+
+    dateInputWrapper.simulate("focus");
+
+    const firstDay = datePicker
+      .find(".react-datepicker__day-names")
+      .childAt(0)
+      .text();
+    expect(firstDay).to.equal("Mo");
+  });
+
+  it("should show the correct start of week for US locale", () => {
+    registerLocale("us", enUS);
+
+    var datePicker = mount(<DatePicker locale="us" />);
+    const dateInput = datePicker.instance().input;
+    const dateInputWrapper = datePicker.find("input");
+    const focusSpy = sandbox.spy(dateInput, "focus");
+
+    dateInputWrapper.simulate("focus");
+
+    const firstDay = datePicker
+      .find(".react-datepicker__day-names")
+      .childAt(0)
+      .text();
+    expect(firstDay).to.equal("Su");
   });
 });

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -1776,9 +1776,9 @@ describe("DatePicker", () => {
   });
 
   it("should show the correct start of week for GB locale", () => {
-    registerLocale("gb", enGB);
+    registerLocale("en-GB", enGB);
 
-    var datePicker = mount(<DatePicker locale="gb" />);
+    const datePicker = mount(<DatePicker locale="en-GB" />);
     const dateInput = datePicker.instance().input;
     const dateInputWrapper = datePicker.find("input");
     const focusSpy = sandbox.spy(dateInput, "focus");
@@ -1793,9 +1793,9 @@ describe("DatePicker", () => {
   });
 
   it("should show the correct start of week for US locale", () => {
-    registerLocale("us", enUS);
+    registerLocale("en-US", enUS);
 
-    var datePicker = mount(<DatePicker locale="us" />);
+    const datePicker = mount(<DatePicker locale="en-US" />);
     const dateInput = datePicker.instance().input;
     const dateInputWrapper = datePicker.find("input");
     const focusSpy = sandbox.spy(dateInput, "focus");


### PR DESCRIPTION
Fixes #3015

The locale we defaulting to 0, via the default props. This meant that 0 was passed all the way down to the function `getStartOfWeek`. The result of this is that the week will always start on a Sunday, ignoring the locale that is set.

The solution is just to make this undefined, which will then use the correct locale version if its set.
This should be fine as any uses where the number is overridden is still passed down, and those without a locale set will be defaulting to the US, which is 0 (sunday)