### PR TITLE
chore: updated react-onclickoutside support shadow-dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "classnames": "^2.2.6",
     "date-fns": "^2.24.0",
     "prop-types": "^15.7.2",
-    "react-onclickoutside": "^6.10.0",
+    "react-onclickoutside": "^6.12.0",
     "react-popper": "^2.2.5"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7990,10 +7990,10 @@ react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-onclickoutside@^6.10.0:
-  version "6.11.2"
-  resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.11.2.tgz#790e2100b9a3589eefca1404ecbf0476b81b7928"
-  integrity sha512-640486eSwU/t5iD6yeTlefma8dI3bxPXD93hM9JGKyYITAd0P1JFkkcDeyHZRqNpY/fv1YW0Fad9BXr44OY8wQ==
+react-onclickoutside@^6.12.0:
+  version "6.12.0"
+  resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.12.0.tgz#c63db2e3c2c852b288160cdb6cff443604e28db4"
+  integrity sha512-oPlOTYcISLHfpMog2lUZMFSbqOs4LFcA4+vo7fpfevB5v9Z0D5VBDBkfeO5lv+hpEcGoaGk67braLT+QT+eICA==
 
 react-popper@^2.2.5:
   version "2.2.5"


### PR DESCRIPTION
Related to issue https://github.com/Hacker0x01/react-datepicker/issues/3227

# Is your feature request related to a problem? Please describe.
react-onclickoutside recently pushed an update to support shadow-dom interactions. This update is working successfully, however when npm publishing using react-datepicker as a dependency it is not pulling in 6.12.0 version, instead it is respecting the yarn-lock and keeping version 6.10.0 which causes the resulting package not to support shadow-dom.

# Describe the solution you'd like
Update react-onclickoutside to 6.12.0

# Describe alternatives you've considered
If you want to create an npm package that uses react-datepicker, you will not be able to use the latest version of react-onclickoutside which support shadow dom.

# Additional context
Related react-onlickoutside PR for supporting shadow-dom Pomax/react-onclickoutside#363