### PR TITLE
Add support for seconds to the timepicker

### DIFF
--- a/docs-site/src/components/Examples/index.js
+++ b/docs-site/src/components/Examples/index.js
@@ -71,6 +71,7 @@ import RenderCustomHeader from "../../examples/renderCustomHeader";
 import RenderCustomHeaderTwoMonths from "../../examples/renderCustomHeaderTwoMonths";
 import RenderCustomDay from "../../examples/renderCustomDay";
 import TimeInput from "../../examples/timeInput";
+import TimeInputSeconds from "../../examples/timeInputSeconds";
 import StrictParsing from "../../examples/strictParsing";
 import MonthPicker from "../../examples/monthPicker";
 import YearPicker from "../../examples/yearPicker";
@@ -285,6 +286,10 @@ export default class exampleComponents extends React.Component {
     {
       title: "Input time",
       component: TimeInput,
+    },
+    {
+      title: "Input time with seconds",
+      component: TimeInputSeconds,
     },
     {
       title: "Locale",

--- a/docs-site/src/examples/timeInputSeconds.js
+++ b/docs-site/src/examples/timeInputSeconds.js
@@ -1,0 +1,13 @@
+() => {
+  const [startDate, setStartDate] = useState(new Date());
+  return (
+    <DatePicker
+      selected={startDate}
+      onChange={(date) => setStartDate(date)}
+      timeInputLabel="Time:"
+      dateFormat="MM/dd/yyyy h:mm:ss aa"
+      showTimeInput
+      timeInputSeconds
+    />
+  );
+};

--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -132,6 +132,7 @@ export default class Calendar extends React.Component {
     onWeekSelect: PropTypes.func,
     showTimeSelect: PropTypes.bool,
     showTimeInput: PropTypes.bool,
+    timeInputSeconds: PropTypes.bool,
     showMonthYearPicker: PropTypes.bool,
     showFullMonthYearPicker: PropTypes.bool,
     showTwoColumnMonthYearPicker: PropTypes.bool,
@@ -962,9 +963,13 @@ export default class Calendar extends React.Component {
   renderInputTimeSection = () => {
     const time = new Date(this.props.selected);
     const timeValid = isValid(time) && Boolean(this.props.selected);
-    const timeString = timeValid
-      ? `${addZero(time.getHours())}:${addZero(time.getMinutes())}`
-      : "";
+    let timeWithColon = `${addZero(time.getHours())}:${addZero(
+      time.getMinutes()
+    )}`;
+    if (this.props.timeInputSeconds) {
+      timeWithColon += `:${addZero(time.getSeconds())}`;
+    }
+    const timeString = timeValid ? timeWithColon : "";
     if (this.props.showTimeInput) {
       return (
         <InputTime
@@ -973,6 +978,7 @@ export default class Calendar extends React.Component {
           timeInputLabel={this.props.timeInputLabel}
           onChange={this.props.onTimeChange}
           customTimeInput={this.props.customTimeInput}
+          timeInputSeconds={this.props.timeInputSeconds}
         />
       );
     }

--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -191,7 +191,7 @@ export function setTime(date, { hour = 0, minute = 0, second = 0 }) {
   return setHours(setMinutes(setSeconds(date, second), minute), hour);
 }
 
-export { setMinutes, setHours, setMonth, setQuarter, setYear };
+export { setSeconds, setMinutes, setHours, setMonth, setQuarter, setYear };
 
 // ** Date Getters **
 
@@ -533,7 +533,8 @@ export function isTimeInList(time, times) {
   return times.some(
     (listTime) =>
       getHours(listTime) === getHours(time) &&
-      getMinutes(listTime) === getMinutes(time)
+      getMinutes(listTime) === getMinutes(time) &&
+      getSeconds(listTime) === getSeconds(time)
   );
 }
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -112,6 +112,7 @@ export default class DatePicker extends React.Component {
       nextYearAriaLabel: "Next Year",
       nextYearButtonLabel: "Next Year",
       timeInputLabel: "Time",
+      timeInputSeconds: false,
       enableTabLoop: true,
       yearItemNumber: DEFAULT_YEAR_ITEM_NUMBER,
 
@@ -273,6 +274,7 @@ export default class DatePicker extends React.Component {
     nextYearAriaLabel: PropTypes.string,
     nextYearButtonLabel: PropTypes.string,
     timeInputLabel: PropTypes.string,
+    timeInputSeconds: PropTypes.bool,
     renderCustomHeader: PropTypes.func,
     renderDayContents: PropTypes.func,
     wrapperClassName: PropTypes.string,
@@ -625,6 +627,7 @@ export default class DatePicker extends React.Component {
     let changedDate = setTime(selected, {
       hour: getHours(time),
       minute: getMinutes(time),
+      second: getSeconds(time),
     });
 
     this.setState({
@@ -938,6 +941,7 @@ export default class DatePicker extends React.Component {
         nextYearAriaLabel={this.props.nextYearAriaLabel}
         nextYearButtonLabel={this.props.nextYearButtonLabel}
         timeInputLabel={this.props.timeInputLabel}
+        timeInputSeconds={this.props.timeInputSeconds}
         disabledKeyboardNavigation={this.props.disabledKeyboardNavigation}
         renderCustomHeader={this.props.renderCustomHeader}
         popperProps={this.props.popperProps}

--- a/src/inputTime.jsx
+++ b/src/inputTime.jsx
@@ -8,6 +8,7 @@ export default class inputTime extends React.Component {
     timeString: PropTypes.string,
     timeInputLabel: PropTypes.string,
     customTimeInput: PropTypes.element,
+    timeInputSeconds: PropTypes.bool,
   };
 
   constructor(props) {
@@ -34,6 +35,7 @@ export default class inputTime extends React.Component {
     const date = new Date();
     date.setHours(time.split(":")[0]);
     date.setMinutes(time.split(":")[1]);
+    date.setSeconds(time.split(":")[2]);
     this.props.onChange(date);
   };
 
@@ -71,7 +73,13 @@ export default class inputTime extends React.Component {
           {this.props.timeInputLabel}
         </div>
         <div className="react-datepicker-time__input-container">
-          <div className="react-datepicker-time__input">
+          <div
+            className={
+              this.props.timeInputSeconds
+                ? "react-datepicker-time__input react-datepicker-time__input-seconds"
+                : "react-datepicker-time__input"
+            }
+          >
             {this.renderTimeInput()}
           </div>
         </div>

--- a/src/inputTime.jsx
+++ b/src/inputTime.jsx
@@ -19,6 +19,11 @@ export default class inputTime extends React.Component {
     };
   }
 
+  /**
+   * This routine will update local state from props whenever the component renders.
+   * This can cause some issues where if local state changes, it will be overwritten with props.
+   * See: https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#anti-pattern-unconditionally-copying-props-to-state
+   */
   static getDerivedStateFromProps(props, state) {
     if (props.timeString !== state.time) {
       return {
@@ -35,7 +40,11 @@ export default class inputTime extends React.Component {
     const date = new Date();
     date.setHours(time.split(":")[0]);
     date.setMinutes(time.split(":")[1]);
-    date.setSeconds(time.split(":")[2]);
+    // If seconds were specified on the time string, set the seconds into the date object.
+    // When seconds are not specified, "new Date()" is going to have seconds set to current time.
+    if (time.split(":")[2]) {
+      date.setSeconds(time.split(":")[2]);
+    }
     this.props.onChange(date);
   };
 

--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -262,6 +262,10 @@
   .react-datepicker-time__input-container {
     display: inline-block;
 
+    .react-datepicker-time__input.react-datepicker-time__input-seconds {
+      margin-left: 0;
+    }
+
     .react-datepicker-time__input {
       display: inline-block;
       margin-left: 10px;

--- a/src/time.jsx
+++ b/src/time.jsx
@@ -3,8 +3,10 @@ import PropTypes from "prop-types";
 import {
   getHours,
   getMinutes,
+  getSeconds,
   setHours,
   setMinutes,
+  setSeconds,
   newDate,
   getStartOfDay,
   addMinutes,
@@ -89,20 +91,21 @@ export default class Time extends React.Component {
     this.props.onChange(time);
   };
 
-  isSelectedTime = (time, currH, currM) =>
+  isSelectedTime = (time, currH, currM, currS) =>
     this.props.selected &&
     currH === getHours(time) &&
-    currM === getMinutes(time);
+    currM === getMinutes(time) &&
+    (typeof currS === "undefined" || currS === getSeconds(time));
 
-  liClasses = (time, currH, currM) => {
+  liClasses = (time, currH, currM, currS) => {
     let classes = [
       "react-datepicker__time-list-item",
       this.props.timeClassName
-        ? this.props.timeClassName(time, currH, currM)
+        ? this.props.timeClassName(time, currH, currM, currS)
         : undefined,
     ];
 
-    if (this.isSelectedTime(time, currH, currM)) {
+    if (this.isSelectedTime(time, currH, currM, currS)) {
       classes.push("react-datepicker__time-list-item--selected");
     }
 
@@ -118,7 +121,9 @@ export default class Time extends React.Component {
     }
     if (
       this.props.injectTimes &&
-      (getHours(time) * 60 + getMinutes(time)) % this.props.intervals !== 0
+      (getHours(time) * 60 + getMinutes(time) + getSeconds(time)) %
+        this.props.intervals !==
+        0
     ) {
       classes.push("react-datepicker__time-list-item--injected");
     }
@@ -155,7 +160,11 @@ export default class Time extends React.Component {
       this.props.selected || this.props.openToDate || newDate();
     const currH = getHours(activeDate);
     const currM = getMinutes(activeDate);
-    const activeTime = setHours(setMinutes(base, currM), currH);
+    const currS = getSeconds(activeDate);
+    const activeTime = setHours(
+      setMinutes(setSeconds(base, currS), currM),
+      currH
+    );
 
     for (let i = 0; i < multiplier; i++) {
       const currentTime = addMinutes(base, i * intervals);
@@ -188,7 +197,7 @@ export default class Time extends React.Component {
         }}
         tabIndex="0"
         aria-selected={
-          this.isSelectedTime(time, currH, currM) ? "true" : undefined
+          this.isSelectedTime(time, currH, currM, currS) ? "true" : undefined
         }
       >
         {formatDate(time, format, this.props.locale)}

--- a/test/time_input_test.js
+++ b/test/time_input_test.js
@@ -40,6 +40,15 @@ describe("timeInput", () => {
     expect(timeComponent.state("time")).to.equal("13:00");
   });
 
+  xit("should trigger onChange event (with seconds)", () => {
+    const timeComponent = shallow(
+      <InputTimeComponent onChange={console.log} />
+    );
+    const input = timeComponent.find("input");
+    input.simulate("change", { target: { value: "13:00:01" } });
+    expect(timeComponent.state("time")).to.equal("13:00:01");
+  });
+
   it("should trigger onChange event and set the value as last valid timeString if empty string is passed as time input value", () => {
     const timeComponent = shallow(
       <InputTimeComponent timeString="13:00" onChange={console.log} />

--- a/test/time_input_test.js
+++ b/test/time_input_test.js
@@ -40,13 +40,44 @@ describe("timeInput", () => {
     expect(timeComponent.state("time")).to.equal("13:00");
   });
 
-  xit("should trigger onChange event (with seconds)", () => {
+  it("should trigger onChange event (with seconds)", () => {
+    const onChangeSecondsSpy = sandbox.spy();
     const timeComponent = shallow(
-      <InputTimeComponent onChange={console.log} />
+      <InputTimeComponent
+        timeString="12:00:00"
+        timeInputSeconds
+        onChange={onChangeSecondsSpy}
+      />
     );
     const input = timeComponent.find("input");
     input.simulate("change", { target: { value: "13:00:01" } });
-    expect(timeComponent.state("time")).to.equal("13:00:01");
+    assert(
+      onChangeSecondsSpy.called === true,
+      "should call InputTimeComponent onChange"
+    );
+  });
+
+  it("should send updated time in onChange event (with seconds)", () => {
+    const onChangeSecondsSpy = sandbox.spy();
+    const timeComponent = mount(
+      <InputTimeComponent
+        timeString="12:00:00"
+        timeInputSeconds
+        onChange={onChangeSecondsSpy}
+      />
+    );
+    let input = timeComponent.find("input");
+    input.simulate("change", { target: { value: "13:00:01" } });
+    // The onChange inside InputTimeComponent creates a Date() object and returns it.
+    // We want to pull out the hours:minutes:seconds out of that date object to see if it matches.
+    const newDate = onChangeSecondsSpy.getCall(0).args[0];
+    const dateCompare =
+      newDate.getHours().toString().padStart(2, "0") +
+      ":" +
+      newDate.getMinutes().toString().padStart(2, "0") +
+      ":" +
+      newDate.getSeconds().toString().padStart(2, "0");
+    expect(dateCompare).to.equal("13:00:01");
   });
 
   it("should trigger onChange event and set the value as last valid timeString if empty string is passed as time input value", () => {


### PR DESCRIPTION
As the title says, this PR is to add support for seconds to the time picker. When using a customTimeInput it will pass HH:mm:ss to the component with this change