### PR TITLE
Uses react dom portals for portal version when portalId is provided

### DIFF
--- a/docs-site/src/components/Examples/index.js
+++ b/docs-site/src/components/Examples/index.js
@@ -43,6 +43,7 @@ import OnBlurCallbacks from "../../examples/onBlurCallbacks";
 import ConfigurePopper from "../../examples/configurePopper";
 import Portal from "../../examples/portal";
 import PortalById from "../../examples/portalById";
+import WithPortalById from "../../examples/withPortalById";
 import TabIndex from "../../examples/tabIndex";
 import YearDropdown from "../../examples/yearDropdown";
 import YearItemNumber from "../../examples/yearItemNumber";
@@ -51,6 +52,7 @@ import MonthDropdownShort from "../../examples/monthDropdownShort";
 import MonthYearDropdown from "../../examples/monthYearDropdown";
 import YearSelectDropdown from "../../examples/yearSelectDropdown";
 import Inline from "../../examples/inline";
+import InlineVisible from "../../examples/inlineVisible";
 import OpenToDate from "../../examples/openToDate";
 import FixedCalendar from "../../examples/fixedCalendar";
 import WeekNumbers from "../../examples/weekNumbers";
@@ -262,8 +264,8 @@ export default class exampleComponents extends React.Component {
       component: Inline,
     },
     {
-      title: "Inline portal version",
-      component: Inline,
+      title: "Button to show Inline version",
+      component: InlineVisible,
     },
     {
       title: "Input time",
@@ -354,6 +356,12 @@ export default class exampleComponents extends React.Component {
       description:
         "If the provided portalId cannot be found in the dom, one will be created by default with that id.",
       component: PortalById,
+    },
+    {
+      title: "Portal version with portal by id",
+      description:
+        "If the provided portalId cannot be found in the dom, one will be created by default with that id.",
+      component: WithPortalById,
     },
     {
       title: "Quarter Picker",

--- a/docs-site/src/examples/inlineVisible.js
+++ b/docs-site/src/examples/inlineVisible.js
@@ -3,6 +3,7 @@
   const [isOpen, setIsOpen] = useState(false);
   const handleChange = (e) => {
     setIsOpen(!isOpen);
+    setStartDate(e);
   };
   const handleClick = (e) => {
     e.preventDefault();
@@ -14,12 +15,7 @@
         {format(startDate, "dd-MM-yyyy")}
       </button>
       {isOpen && (
-        <DatePicker
-          selected={startDate}
-          onChange={handleChange}
-          withPortal
-          inline
-        />
+        <DatePicker selected={startDate} onChange={handleChange} inline />
       )}
     </>
   );

--- a/docs-site/src/examples/withPortalById.js
+++ b/docs-site/src/examples/withPortalById.js
@@ -1,0 +1,11 @@
+() => {
+  const [startDate, setStartDate] = useState(new Date());
+  return (
+    <DatePicker
+      selected={startDate}
+      onChange={(date) => setStartDate(date)}
+      withPortal
+      portalId="root-portal"
+    />
+  );
+};

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import Calendar from "./calendar";
+import Portal from "./portal";
 import PopperComponent, { popperPlacementPositions } from "./popper_component";
 import classnames from "classnames";
 import startOfDay from "date-fns/startOfDay";
@@ -1014,25 +1015,35 @@ export default class DatePicker extends React.Component {
     }
   };
 
+  renderInputContainer() {
+    return (
+      <div className="react-datepicker__input-container">
+        {this.renderDateInput()}
+        {this.renderClearButton()}
+      </div>
+    );
+  }
+
   render() {
     const calendar = this.renderCalendar();
 
-    if (this.props.inline && !this.props.withPortal) {
-      return calendar;
-    }
+    if (this.props.inline) return calendar;
 
     if (this.props.withPortal) {
+      let portalContainer = this.state.open ? (
+        <div className="react-datepicker__portal">{calendar}</div>
+      ) : null;
+
+      if (this.state.open && this.props.portalId) {
+        portalContainer = (
+          <Portal portalId={this.props.portalId}>{portalContainer}</Portal>
+        );
+      }
+
       return (
         <div>
-          {!this.props.inline ? (
-            <div className="react-datepicker__input-container">
-              {this.renderDateInput()}
-              {this.renderClearButton()}
-            </div>
-          ) : null}
-          {this.state.open || this.props.inline ? (
-            <div className="react-datepicker__portal">{calendar}</div>
-          ) : null}
+          {this.renderInputContainer()}
+          {portalContainer}
         </div>
       );
     }
@@ -1044,12 +1055,7 @@ export default class DatePicker extends React.Component {
         hidePopper={!this.isCalendarOpen()}
         portalId={this.props.portalId}
         popperModifiers={this.props.popperModifiers}
-        targetComponent={
-          <div className="react-datepicker__input-container">
-            {this.renderDateInput()}
-            {this.renderClearButton()}
-          </div>
-        }
+        targetComponent={this.renderInputContainer()}
         popperContainer={this.props.popperContainer}
         popperComponent={calendar}
         popperPlacement={this.props.popperPlacement}

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -514,6 +514,19 @@ describe("DatePicker", () => {
     expect(datePicker.calendar).to.exist;
   });
 
+  it("should ignore withPortal prop when inline prop is set", () => {
+    var datePicker = TestUtils.renderIntoDocument(
+      <DatePicker inline withPortal />
+    );
+
+    expect(function () {
+      TestUtils.findRenderedDOMComponentWithClass(
+        datePicker,
+        "react-datepicker__portal"
+      );
+    }).to.throw();
+  });
+
   it("should render Calendar in portal when withPortal is set and input has focus", () => {
     var datePicker = TestUtils.renderIntoDocument(<DatePicker withPortal />);
     var dateInput = datePicker.input;
@@ -538,6 +551,16 @@ describe("DatePicker", () => {
       );
     }).to.throw();
     expect(datePicker.calendar).not.to.exist;
+  });
+
+  it("should render Calendar in a ReactDOM portal when withPortal is set and portalId is set", () => {
+    var datePicker = TestUtils.renderIntoDocument(
+      <DatePicker withPortal portalId="portal-id-dom-test" />
+    );
+    var dateInput = datePicker.input;
+    TestUtils.Simulate.focus(ReactDOM.findDOMNode(dateInput));
+
+    expect(document.getElementById("portal-id-dom-test")).to.exist;
   });
 
   function getOnInputKeyDownStuff(opts) {


### PR DESCRIPTION
## Changes
* providing `portalId` when used in conjunction with `withPortal` will render the portal version calendar in a ReactDOM portal (using the Portal component).
* Removes confusing logic of inline portals. Inline always renders the calendar. Providing the `withPortal` prop only wrapped the calendar in the portal class.
* Adds documentation for portal versions rendered with ReactDOM portals.
* Removes documentation for InlinePortal which was not used.
* Adds documentation for toggling an Inline calendar.
* Tests inline prop will ignore withPortal prop
* Tests withPortal and portalId will render a portal version with the portalId