### PR TITLE
Added new feature and fix a bug same day pre selected in diferent months

### DIFF
--- a/docs-site/src/components/Examples/index.js
+++ b/docs-site/src/components/Examples/index.js
@@ -84,6 +84,7 @@ import CloseOnScroll from "../../examples/closeOnScroll";
 import CloseOnScrollCallback from "../../examples/closeOnScrollCallback";
 import SelectsRange from "../../examples/selectsRange";
 import CalendarStartDay from "../../examples/calendarStartDay";
+import CalendarShowDaysOnlyInMonth from "../../examples/calendarShowDaysOnlyInMonth";
 
 import "./style.scss";
 import "react-datepicker/dist/react-datepicker.css";
@@ -430,6 +431,10 @@ export default class exampleComponents extends React.Component {
     {
       title: "Calendar Start day",
       component: CalendarStartDay,
+    },
+    {
+      title: "Calendar not show days outside month",
+      component: CalendarShowDaysOnlyInMonth,
     },
   ];
 

--- a/docs-site/src/examples/calendarShowDaysOnlyInMonth.js
+++ b/docs-site/src/examples/calendarShowDaysOnlyInMonth.js
@@ -1,0 +1,13 @@
+() => {
+  const [startDate, setDate] = useState(new Date());
+  return (
+    <DatePicker
+      startDate={startDate}
+      onChange={(update) => {
+        setDate(update);
+      }}
+      isClearable={true}
+      monthNotShowsDuplicateDays={true}
+    />
+  );
+};

--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -61,6 +61,7 @@ export default class Calendar extends React.Component {
     return {
       onDropdownFocus: () => {},
       monthsShown: 1,
+      monthNotShowsDuplicateDays: false,
       monthSelectedIn: 0,
       forceShowMonthNavigation: false,
       timeCaption: "Time",
@@ -108,6 +109,7 @@ export default class Calendar extends React.Component {
     maxDate: PropTypes.instanceOf(Date),
     minDate: PropTypes.instanceOf(Date),
     monthsShown: PropTypes.number,
+    monthNotShowsDuplicateDays: PropTypes.bool,
     monthSelectedIn: PropTypes.number,
     nextMonthAriaLabel: PropTypes.string,
     nextYearAriaLabel: PropTypes.string,
@@ -323,7 +325,7 @@ export default class Calendar extends React.Component {
       }
     }
 
-    this.props.setPreSelection && this.props.setPreSelection(date);
+    // this.props.setPreSelection && this.props.setPreSelection(date);
   };
 
   handleMonthYearChange = (date) => {
@@ -816,8 +818,10 @@ export default class Calendar extends React.Component {
       var monthsToAdd = i - this.props.monthSelectedIn;
       var monthDate = addMonths(fromMonthDate, monthsToAdd);
       var monthKey = `month-${i}`;
-      var monthShowsDuplicateDaysEnd = i < this.props.monthsShown - 1;
-      var monthShowsDuplicateDaysStart = i > 0;
+      var monthShowsDuplicateDaysEnd =
+        this.props.monthNotShowsDuplicateDays ?? i < this.props.monthsShown - 1;
+      var monthShowsDuplicateDaysStart =
+        this.props.monthNotShowsDuplicateDays ?? i > 0;
       monthList.push(
         <div
           key={monthKey}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -87,6 +87,7 @@ export default class DatePicker extends React.Component {
       onYearChange() {},
       onInputError() {},
       monthsShown: 1,
+      monthNotShowsDuplicateDays: false,
       readOnly: false,
       withPortal: false,
       shouldCloseOnSelect: true,
@@ -174,6 +175,7 @@ export default class DatePicker extends React.Component {
     maxDate: PropTypes.instanceOf(Date),
     minDate: PropTypes.instanceOf(Date),
     monthsShown: PropTypes.number,
+    monthNotShowsDuplicateDays: PropTypes.bool,
     name: PropTypes.string,
     onBlur: PropTypes.func,
     onChange: PropTypes.func.isRequired,
@@ -893,6 +895,7 @@ export default class DatePicker extends React.Component {
         outsideClickIgnoreClass={outsideClickIgnoreClass}
         fixedHeight={this.props.fixedHeight}
         monthsShown={this.props.monthsShown}
+        monthNotShowsDuplicateDays={this.props.monthNotShowsDuplicateDays}
         monthSelectedIn={this.state.monthSelectedIn}
         onDropdownFocus={this.handleDropdownFocus}
         onMonthChange={this.props.onMonthChange}


### PR DESCRIPTION
# Feature added

- I add a new prop (monthNotShowsDuplicateDays) to choose between show or hide days outside month by default is false to stay with the current behavior

## Bug fixed
- I remove from function handleMonthChange the called function preSelection, because it was setting the same day keyboard-selected in every month