### PR TITLE
fix: select the min date when the time is selected before date and min date is after current day

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -325,6 +325,8 @@ export default class DatePicker extends React.Component {
       ? this.props.startDate
       : this.props.selectsStart && this.props.endDate
       ? this.props.endDate
+      : this.props.minDate && this.props.minDate > newDate()
+      ? this.props.minDate
       : newDate();
 
   calcInitialState = () => {


### PR DESCRIPTION
When you are using the calendar with time selector and minDate attribute set to a date after the current date, if you select a time without select date before, the calendar will put a current day in the date, but is wrong, because the current day is disabled. 
The PR fix the problem.