### PR TITLE
Bugfix - Navigation button icons are hidden in Safari

### DIFF
--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -189,6 +189,7 @@
   position: relative;
   top: -1px;
   font-size: 20px;
+  width: 0;
 
   &::before {
     @extend %navigation-chevron;


### PR DESCRIPTION
## In this PR:

* Set explicit 0 width for navigation icon span container to render consistently on Safari

## Notes:

Chrome, Firefox, Edge, and other browsers implicitly sets the navigation button's width to 0 (collapsed) due to the combination of absolute and relative positioning. Safari, on the other hand, calculates a width based on left/right and other values, which leaves the icon outside of the button's hidden overflow. Setting an explicit width of 0 does not change rendering on other browsers, but helps Safari render the icon as expected.

Tested on Chrome, Firefox, Edge, Opera, and Safari.

## Screenshots:

**Original navigation rendering in Safari:**
![image](https://user-images.githubusercontent.com/1672105/125113281-72d28100-e0b6-11eb-97d7-a61ce0987725.png)

**Updated navigation rendering in Safari:**
![image](https://user-images.githubusercontent.com/1672105/125113215-59c9d000-e0b6-11eb-90a7-beee192b72f1.png)
