### PR TITLE
center header demo example fixes #3254

### DIFF
--- a/docs-site/src/components/Examples/hero.scss
+++ b/docs-site/src/components/Examples/hero.scss
@@ -23,6 +23,7 @@
   }
 
   &__example {
+    display: inline-block;
     margin: 0 auto;
   }
 


### PR DESCRIPTION
Correct position of the demo example in the header.

![center-datepicker](https://user-images.githubusercontent.com/12084773/138551702-4162aec6-9e9a-4c55-9ed7-aafd91bee53c.png)
