### PR TITLE
Fix invalid syntax

### DIFF
--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -166,7 +166,7 @@ export function safeDateFormat(date, { dateFormat, locale }) {
       formatDate(
         date,
         Array.isArray(dateFormat) ? dateFormat[0] : dateFormat,
-        (locale: locale)
+        locale
       )) ||
     ""
   );
@@ -214,7 +214,7 @@ export function getWeek(date, locale) {
 }
 
 export function getDayOfWeekCode(day, locale) {
-  return formatDate(day, "ddd", (locale: locale));
+  return formatDate(day, "ddd", locale);
 }
 
 // *** Start of ***


### PR DESCRIPTION
Without this change, VS Code complains:

"Type annotations can only be used in TypeScript files."

This invalid syntax worked because it was considered to be Flow syntax by Babel. Flow type-checking is not enabled for date_utils.js, so it also passed type-checking (`yarn flow`).