### PR TITLE
dynamic time height

### DIFF
--- a/src/time.jsx
+++ b/src/time.jsx
@@ -75,6 +75,18 @@ export default class Time extends React.Component {
     }
   }
 
+  componentDidUpdate() {
+    if (this.props.monthRef && this.header) {
+      const updatedHeight =
+        this.props.monthRef.clientHeight - this.header.clientHeight;
+      if (this.state.height !== updatedHeight) {
+        this.setState({
+          height: updatedHeight,
+        });
+      }
+    }
+  }
+
   handleClick = (time) => {
     if (
       ((this.props.minTime || this.props.maxTime) &&

--- a/test/timepicker_test.js
+++ b/test/timepicker_test.js
@@ -4,6 +4,7 @@ import TestUtils from "react-dom/test-utils";
 import ReactDOM from "react-dom";
 import Time from "../src/time";
 import { newDate, formatDate } from "../src/date_utils";
+import { mount } from "enzyme";
 
 function getKey(key) {
   switch (key) {
@@ -254,4 +255,31 @@ describe("TimePicker", () => {
     onChangeMoment = newDate(m);
     renderDatePicker(m);
   }
+});
+
+describe("TimePicker height test", () => {
+  it("should be null when monthRef is undefined", () => {
+    const time = mount(<Time />);
+    expect(time.state("height")).to.equal(null);
+  });
+
+  it("should equal monthRef's clientHeight after mount", () => {
+    const monthRef = {
+      clientHeight: 100,
+    };
+    //The headers clientHeight is 0
+    const time = mount(<Time monthRef={monthRef} />);
+    expect(time.state("height")).to.equal(100);
+  });
+
+  it("should equal monthRef's clientHeight after update", () => {
+    const monthRef = {
+      clientHeight: 100,
+    };
+    const time = mount(<Time monthRef={monthRef} />);
+    expect(time.state("height")).to.equal(100);
+    monthRef.clientHeight = 120;
+    time.instance().componentDidUpdate();
+    expect(time.state("height")).to.equal(120);
+  });
 });


### PR DESCRIPTION
Update the timepicker's height when the height of the calendar changes.

Before:

![timePickerHeightFixed](https://user-images.githubusercontent.com/12084773/138568218-f5588c41-b3c2-40ef-b889-f3d360021e34.gif)

After:

![timePickerHeightDynamic](https://user-images.githubusercontent.com/12084773/138569993-b1f2a640-91f1-4be9-8c61-c19f00b39019.gif)
 