### PR TITLE
Add ability to exclude and include date intervals

### DIFF
--- a/docs-site/src/components/Examples/index.js
+++ b/docs-site/src/components/Examples/index.js
@@ -28,6 +28,7 @@ import Locale from "../../examples/locale";
 import LocaleWithTime from "../../examples/localeWithTime";
 import LocaleWithoutGlobalVariable from "../../examples/localeWithoutGlobalVariable";
 import ExcludeDates from "../../examples/excludeDates";
+import ExcludeDateIntervals from "../../examples/excludeDateIntervals";
 import HighlightDates from "../../examples/highlightDates";
 import HighlightDatesRanges from "../../examples/highlightDatesRanges";
 import IncludeDates from "../../examples/includeDates";
@@ -218,6 +219,10 @@ export default class exampleComponents extends React.Component {
     {
       title: "Exclude dates",
       component: ExcludeDates,
+    },
+    {
+      title: "Exclude date intervals",
+      component: ExcludeDateIntervals
     },
     {
       title: "Exclude Times",

--- a/docs-site/src/components/Examples/index.js
+++ b/docs-site/src/components/Examples/index.js
@@ -32,6 +32,7 @@ import ExcludeDateIntervals from "../../examples/excludeDateIntervals";
 import HighlightDates from "../../examples/highlightDates";
 import HighlightDatesRanges from "../../examples/highlightDatesRanges";
 import IncludeDates from "../../examples/includeDates";
+import IncludeDateIntervals from "../../examples/includeDateIntervals";
 import FilterDates from "../../examples/filterDates";
 import DateRange from "../../examples/dateRange";
 import DateRangeInputWithClearButton from "../../examples/dateRangeInputWithClearButton";
@@ -222,7 +223,7 @@ export default class exampleComponents extends React.Component {
     },
     {
       title: "Exclude date intervals",
-      component: ExcludeDateIntervals
+      component: ExcludeDateIntervals,
     },
     {
       title: "Exclude Times",
@@ -255,6 +256,10 @@ export default class exampleComponents extends React.Component {
     {
       title: "Include dates",
       component: IncludeDates,
+    },
+    {
+      title: "Include date intervals",
+      component: IncludeDateIntervals,
     },
     {
       title: "Include Times",

--- a/docs-site/src/examples/excludeDateIntervals.js
+++ b/docs-site/src/examples/excludeDateIntervals.js
@@ -1,0 +1,12 @@
+() => {
+	const [startDate, setStartDate] = useState(new Date());
+	return (
+	  <DatePicker
+		selected={startDate}
+		onChange={date => setStartDate(date)}
+		excludeDateIntervals={[{start: subDays(new Date(), 5), end: addDays(new Date(), 5) }]}
+		placeholderText="Select a date other than the interval from 5 days ago to 5 days in the future"
+	  />
+	);
+  };
+  

--- a/docs-site/src/examples/includeDateIntervals.js
+++ b/docs-site/src/examples/includeDateIntervals.js
@@ -1,0 +1,13 @@
+() => {
+  const [startDate, setStartDate] = useState(null);
+  return (
+    <DatePicker
+      selected={startDate}
+      onChange={(date) => setStartDate(date)}
+      includeDateIntervals={[
+        { start: subDays(new Date(), 5), end: addDays(new Date(), 5) },
+      ]}
+      placeholderText="This only includes dates from 5 days ago to 5 days in the future"
+    />
+  );
+};

--- a/docs/datepicker.md
+++ b/docs/datepicker.md
@@ -27,7 +27,7 @@ General datepicker component.
 | `dropdownMode` (required)    | `enum('scroll'\|'select')`     | `'scroll'`      |                                                                                               |
 | `endDate`                    | `instanceOf(Date)`             |                 |                                                                                               |
 | `excludeDates`               | `array`                        |                 |                                                                                               |
-| `excludeDateIntervals`       | `array`                        |                 |                                            |
+| `excludeDateIntervals`       | `array`                        |                 |                                                                                               |
 | `excludeTimes`               | `array`                        |                 |                                                                                               |
 | `excludeScrollbar`           | `array`                        |                 |                                                                                               |
 | `filterDate`                 | `func`                         |                 |                                                                                               |
@@ -39,6 +39,7 @@ General datepicker component.
 | `highlightDates`             | `array`                        |                 |                                                                                               |
 | `id`                         | `string`                       |                 |                                                                                               |
 | `includeDates`               | `array`                        |                 |                                                                                               |
+| `includeDateIntervals`       | `array`                        |                 |                                                                                               |
 | `includeTimes`               | `array`                        |                 |                                                                                               |
 | `injectTimes`                | `array`                        |                 |                                                                                               |
 | `inline`                     | `bool`                         |                 |                                                                                               |

--- a/docs/datepicker.md
+++ b/docs/datepicker.md
@@ -27,6 +27,7 @@ General datepicker component.
 | `dropdownMode` (required)    | `enum('scroll'\|'select')`     | `'scroll'`      |                                                                                               |
 | `endDate`                    | `instanceOf(Date)`             |                 |                                                                                               |
 | `excludeDates`               | `array`                        |                 |                                                                                               |
+| `excludeDateIntervals`       | `array`                        |                 |                                            |
 | `excludeTimes`               | `array`                        |                 |                                                                                               |
 | `excludeScrollbar`           | `array`                        |                 |                                                                                               |
 | `filterDate`                 | `func`                         |                 |                                                                                               |

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,6 +46,7 @@
 | `highlightDates`             | `array`                        |                    |             |
 | `id`                         | `string`                       |                    |             |
 | `includeDates`               | `array`                        |                    |             |
+| `includeDateIntervals`       | `array`                        |                    |             |
 | `includeTimes`               | `array`                        |                    |             |
 | `injectTimes`                | `array`                        |                    |             |
 | `inline`                     | `bool`                         |                    |             |

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,6 +33,7 @@
 | `enableTabLoop`              | `bool`                         | `true`             |             |
 | `endDate`                    | `instanceOfDate`               |                    |             |
 | `excludeDates`               | `array`                        |                    |             |
+| `excludeDateIntervals`       | `array`                        |                    |             |
 | `excludeScrollbar`           | `bool`                         | `true`             |             |
 | `excludeTimes`               | `array`                        |                    |             |
 | `filterDate`                 | `func`                         |                    |             |

--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -92,6 +92,10 @@ export default class Calendar extends React.Component {
     dropdownMode: PropTypes.oneOf(["scroll", "select"]),
     endDate: PropTypes.instanceOf(Date),
     excludeDates: PropTypes.array,
+    excludeDateIntervals: PropTypes.arrayOf(PropTypes.shape({
+      start: PropTypes.instanceOf(Date),
+      end: PropTypes.instanceOf(Date)
+    })),
     filterDate: PropTypes.func,
     fixedHeight: PropTypes.bool,
     formatWeekNumber: PropTypes.func,
@@ -847,6 +851,7 @@ export default class Calendar extends React.Component {
             minDate={this.props.minDate}
             maxDate={this.props.maxDate}
             excludeDates={this.props.excludeDates}
+            excludeDateIntervals={this.props.excludeDateIntervals}
             highlightDates={this.props.highlightDates}
             selectingDate={this.state.selectingDate}
             includeDates={this.props.includeDates}

--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -92,15 +92,23 @@ export default class Calendar extends React.Component {
     dropdownMode: PropTypes.oneOf(["scroll", "select"]),
     endDate: PropTypes.instanceOf(Date),
     excludeDates: PropTypes.array,
-    excludeDateIntervals: PropTypes.arrayOf(PropTypes.shape({
-      start: PropTypes.instanceOf(Date),
-      end: PropTypes.instanceOf(Date)
-    })),
+    excludeDateIntervals: PropTypes.arrayOf(
+      PropTypes.shape({
+        start: PropTypes.instanceOf(Date),
+        end: PropTypes.instanceOf(Date),
+      })
+    ),
     filterDate: PropTypes.func,
     fixedHeight: PropTypes.bool,
     formatWeekNumber: PropTypes.func,
     highlightDates: PropTypes.instanceOf(Map),
     includeDates: PropTypes.array,
+    includeDateIntervals: PropTypes.arrayOf(
+      PropTypes.shape({
+        start: PropTypes.instanceOf(Date),
+        end: PropTypes.instanceOf(Date),
+      })
+    ),
     includeTimes: PropTypes.array,
     injectTimes: PropTypes.array,
     inline: PropTypes.bool,
@@ -855,6 +863,7 @@ export default class Calendar extends React.Component {
             highlightDates={this.props.highlightDates}
             selectingDate={this.state.selectingDate}
             includeDates={this.props.includeDates}
+            includeDateIntervals={this.props.includeDateIntervals}
             inline={this.props.inline}
             shouldFocusDayInline={this.props.shouldFocusDayInline}
             fixedHeight={this.props.fixedHeight}

--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -402,12 +402,14 @@ export function getQuarterShortInLocale(quarter, locale) {
 
 export function isDayDisabled(
   day,
-  { minDate, maxDate, excludeDates, includeDates, filterDate } = {}
+  { minDate, maxDate, excludeDates, excludeDateIntervals, includeDates, filterDate } = {}
 ) {
   return (
     isOutOfBounds(day, { minDate, maxDate }) ||
     (excludeDates &&
       excludeDates.some((excludeDate) => isSameDay(day, excludeDate))) ||
+    (excludeDateIntervals &&
+      excludeDateIntervals.some(({start,end}) => isWithinInterval(day, {start, end}))) ||
     (includeDates &&
       !includeDates.some((includeDate) => isSameDay(day, includeDate))) ||
     (filterDate && !filterDate(newDate(day))) ||
@@ -415,7 +417,10 @@ export function isDayDisabled(
   );
 }
 
-export function isDayExcluded(day, { excludeDates } = {}) {
+export function isDayExcluded(day, { excludeDates, excludeDateIntervals } = {}) {
+  if (excludeDateIntervals && excludeDateIntervals.length > 0) {
+    return excludeDateIntervals.some(({start, end}) => isWithinInterval(day, {start, end}))
+  }
   return (
     (excludeDates &&
       excludeDates.some((excludeDate) => isSameDay(day, excludeDate))) ||

--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -80,11 +80,16 @@ export function parseDate(value, dateFormat, locale, strictParsing, minDate) {
   let strictParsingValueMatch = true;
   if (Array.isArray(dateFormat)) {
     dateFormat.forEach((df) => {
-      let tryParseDate = parse(value, df, new Date(), { locale: localeObject });
+      let tryParseDate = parse(value, df, new Date(), {
+        locale: localeObject,
+      });
       if (strictParsing) {
         strictParsingValueMatch =
           isValid(tryParseDate, minDate) &&
-          value === format(tryParseDate, df, { awareOfUnicodeTokens: true });
+          value ===
+            format(tryParseDate, df, {
+              awareOfUnicodeTokens: true,
+            });
       }
       if (isValid(tryParseDate, minDate) && strictParsingValueMatch) {
         parsedDate = tryParseDate;
@@ -402,24 +407,43 @@ export function getQuarterShortInLocale(quarter, locale) {
 
 export function isDayDisabled(
   day,
-  { minDate, maxDate, excludeDates, excludeDateIntervals, includeDates, filterDate } = {}
+  {
+    minDate,
+    maxDate,
+    excludeDates,
+    excludeDateIntervals,
+    includeDates,
+    includeDateIntervals,
+    filterDate,
+  } = {}
 ) {
   return (
     isOutOfBounds(day, { minDate, maxDate }) ||
     (excludeDates &&
       excludeDates.some((excludeDate) => isSameDay(day, excludeDate))) ||
     (excludeDateIntervals &&
-      excludeDateIntervals.some(({start,end}) => isWithinInterval(day, {start, end}))) ||
+      excludeDateIntervals.some(({ start, end }) =>
+        isWithinInterval(day, { start, end })
+      )) ||
     (includeDates &&
       !includeDates.some((includeDate) => isSameDay(day, includeDate))) ||
+    (includeDateIntervals &&
+      !includeDateIntervals.some(({ start, end }) =>
+        isWithinInterval(day, { start, end })
+      )) ||
     (filterDate && !filterDate(newDate(day))) ||
     false
   );
 }
 
-export function isDayExcluded(day, { excludeDates, excludeDateIntervals } = {}) {
+export function isDayExcluded(
+  day,
+  { excludeDates, excludeDateIntervals } = {}
+) {
   if (excludeDateIntervals && excludeDateIntervals.length > 0) {
-    return excludeDateIntervals.some(({start, end}) => isWithinInterval(day, {start, end}))
+    return excludeDateIntervals.some(({ start, end }) =>
+      isWithinInterval(day, { start, end })
+    );
   }
   return (
     (excludeDates &&

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -157,6 +157,10 @@ export default class DatePicker extends React.Component {
     dropdownMode: PropTypes.oneOf(["scroll", "select"]).isRequired,
     endDate: PropTypes.instanceOf(Date),
     excludeDates: PropTypes.array,
+    excludeDateIntervals: PropTypes.arrayOf(PropTypes.shape({
+      start: PropTypes.instanceOf(Date),
+      end: PropTypes.instanceOf(Date)
+    })),
     filterDate: PropTypes.func,
     fixedHeight: PropTypes.bool,
     formatWeekNumber: PropTypes.func,
@@ -867,6 +871,7 @@ export default class DatePicker extends React.Component {
         startDate={this.props.startDate}
         endDate={this.props.endDate}
         excludeDates={this.props.excludeDates}
+        excludeDateIntervals={this.props.excludeDateIntervals}
         filterDate={this.props.filterDate}
         onClickOutside={this.handleCalendarClickOutside}
         formatWeekNumber={this.props.formatWeekNumber}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -157,16 +157,19 @@ export default class DatePicker extends React.Component {
     dropdownMode: PropTypes.oneOf(["scroll", "select"]).isRequired,
     endDate: PropTypes.instanceOf(Date),
     excludeDates: PropTypes.array,
-    excludeDateIntervals: PropTypes.arrayOf(PropTypes.shape({
-      start: PropTypes.instanceOf(Date),
-      end: PropTypes.instanceOf(Date)
-    })),
+    excludeDateIntervals: PropTypes.arrayOf(
+      PropTypes.shape({
+        start: PropTypes.instanceOf(Date),
+        end: PropTypes.instanceOf(Date),
+      })
+    ),
     filterDate: PropTypes.func,
     fixedHeight: PropTypes.bool,
     formatWeekNumber: PropTypes.func,
     highlightDates: PropTypes.array,
     id: PropTypes.string,
     includeDates: PropTypes.array,
+    includeDateIntervals: PropTypes.array,
     includeTimes: PropTypes.array,
     injectTimes: PropTypes.array,
     inline: PropTypes.bool,
@@ -877,6 +880,7 @@ export default class DatePicker extends React.Component {
         formatWeekNumber={this.props.formatWeekNumber}
         highlightDates={this.state.highlightDates}
         includeDates={this.props.includeDates}
+        includeDateIntervals={this.props.includeDateIntervals}
         includeTimes={this.props.includeTimes}
         injectTimes={this.props.injectTimes}
         inline={this.props.inline}

--- a/src/month.jsx
+++ b/src/month.jsx
@@ -18,6 +18,10 @@ export default class Month extends React.Component {
     endDate: PropTypes.instanceOf(Date),
     orderInDisplay: PropTypes.number,
     excludeDates: PropTypes.array,
+    excludeDateIntervals: PropTypes.arrayOf(PropTypes.shape({
+      start: PropTypes.instanceOf(Date),
+      end: PropTypes.instanceOf(Date)
+    })),
     filterDate: PropTypes.func,
     fixedHeight: PropTypes.bool,
     formatWeekNumber: PropTypes.func,
@@ -158,6 +162,7 @@ export default class Month extends React.Component {
           minDate={this.props.minDate}
           maxDate={this.props.maxDate}
           excludeDates={this.props.excludeDates}
+          excludeDateIntervals={this.props.excludeDateIntervals}
           includeDates={this.props.includeDates}
           inline={this.props.inline}
           shouldFocusDayInline={this.props.shouldFocusDayInline}

--- a/src/month.jsx
+++ b/src/month.jsx
@@ -18,15 +18,18 @@ export default class Month extends React.Component {
     endDate: PropTypes.instanceOf(Date),
     orderInDisplay: PropTypes.number,
     excludeDates: PropTypes.array,
-    excludeDateIntervals: PropTypes.arrayOf(PropTypes.shape({
-      start: PropTypes.instanceOf(Date),
-      end: PropTypes.instanceOf(Date)
-    })),
+    excludeDateIntervals: PropTypes.arrayOf(
+      PropTypes.shape({
+        start: PropTypes.instanceOf(Date),
+        end: PropTypes.instanceOf(Date),
+      })
+    ),
     filterDate: PropTypes.func,
     fixedHeight: PropTypes.bool,
     formatWeekNumber: PropTypes.func,
     highlightDates: PropTypes.instanceOf(Map),
     includeDates: PropTypes.array,
+    includeDateIntervals: PropTypes.array,
     inline: PropTypes.bool,
     shouldFocusDayInline: PropTypes.bool,
     locale: PropTypes.oneOfType([
@@ -164,6 +167,7 @@ export default class Month extends React.Component {
           excludeDates={this.props.excludeDates}
           excludeDateIntervals={this.props.excludeDateIntervals}
           includeDates={this.props.includeDates}
+          includeDateIntervals={this.props.includeDateIntervals}
           inline={this.props.inline}
           shouldFocusDayInline={this.props.shouldFocusDayInline}
           highlightDates={this.props.highlightDates}

--- a/src/week.jsx
+++ b/src/week.jsx
@@ -19,6 +19,10 @@ export default class Week extends React.Component {
     chooseDayAriaLabelPrefix: PropTypes.string,
     endDate: PropTypes.instanceOf(Date),
     excludeDates: PropTypes.array,
+    excludeDateIntervals: PropTypes.arrayOf(PropTypes.shape({
+      start: PropTypes.instanceOf(Date),
+      end: PropTypes.instanceOf(Date)
+    })),
     filterDate: PropTypes.func,
     formatWeekNumber: PropTypes.func,
     highlightDates: PropTypes.instanceOf(Map),
@@ -121,6 +125,7 @@ export default class Week extends React.Component {
             minDate={this.props.minDate}
             maxDate={this.props.maxDate}
             excludeDates={this.props.excludeDates}
+            excludeDateIntervals={this.props.excludeDateIntervals}
             includeDates={this.props.includeDates}
             highlightDates={this.props.highlightDates}
             selectingDate={this.props.selectingDate}

--- a/src/week.jsx
+++ b/src/week.jsx
@@ -19,14 +19,17 @@ export default class Week extends React.Component {
     chooseDayAriaLabelPrefix: PropTypes.string,
     endDate: PropTypes.instanceOf(Date),
     excludeDates: PropTypes.array,
-    excludeDateIntervals: PropTypes.arrayOf(PropTypes.shape({
-      start: PropTypes.instanceOf(Date),
-      end: PropTypes.instanceOf(Date)
-    })),
+    excludeDateIntervals: PropTypes.arrayOf(
+      PropTypes.shape({
+        start: PropTypes.instanceOf(Date),
+        end: PropTypes.instanceOf(Date),
+      })
+    ),
     filterDate: PropTypes.func,
     formatWeekNumber: PropTypes.func,
     highlightDates: PropTypes.instanceOf(Map),
     includeDates: PropTypes.array,
+    includeDateIntervals: PropTypes.array,
     inline: PropTypes.bool,
     shouldFocusDayInline: PropTypes.bool,
     locale: PropTypes.oneOfType([
@@ -127,6 +130,7 @@ export default class Week extends React.Component {
             excludeDates={this.props.excludeDates}
             excludeDateIntervals={this.props.excludeDateIntervals}
             includeDates={this.props.includeDates}
+            includeDateIntervals={this.props.includeDateIntervals}
             highlightDates={this.props.highlightDates}
             selectingDate={this.props.selectingDate}
             filterDate={this.props.filterDate}

--- a/test/date_utils_test.js
+++ b/test/date_utils_test.js
@@ -197,6 +197,36 @@ describe("date_utils", function () {
       const day = newDate();
       expect(isDayDisabled(day, { excludeDates: [day] })).to.be.true;
     });
+      
+    it("should be disabled if on excluded date interval start", () => {
+      const day = newDate();
+      expect(isDayDisabled(day, { excludeDateIntervals: [{start: day, end: addDays(day, 1)}] })).to.be.true;
+    });
+   
+    it("should be disabled if within excluded date interval", () => {
+      const day = newDate();
+      expect(isDayDisabled(day, { excludeDateIntervals: [{start: subDays(day, 1), end: addDays(day, 1)}] })).to.be.true;
+    });
+   
+    it("should be disabled if on excluded date interval end", () => {
+      const day = newDate();
+      expect(isDayDisabled(day, { excludeDateIntervals: [{start: subDays(day, 1), end: day}] })).to.be.true;
+    });
+   
+    it("should throw error if excluded date interval is invalid", () => {
+      const day = newDate();
+      expect(() => isDayDisabled(day, { excludeDateIntervals: [{start: addDays(day, 1), end: subDays(day, 1)}] })).to.throw('Invalid interval');
+    });
+   
+    it("should be enabled if excluded date interval is empty", () => {
+      const day = newDate();
+      expect(isDayDisabled(day, { excludeDateIntervals: [] })).to.be.false;
+    });
+   
+    it("should be enabled if not in excluded date interval", () => {
+      const day = newDate();
+      expect(isDayDisabled(day, { excludeDateIntervals: [{start: addDays(day, 1), end: addDays(day, 2)}] })).to.be.false;
+    });
 
     it("should be enabled if in included dates", () => {
       const day = newDate();
@@ -239,12 +269,37 @@ describe("date_utils", function () {
       expect(isDayExcluded(day)).to.be.false;
     });
 
-    it("should be excluded if in excluded dates", () => {
+    it("should be excluded if within excluded date interval", () => {
+      const day = newDate();
+      expect(isDayExcluded(day, { excludeDateIntervals: [{start: subDays(day, 1), end: addDays(day, 1)}] })).to.be.true;
+    });
+
+    it("should not be excluded if excluded date interval is empty", () => {
+      const day = newDate();
+      expect(isDayExcluded(day, { excludeDateIntervals: [] })).to.be.false;
+    });
+
+    it("should not be excluded if not within excluded date intervals", () => {
+      const day = newDate();
+      expect(isDayExcluded(day, { excludeDateIntervals: [{start: addDays(day, 1), end: addDays(day, 2)}] })).to.be.false;
+    });
+
+    it("should throw error if excluded date interval is invalid", () => {
+      const day = newDate();
+      expect(() => isDayExcluded(day, { excludeDateIntervals: [{start: addDays(day, 1), end: subDays(day, 1)}] })).to.be.throw('Invalid interval');
+    });
+
+    it("should not be excluded if in excluded dates and not within excluded date intervals", () => {
+      const day = newDate();
+      expect(isDayExcluded(day, { excludeDates: [day], excludeDateIntervals: [{start: addDays(day, 1), end: addDays(day, 2)}] })).to.be.false;
+    });
+    
+    it("should be excluded if in excluded dates and there are no excluded date intervals", () => {
       const day = newDate();
       expect(isDayExcluded(day, { excludeDates: [day] })).to.be.true;
     });
 
-    it("should not be excluded if not in excluded dates", () => {
+    it("should not be excluded if not in excluded dates and there are no excluded date intervals", () => {
       const day = newDate();
       const excludedDay = newDate();
       const currentMonth = excludedDay.getMonth();
@@ -359,7 +414,7 @@ describe("date_utils", function () {
       expect(isQuarterDisabled(day, { includeDates: [day] })).to.be.false;
     });
 
-    xit("should be disabled if not in included dates", () => {
+    it("should be disabled if not in included dates", () => {
       const day = newDate();
       const includeDates = [addDays(day, 40)];
       expect(isQuarterDisabled(day, { includeDates })).to.be.true;

--- a/test/date_utils_test.js
+++ b/test/date_utils_test.js
@@ -197,35 +197,61 @@ describe("date_utils", function () {
       const day = newDate();
       expect(isDayDisabled(day, { excludeDates: [day] })).to.be.true;
     });
-      
+
     it("should be disabled if on excluded date interval start", () => {
       const day = newDate();
-      expect(isDayDisabled(day, { excludeDateIntervals: [{start: day, end: addDays(day, 1)}] })).to.be.true;
+      expect(
+        isDayDisabled(day, {
+          excludeDateIntervals: [{ start: day, end: addDays(day, 1) }],
+        })
+      ).to.be.true;
     });
-   
+
     it("should be disabled if within excluded date interval", () => {
       const day = newDate();
-      expect(isDayDisabled(day, { excludeDateIntervals: [{start: subDays(day, 1), end: addDays(day, 1)}] })).to.be.true;
+      expect(
+        isDayDisabled(day, {
+          excludeDateIntervals: [
+            { start: subDays(day, 1), end: addDays(day, 1) },
+          ],
+        })
+      ).to.be.true;
     });
-   
+
     it("should be disabled if on excluded date interval end", () => {
       const day = newDate();
-      expect(isDayDisabled(day, { excludeDateIntervals: [{start: subDays(day, 1), end: day}] })).to.be.true;
+      expect(
+        isDayDisabled(day, {
+          excludeDateIntervals: [{ start: subDays(day, 1), end: day }],
+        })
+      ).to.be.true;
     });
-   
+
     it("should throw error if excluded date interval is invalid", () => {
       const day = newDate();
-      expect(() => isDayDisabled(day, { excludeDateIntervals: [{start: addDays(day, 1), end: subDays(day, 1)}] })).to.throw('Invalid interval');
+      expect(() =>
+        isDayDisabled(day, {
+          excludeDateIntervals: [
+            { start: addDays(day, 1), end: subDays(day, 1) },
+          ],
+        })
+      ).to.throw("Invalid interval");
     });
-   
+
     it("should be enabled if excluded date interval is empty", () => {
       const day = newDate();
       expect(isDayDisabled(day, { excludeDateIntervals: [] })).to.be.false;
     });
-   
+
     it("should be enabled if not in excluded date interval", () => {
       const day = newDate();
-      expect(isDayDisabled(day, { excludeDateIntervals: [{start: addDays(day, 1), end: addDays(day, 2)}] })).to.be.false;
+      expect(
+        isDayDisabled(day, {
+          excludeDateIntervals: [
+            { start: addDays(day, 1), end: addDays(day, 2) },
+          ],
+        })
+      ).to.be.false;
     });
 
     it("should be enabled if in included dates", () => {
@@ -233,10 +259,32 @@ describe("date_utils", function () {
       expect(isDayDisabled(day, { includeDates: [day] })).to.be.false;
     });
 
+    it("should be enabled if in included date intervals", () => {
+      const day = newDate();
+      expect(
+        isDayDisabled(day, {
+          includeDateIntervals: [
+            { start: subDays(day, 1), end: addDays(day, 1) },
+          ],
+        })
+      ).to.be.false;
+    });
+
     it("should be disabled if not in included dates", () => {
       const day = newDate();
       const includeDates = [addDays(day, 1)];
       expect(isDayDisabled(day, { includeDates })).to.be.true;
+    });
+
+    it("should be disabled if not in included dates", () => {
+      const day = newDate();
+      expect(
+        isDayDisabled(day, {
+          includeDateIntervals: [
+            { start: subDays(day, 10), end: subDays(day, 5) },
+          ],
+        })
+      ).to.be.true;
     });
 
     it("should be enabled if date filter returns true", () => {
@@ -271,7 +319,13 @@ describe("date_utils", function () {
 
     it("should be excluded if within excluded date interval", () => {
       const day = newDate();
-      expect(isDayExcluded(day, { excludeDateIntervals: [{start: subDays(day, 1), end: addDays(day, 1)}] })).to.be.true;
+      expect(
+        isDayExcluded(day, {
+          excludeDateIntervals: [
+            { start: subDays(day, 1), end: addDays(day, 1) },
+          ],
+        })
+      ).to.be.true;
     });
 
     it("should not be excluded if excluded date interval is empty", () => {
@@ -281,19 +335,38 @@ describe("date_utils", function () {
 
     it("should not be excluded if not within excluded date intervals", () => {
       const day = newDate();
-      expect(isDayExcluded(day, { excludeDateIntervals: [{start: addDays(day, 1), end: addDays(day, 2)}] })).to.be.false;
+      expect(
+        isDayExcluded(day, {
+          excludeDateIntervals: [
+            { start: addDays(day, 1), end: addDays(day, 2) },
+          ],
+        })
+      ).to.be.false;
     });
 
     it("should throw error if excluded date interval is invalid", () => {
       const day = newDate();
-      expect(() => isDayExcluded(day, { excludeDateIntervals: [{start: addDays(day, 1), end: subDays(day, 1)}] })).to.be.throw('Invalid interval');
+      expect(() =>
+        isDayExcluded(day, {
+          excludeDateIntervals: [
+            { start: addDays(day, 1), end: subDays(day, 1) },
+          ],
+        })
+      ).to.be.throw("Invalid interval");
     });
 
     it("should not be excluded if in excluded dates and not within excluded date intervals", () => {
       const day = newDate();
-      expect(isDayExcluded(day, { excludeDates: [day], excludeDateIntervals: [{start: addDays(day, 1), end: addDays(day, 2)}] })).to.be.false;
+      expect(
+        isDayExcluded(day, {
+          excludeDates: [day],
+          excludeDateIntervals: [
+            { start: addDays(day, 1), end: addDays(day, 2) },
+          ],
+        })
+      ).to.be.false;
     });
-    
+
     it("should be excluded if in excluded dates and there are no excluded date intervals", () => {
       const day = newDate();
       expect(isDayExcluded(day, { excludeDates: [day] })).to.be.true;

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -913,6 +913,31 @@ describe("DatePicker", () => {
       TestUtils.Simulate.keyDown(data.nodeInput, getKey("Enter"));
       expect(data.callback.calledOnce).to.be.false;
     });
+    describe("with excludeDateIntervals", () => {
+      it("should not select the start date of the interval", () => {
+        var data = getOnInputKeyDownStuff({
+          excludeDateIntervals: [{start: utils.subDays(utils.newDate(), 1), end: utils.addDays(utils.newDate(), 1)}]
+        });
+        TestUtils.Simulate.keyDown(data.nodeInput, getKey("ArrowLeft"));
+        TestUtils.Simulate.keyDown(data.nodeInput, getKey("Enter"));
+        expect(data.callback.calledOnce).to.be.false;
+      });
+      it("should not select a dates within the interval", () => {
+        var data = getOnInputKeyDownStuff({
+          excludeDateIntervals: [{start: utils.subDays(utils.newDate(), 1), end: utils.addDays(utils.newDate(), 1)}]
+        });
+        TestUtils.Simulate.keyDown(data.nodeInput, getKey("Enter"));
+        expect(data.callback.calledOnce).to.be.false;
+      });
+      it("should not select the end date of the interval", () => {
+        var data = getOnInputKeyDownStuff({
+          excludeDateIntervals: [{start: utils.subDays(utils.newDate(), 1), end: utils.addDays(utils.newDate(), 1)}]
+        });
+        TestUtils.Simulate.keyDown(data.nodeInput, getKey("ArrowRight"));
+        TestUtils.Simulate.keyDown(data.nodeInput, getKey("Enter"));
+        expect(data.callback.calledOnce).to.be.false;
+      });
+    });
     it("should not select dates excluded from filterDate", () => {
       var data = getOnInputKeyDownStuff({
         filterDate: (date) =>

--- a/test/day_test.js
+++ b/test/day_test.js
@@ -353,6 +353,18 @@ describe("Day", () => {
         });
         expect(shallowDay.hasClass(rangeDayClassName)).to.be.false;
       });
+
+      it("should not highlight for disabled dates within interval", () => {
+        const endDate = newDate();
+        const selectingDate = subDays(endDate, 1);
+        const shallowDay = renderDay(selectingDate, {
+          selectingDate,
+          endDate,
+          selectsStart: true,
+          excludeDateIntervals: [{start: subDays(selectingDate, 1), end: endDate}]
+        });
+        expect(shallowDay.hasClass(rangeDayClassName)).to.be.false;
+      });
     });
 
     describe("for an end date picker", () => {
@@ -430,6 +442,18 @@ describe("Day", () => {
           selectingDate,
           selectsEnd: true,
           excludeDates: [selectingDate],
+        });
+        expect(shallowDay.hasClass(rangeDayClassName)).to.be.false;
+      });
+
+      it("should not highlight for disabled dates within interval", () => {
+        const startDate = newDate();
+        const selectingDate = addDays(startDate, 1);
+        const shallowDay = renderDay(selectingDate, {
+          startDate,
+          selectingDate,
+          selectsEnd: true,
+          excludeDateIntervals: [{start: startDate, end: addDays(selectingDate, 1)}]
         });
         expect(shallowDay.hasClass(rangeDayClassName)).to.be.false;
       });
@@ -540,9 +564,21 @@ describe("Day", () => {
       expect(shallowDay.hasClass(className)).to.equal(true);
     });
 
+    it("should be disabled if date is within excluded interval", () => {
+      const day = newDate();
+      const shallowDay = renderDay(day, { excludeDateIntervals: [{start: subDays(day, 1), end: addDays(day, 1)}] });
+      expect(shallowDay.hasClass(className)).to.equal(true);
+    });
+
     it("should have aria-disabled attribute with true value if date is disabled", () => {
       const day = newDate();
       const shallowDay = renderDay(day, { excludeDates: [day] });
+      expect(shallowDay.prop("aria-disabled")).to.equal(true);
+    });
+
+    it("should have aria-disabled attribute with true value if date is within excluded interval", () => {
+      const day = newDate();
+      const shallowDay = renderDay(day, { excludeDateIntervals: [{start: subDays(day, 1), end: addDays(day, 1)}] });
       expect(shallowDay.prop("aria-disabled")).to.equal(true);
     });
 
@@ -572,6 +608,17 @@ describe("Day", () => {
       const shallowDay = renderDay(day, {
         ariaLabelPrefixWhenDisabled: ariaLabelPrefixWhenDisabled,
         excludeDates: [day],
+      });
+      expect(
+        shallowDay.html().indexOf(`aria-label="${ariaLabelPrefixWhenDisabled}`)
+      ).not.equal(-1);
+    });
+
+    it("should have the correct provided prefix if date is within excluded interval", () => {
+      const day = newDate();
+      const shallowDay = renderDay(day, {
+        ariaLabelPrefixWhenDisabled: ariaLabelPrefixWhenDisabled,
+        excludeDateIntervals: [{start: subDays(day, 1), end: addDays(day, 1)}]
       });
       expect(
         shallowDay.html().indexOf(`aria-label="${ariaLabelPrefixWhenDisabled}`)
@@ -620,6 +667,15 @@ describe("Day", () => {
       const day = newDate();
       const dayNode = shallow(
         <Day day={day} excludeDates={[day]} onClick={onClick} />
+      );
+      dayNode.find(".react-datepicker__day").simulate("click");
+      expect(onClickCalled).to.be.false;
+    });
+
+    it("should not call onClick if day is within excluded interval", () => {
+      const day = newDate();
+      const dayNode = shallow(
+        <Day day={day} excludeDateIntervals={[{start: subDays(day, 1), end: addDays(day, 1)}]} onClick={onClick} />
       );
       dayNode.find(".react-datepicker__day").simulate("click");
       expect(onClickCalled).to.be.false;
@@ -736,7 +792,7 @@ describe("Day", () => {
       expect(shallowDay.hasClass(rangeDayClassName)).to.be.false;
     });
 
-    it("should not highlight for disabled dates", () => {
+    it("should not highlight for disabled (excluded) dates", () => {
       const endDate = newDate();
       const selectingDate = subDays(endDate, 1);
       const shallowDay = renderDay(selectingDate, {
@@ -744,6 +800,18 @@ describe("Day", () => {
         endDate,
         selectsRange: true,
         excludeDates: [selectingDate],
+      });
+      expect(shallowDay.hasClass(rangeDayClassName)).to.be.false;
+    });
+    
+    it("should not highlight for disabled (within excluded interval) dates", () => {
+      const endDate = newDate();
+      const selectingDate = subDays(endDate, 1);
+      const shallowDay = renderDay(selectingDate, {
+        selectingDate,
+        endDate,
+        selectsRange: true,
+        excludeDateIntervals: [{start: selectingDate, end: endDate}]
       });
       expect(shallowDay.hasClass(rangeDayClassName)).to.be.false;
     });


### PR DESCRIPTION
Added properties to exclude and include dates from one or many intervals.

This is intended to make it easier to define these ranges when there are a large number of dates included (eg: a year or more), since it only needs pairs of start and end dates, instead of the array of all the specific dates needed for excludeDates and includeDates.

The term "intervals" is kept instead of "range" because both props need to be fed with intervals as defined by date-fns. It could be changed, however, if needed.