### PR TITLE
Fix isValid helper so it accepts dates equal to minDate (#3262)

### DIFF
--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -132,7 +132,7 @@ export { isDate };
 
 export function isValid(date, minDate) {
   minDate = minDate ? minDate : new Date("1/1/1000");
-  return isValidDate(date) && isAfter(date, minDate);
+  return isValidDate(date) && !isBefore(date, minDate);
 }
 
 // ** Date Formatting **

--- a/test/date_utils_test.js
+++ b/test/date_utils_test.js
@@ -12,6 +12,7 @@ import {
   isDayExcluded,
   isMonthDisabled,
   isQuarterDisabled,
+  isValid,
   monthDisabledBefore,
   monthDisabledAfter,
   yearDisabledBefore,
@@ -386,6 +387,17 @@ describe("date_utils", function () {
       };
       isQuarterDisabled(day, { filterDate });
       expect(isEqual(day, dayClone)).to.be.true;
+    });
+  });
+
+  describe("isValid", () => {
+    it("should return true if date is valid and equal or after minDate", () => {
+      expect(isValid(newDate("2021-11-15"), newDate("2021-11-15"))).to.be.true;
+      expect(isValid(newDate("2021-11-30"), newDate("2021-11-15"))).to.be.true;
+    });
+
+    it("should return false if date is valid and before minDate", () => {
+      expect(isValid(newDate("2021-11-01"), newDate("2021-11-15"))).to.be.false;
     });
   });
 


### PR DESCRIPTION
Argument `minDate` suggest that date should be equal or higher than it, but previous version wasn't accepting equal date. This solves the issue of not being able to input `minDate` via keyboard when `dateFormat` array was set.