### PR TITLE
Prevent opening calendar on click if preventOpenOnFocus is true

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -623,7 +623,11 @@ export default class DatePicker extends React.Component {
   };
 
   onInputClick = () => {
-    if (!this.props.disabled && !this.props.readOnly) {
+    if (
+      !this.props.disabled &&
+      !this.props.readOnly &&
+      !this.props.preventOpenOnFocus
+    ) {
       this.setOpen(true);
     }
 

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -1347,6 +1347,12 @@ describe("DatePicker", () => {
       .simulate("click");
     assert(onInputClickSpy.callCount, 1);
   });
+  it("should not open calendar onClick if preventOpenOnFocus", () => {
+    var datePicker = mount(<DatePicker preventOpenOnFocus />)
+      .find("input")
+      .simulate("click");
+    expect(datePicker.calendar).to.not.exist;
+  });
 
   it("should set monthSelectedIn to 0 if monthsShown prop changes", () => {
     const datePicker = mount(<DatePicker monthsShown={2} inline />);


### PR DESCRIPTION
I was trying to utilize `onKeyDown` in my TimePicker input-only component, to change the time with the arrow-keys. 
However, I ran into trouble as [this part of the code](https://github.com/Hacker0x01/react-datepicker/blob/master/src/index.jsx#L653 ) expected a calendar to exist (or at least this.state.open is true, even though it is not rendered as I have applied `open={false}` and `showTimeInput={false}`

And technically, a mouse-click is also a focus-event, thus it is correct to avoid opening if `prevenOpenOnFocus={true}`.

Please let me know if the change is not wanted, or if you'll need further explanation of how my custom TimePicker component is setup.