### PR TITLE
Allow Quarter and Month disable by includeDates and excludeDates

### DIFF
--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -428,7 +428,7 @@ export function isMonthDisabled(
   { minDate, maxDate, excludeDates, includeDates, filterDate } = {}
 ) {
   return (
-    isOutOfBounds(month, { minDate, maxDate }) ||
+    ((minDate || maxDate) && isOutOfBounds(month, { minDate, maxDate })) ||
     (excludeDates &&
       excludeDates.some((excludeDate) => isSameMonth(month, excludeDate))) ||
     (includeDates &&
@@ -460,7 +460,7 @@ export function isQuarterDisabled(
   { minDate, maxDate, excludeDates, includeDates, filterDate } = {}
 ) {
   return (
-    isOutOfBounds(quarter, { minDate, maxDate }) ||
+    ((minDate || maxDate) && isOutOfBounds(quarter, { minDate, maxDate })) ||
     (excludeDates &&
       excludeDates.some((excludeDate) =>
         isSameQuarter(quarter, excludeDate)

--- a/src/month.jsx
+++ b/src/month.jsx
@@ -256,25 +256,18 @@ export default class Month extends React.Component {
   };
 
   getMonthClassNames = (m) => {
-    const {
-      day,
-      startDate,
-      endDate,
-      selected,
-      minDate,
-      maxDate,
-      preSelection,
-      monthClassName,
-    } = this.props;
+    const { day, startDate, endDate, selected, preSelection, monthClassName } =
+      this.props;
     const _monthClassName = monthClassName ? monthClassName(day) : undefined;
     return classnames(
       "react-datepicker__month-text",
       `react-datepicker__month-${m}`,
       _monthClassName,
       {
-        "react-datepicker__month--disabled":
-          (minDate || maxDate) &&
-          utils.isMonthDisabled(utils.setMonth(day, m), this.props),
+        "react-datepicker__month--disabled": utils.isMonthDisabled(
+          utils.setMonth(day, m),
+          this.props
+        ),
         "react-datepicker__month--selected":
           utils.getMonth(day) === m &&
           utils.getYear(day) === utils.getYear(selected),
@@ -319,14 +312,15 @@ export default class Month extends React.Component {
   };
 
   getQuarterClassNames = (q) => {
-    const { day, startDate, endDate, selected, minDate, maxDate } = this.props;
+    const { day, startDate, endDate, selected } = this.props;
     return classnames(
       "react-datepicker__quarter-text",
       `react-datepicker__quarter-${q}`,
       {
-        "react-datepicker__quarter--disabled":
-          (minDate || maxDate) &&
-          utils.isQuarterDisabled(utils.setQuarter(day, q), this.props),
+        "react-datepicker__quarter--disabled": utils.isQuarterDisabled(
+          utils.setQuarter(day, q),
+          this.props
+        ),
         "react-datepicker__quarter--selected":
           utils.getQuarter(day) === q &&
           utils.getYear(day) === utils.getYear(selected),


### PR DESCRIPTION
Removing minDate || maxDate requirement from Month and Quarter disabled checks to allow disable by includeDates and excludeDates.

Should fix: https://github.com/Hacker0x01/react-datepicker/issues/2328

NOTE:

The existing includeDates check looks to see no dates in that month are included before disabling it. So for instance, if the includeDates contained only 24 July 2021, then July 2021 would not be disabled.

The caveat is that I think when you click a month it tries to select the first day of the month as the selected date. In this case, it would try to select the 01 July 2021 which is not in includeDates, and so actually selecting the month would fail.

It's not clear to me what the expected behaviour should be - but a workaround here is to reduce includeDates down to the first date of each included month when using showMonthYearPicker.