### PR TITLE
fix(doc): add focusSelectedMonth docs props

### DIFF
--- a/docs/datepicker.md
+++ b/docs/datepicker.md
@@ -32,6 +32,7 @@ General datepicker component.
 | `filterDate`                 | `func`                         |                 |                                                                                               |
 | `filterTime`                 | `func`                         |                 |                                                                                               |
 | `fixedHeight`                | `bool`                         |                 |                                                                                               |
+| `focusSelectedMonth`         | `bool`                         | `false`                |                                                                                               |
 | `forceShowMonthNavigation`   | `bool`                         |                 |                                                                                               |
 | `formatWeekNumber`           | `func`                         |                 |                                                                                               |
 | `highlightDates`             | `array`                        |                 |                                                                                               |


### PR DESCRIPTION
This PR adds `focusSelectedMonth` in date-picker props documentation