### PR TITLE
Added new property 'inlineWithInput'

### DIFF
--- a/docs-site/src/components/Examples/index.js
+++ b/docs-site/src/components/Examples/index.js
@@ -52,6 +52,7 @@ import MonthDropdownShort from "../../examples/monthDropdownShort";
 import MonthYearDropdown from "../../examples/monthYearDropdown";
 import YearSelectDropdown from "../../examples/yearSelectDropdown";
 import Inline from "../../examples/inline";
+import inlineWithInput from "../../examples/inlineWithInput";
 import InlineVisible from "../../examples/inlineVisible";
 import OpenToDate from "../../examples/openToDate";
 import FixedCalendar from "../../examples/fixedCalendar";
@@ -262,6 +263,10 @@ export default class exampleComponents extends React.Component {
     {
       title: "Inline version",
       component: Inline,
+    },
+    {
+      title: "Inline with input version",
+      component: inlineWithInput,
     },
     {
       title: "Button to show Inline version",

--- a/docs-site/src/examples/inlineWithInput.js
+++ b/docs-site/src/examples/inlineWithInput.js
@@ -1,0 +1,10 @@
+() => {
+  const [startDate, setStartDate] = useState(new Date());
+  return (
+    <DatePicker
+      selected={startDate}
+      onChange={(date) => setStartDate(date)}
+      inlineWithInput
+    />
+  );
+};

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -441,7 +441,7 @@ export default class DatePicker extends React.Component {
   };
 
   handleCalendarClickOutside = (event) => {
-    if (!this.props.inline) {
+    if (!this.props.inline || !this.props.inlineWithInput) {
       this.setOpen(false);
     }
     this.props.onClickOutside(event);
@@ -493,7 +493,7 @@ export default class DatePicker extends React.Component {
     this.setSelected(date, event, false, monthSelectedIn);
     if (!this.props.shouldCloseOnSelect || this.props.showTimeSelect) {
       this.setPreSelection(date);
-    } else if (!this.props.inline) {
+    } else if (!this.props.inline || !this.props.inlineWithInput) {
       if (!this.props.selectsRange) {
         this.setOpen(false);
       }
@@ -531,7 +531,7 @@ export default class DatePicker extends React.Component {
             second: getSeconds(this.props.selected),
           });
         }
-        if (!this.props.inline) {
+        if (!this.props.inline || !this.props.inlineWithInput) {
           this.setState({
             preSelection: changedDate,
           });
@@ -746,7 +746,7 @@ export default class DatePicker extends React.Component {
       }
       this.setPreSelection(newSelection);
       // need to figure out whether month has changed to focus day in inline version
-      if (this.props.inline) {
+      if (this.props.inline || this.props.inlineWithInput) {
         const prevMonth = getMonth(copy);
         const newMonth = getMonth(newSelection);
         const prevYear = getYear(copy);
@@ -871,7 +871,7 @@ export default class DatePicker extends React.Component {
         includeDates={this.props.includeDates}
         includeTimes={this.props.includeTimes}
         injectTimes={this.props.injectTimes}
-        inline={this.props.inline}
+        inline={this.props.inline || this.props.inlineWithInput}
         shouldFocusDayInline={this.state.shouldFocusDayInline}
         peekNextMonth={this.props.peekNextMonth}
         showMonthDropdown={this.props.showMonthDropdown}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -162,6 +162,7 @@ export default class DatePicker extends React.Component {
     includeTimes: PropTypes.array,
     injectTimes: PropTypes.array,
     inline: PropTypes.bool,
+    inlineWithInput: PropTypes.bool,
     isClearable: PropTypes.bool,
     locale: PropTypes.oneOfType([
       PropTypes.string,
@@ -826,7 +827,11 @@ export default class DatePicker extends React.Component {
   };
 
   renderCalendar = () => {
-    if (!this.props.inline && !this.isCalendarOpen()) {
+    if (
+      !this.props.inline &&
+      !this.props.inlineWithInput &&
+      !this.isCalendarOpen()
+    ) {
       return null;
     }
     return (
@@ -1026,6 +1031,10 @@ export default class DatePicker extends React.Component {
 
   render() {
     const calendar = this.renderCalendar();
+
+    if (this.props.inlineWithInput) {
+      return [this.renderInputContainer(), calendar];
+    }
 
     if (this.props.inline) return calendar;
 

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -528,6 +528,59 @@ describe("DatePicker", () => {
     }).to.throw();
   });
 
+  it("should render calendar inside PopperComponent when inlineWithInput prop is not set", () => {
+    var datePicker = TestUtils.renderIntoDocument(<DatePicker />);
+
+    expect(function () {
+      TestUtils.findRenderedComponentWithType(datePicker, PopperComponent);
+    }).to.not.throw();
+  });
+
+  it("should render calendar directly without PopperComponent when inlineWithInput prop is set", () => {
+    var datePicker = TestUtils.renderIntoDocument(
+      <DatePicker inlineWithInput />
+    );
+
+    expect(function () {
+      TestUtils.findRenderedComponentWithType(datePicker, PopperComponent);
+    }).to.throw();
+    expect(datePicker.calendar).to.exist;
+  });
+
+  it("should ignore disable prop when inlineWithInput prop is set", () => {
+    var datePicker = TestUtils.renderIntoDocument(
+      <DatePicker inlineWithInput disabled />
+    );
+
+    expect(datePicker.calendar).to.exist;
+  });
+
+  it("should ignore withPortal prop when inlineWithInput prop is set", () => {
+    var datePicker = TestUtils.renderIntoDocument(
+      <DatePicker inlineWithInput withPortal />
+    );
+
+    expect(function () {
+      TestUtils.findRenderedDOMComponentWithClass(
+        datePicker,
+        "react-datepicker__portal"
+      );
+    }).to.throw();
+  });
+
+  it("should ignore inline prop when inlineWithInput prop is set", () => {
+    var datePicker = TestUtils.renderIntoDocument(
+      <DatePicker inline inlineWithInput />
+    );
+
+    expect(function () {
+      TestUtils.findRenderedDOMComponentWithClass(
+        datePicker,
+        "react-datepicker__input-container"
+      );
+    }).to.not.throw();
+  });
+
   it("should render Calendar in portal when withPortal is set and input has focus", () => {
     var datePicker = TestUtils.renderIntoDocument(<DatePicker withPortal />);
     var dateInput = datePicker.input;


### PR DESCRIPTION
In fact, this is an extension of the already existing property `inline` that renders the calendar.

But if you use `inlineWithInput`, then the Input element will also be rendered