### PR TITLE
Fix 'Time Select Only' tests

### DIFF
--- a/test/show_time_test.js
+++ b/test/show_time_test.js
@@ -28,9 +28,13 @@ describe("DatePicker", () => {
   });
 
   describe("Time Select Only", () => {
-    var datePicker = mount(
-      <DatePicker showTimeSelect showTimeSelectOnly todayButton="Today" />
-    );
+    let datePicker;
+    before(() => {
+      datePicker = mount(
+        <DatePicker showTimeSelect showTimeSelectOnly todayButton="Today" />
+      );
+      datePicker.find("input").simulate("click");
+    });
 
     it("should not show month container when showTimeSelectOnly prop is present", () => {
       var elem = datePicker.find(".react-datepicker__month-container");


### PR DESCRIPTION
Hi,

This pull request fixes an issue where the tests under "Time Select Only" would always pass regardless of whether the property "showTimeSelectOnly" is true or false.