### PR TITLE
Add selectsDisabledDaysInRange prop to allow highlighting disabled dates in range

### DIFF
--- a/docs-site/src/components/Examples/index.js
+++ b/docs-site/src/components/Examples/index.js
@@ -85,6 +85,7 @@ import CustomTimeInput from "../../examples/customTimeInput";
 import CloseOnScroll from "../../examples/closeOnScroll";
 import CloseOnScrollCallback from "../../examples/closeOnScrollCallback";
 import SelectsRange from "../../examples/selectsRange";
+import selectsRangeWithDisabledDates from "../../examples/selectsRangeWithDisabledDates";
 import CalendarStartDay from "../../examples/calendarStartDay";
 
 import "./style.scss";
@@ -188,6 +189,10 @@ export default class exampleComponents extends React.Component {
     {
       title: "Date range for one datepicker",
       component: SelectsRange,
+    },
+    {
+      title: "Date range for one datepicker with disabled dates highlighted",
+      component: selectsRangeWithDisabledDates,
     },
     {
       title: "Date Range with disabled navigation shown",

--- a/docs-site/src/examples/selectsRangeWithDisabledDates.js
+++ b/docs-site/src/examples/selectsRangeWithDisabledDates.js
@@ -1,0 +1,21 @@
+() => {
+  const [startDate, setStartDate] = useState(new Date());
+  const [endDate, setEndDate] = useState(null);
+  const onChange = (dates) => {
+    const [start, end] = dates;
+    setStartDate(start);
+    setEndDate(end);
+  };
+  return (
+    <DatePicker
+      selected={startDate}
+      onChange={onChange}
+      startDate={startDate}
+      endDate={endDate}
+      excludeDates={[addDays(new Date(), 1), addDays(new Date(), 5)]}
+      selectsRange
+      selectsDisabledDaysInRange
+      inline
+    />
+  );
+};

--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -159,6 +159,7 @@ export default class Calendar extends React.Component {
     selectsEnd: PropTypes.bool,
     selectsStart: PropTypes.bool,
     selectsRange: PropTypes.bool,
+    selectsDisabledDaysInRange: PropTypes.bool,
     showMonthDropdown: PropTypes.bool,
     showPreviousMonths: PropTypes.bool,
     showMonthYearDropdown: PropTypes.bool,
@@ -874,6 +875,7 @@ export default class Calendar extends React.Component {
             selectsStart={this.props.selectsStart}
             selectsEnd={this.props.selectsEnd}
             selectsRange={this.props.selectsRange}
+            selectsDisabledDaysInRange={this.props.selectsDisabledDaysInRange}
             showWeekNumbers={this.props.showWeekNumbers}
             startDate={this.props.startDate}
             endDate={this.props.endDate}

--- a/src/day.jsx
+++ b/src/day.jsx
@@ -37,6 +37,7 @@ export default class Day extends React.Component {
     selectsEnd: PropTypes.bool,
     selectsStart: PropTypes.bool,
     selectsRange: PropTypes.bool,
+    selectsDisabledDaysInRange: PropTypes.bool,
     startDate: PropTypes.instanceOf(Date),
     renderDayContents: PropTypes.func,
     handleOnKeyDown: PropTypes.func,
@@ -116,15 +117,22 @@ export default class Day extends React.Component {
   };
 
   isInSelectingRange = () => {
-    const { day, selectsStart, selectsEnd, selectsRange, startDate, endDate } =
-      this.props;
+    const {
+      day,
+      selectsStart,
+      selectsEnd,
+      selectsRange,
+      selectsDisabledDaysInRange,
+      startDate,
+      endDate,
+    } = this.props;
 
     const selectingDate = this.props.selectingDate ?? this.props.preSelection;
 
     if (
       !(selectsStart || selectsEnd || selectsRange) ||
       !selectingDate ||
-      this.isDisabled()
+      (!selectsDisabledDaysInRange && this.isDisabled())
     ) {
       return false;
     }

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -89,6 +89,7 @@ export default class DatePicker extends React.Component {
       monthsShown: 1,
       readOnly: false,
       withPortal: false,
+      selectsDisabledDaysInRange: false,
       shouldCloseOnSelect: true,
       showTimeSelect: false,
       showTimeInput: false,
@@ -214,6 +215,7 @@ export default class DatePicker extends React.Component {
     selectsEnd: PropTypes.bool,
     selectsStart: PropTypes.bool,
     selectsRange: PropTypes.bool,
+    selectsDisabledDaysInRange: PropTypes.bool,
     showMonthDropdown: PropTypes.bool,
     showPreviousMonths: PropTypes.bool,
     showMonthYearDropdown: PropTypes.bool,
@@ -940,6 +942,7 @@ export default class DatePicker extends React.Component {
         renderDayContents={this.props.renderDayContents}
         onDayMouseEnter={this.props.onDayMouseEnter}
         onMonthMouseLeave={this.props.onMonthMouseLeave}
+        selectsDisabledDaysInRange={this.props.selectsDisabledDaysInRange}
         showTimeInput={this.props.showTimeInput}
         showMonthYearPicker={this.props.showMonthYearPicker}
         showFullMonthYearPicker={this.props.showFullMonthYearPicker}

--- a/src/month.jsx
+++ b/src/month.jsx
@@ -51,6 +51,7 @@ export default class Month extends React.Component {
     selectsEnd: PropTypes.bool,
     selectsStart: PropTypes.bool,
     selectsRange: PropTypes.bool,
+    selectsDisabledDaysInRange: PropTypes.bool,
     showWeekNumbers: PropTypes.bool,
     startDate: PropTypes.instanceOf(Date),
     setOpen: PropTypes.func,
@@ -178,6 +179,7 @@ export default class Month extends React.Component {
           selectsStart={this.props.selectsStart}
           selectsEnd={this.props.selectsEnd}
           selectsRange={this.props.selectsRange}
+          selectsDisabledDaysInRange={this.props.selectsDisabledDaysInRange}
           showWeekNumber={this.props.showWeekNumbers}
           startDate={this.props.startDate}
           endDate={this.props.endDate}

--- a/src/week.jsx
+++ b/src/week.jsx
@@ -49,6 +49,7 @@ export default class Week extends React.Component {
     selectsEnd: PropTypes.bool,
     selectsStart: PropTypes.bool,
     selectsRange: PropTypes.bool,
+    selectsDisabledDaysInRange: PropTypes.bool,
     showWeekNumber: PropTypes.bool,
     startDate: PropTypes.instanceOf(Date),
     setOpen: PropTypes.func,
@@ -139,6 +140,7 @@ export default class Week extends React.Component {
             selectsStart={this.props.selectsStart}
             selectsEnd={this.props.selectsEnd}
             selectsRange={this.props.selectsRange}
+            selectsDisabledDaysInRange={this.props.selectsDisabledDaysInRange}
             startDate={this.props.startDate}
             endDate={this.props.endDate}
             dayClassName={this.props.dayClassName}

--- a/test/day_test.js
+++ b/test/day_test.js
@@ -342,7 +342,7 @@ describe("Day", () => {
         expect(shallowDay.hasClass(rangeDayClassName)).to.be.false;
       });
 
-      it("should not highlight for disabled dates", () => {
+      it("should not highlight for disabled dates when selectsDisabledDaysInRange is false (default)", () => {
         const endDate = newDate();
         const selectingDate = subDays(endDate, 1);
         const shallowDay = renderDay(selectingDate, {
@@ -354,16 +354,46 @@ describe("Day", () => {
         expect(shallowDay.hasClass(rangeDayClassName)).to.be.false;
       });
 
-      it("should not highlight for disabled dates within interval", () => {
+      it("should highlight for disabled dates when selectsDisabledDaysInRange is true", () => {
         const endDate = newDate();
         const selectingDate = subDays(endDate, 1);
         const shallowDay = renderDay(selectingDate, {
           selectingDate,
           endDate,
           selectsStart: true,
-          excludeDateIntervals: [{start: subDays(selectingDate, 1), end: endDate}]
+          excludeDates: [selectingDate],
+          selectsDisabledDaysInRange: true,
+        });
+        expect(shallowDay.hasClass(rangeDayClassName)).to.be.true;
+      });
+
+      it("should not highlight for disabled dates within interval when selectsDisabledDaysInRange is false (default)", () => {
+        const endDate = newDate();
+        const selectingDate = subDays(endDate, 1);
+        const shallowDay = renderDay(selectingDate, {
+          selectingDate,
+          endDate,
+          selectsStart: true,
+          excludeDateIntervals: [
+            { start: subDays(selectingDate, 1), end: endDate },
+          ],
         });
         expect(shallowDay.hasClass(rangeDayClassName)).to.be.false;
+      });
+
+      it("should highlight for disabled dates within interval when selectsDisabledDaysInRange is true", () => {
+        const endDate = newDate();
+        const selectingDate = subDays(endDate, 1);
+        const shallowDay = renderDay(selectingDate, {
+          selectingDate,
+          endDate,
+          selectsStart: true,
+          excludeDateIntervals: [
+            { start: subDays(selectingDate, 1), end: endDate },
+          ],
+          selectsDisabledDaysInRange: true,
+        });
+        expect(shallowDay.hasClass(rangeDayClassName)).to.be.true;
       });
     });
 
@@ -434,7 +464,7 @@ describe("Day", () => {
         expect(shallowDay.hasClass(rangeDayClassName)).to.be.false;
       });
 
-      it("should not highlight for disabled dates", () => {
+      it("should not highlight for disabled dates when selectsDisabledDaysInRange is false (default)", () => {
         const startDate = newDate();
         const selectingDate = addDays(startDate, 1);
         const shallowDay = renderDay(selectingDate, {
@@ -446,16 +476,46 @@ describe("Day", () => {
         expect(shallowDay.hasClass(rangeDayClassName)).to.be.false;
       });
 
-      it("should not highlight for disabled dates within interval", () => {
+      it("should highlight for disabled dates when selectsDisabledDaysInRange is true", () => {
         const startDate = newDate();
         const selectingDate = addDays(startDate, 1);
         const shallowDay = renderDay(selectingDate, {
           startDate,
           selectingDate,
           selectsEnd: true,
-          excludeDateIntervals: [{start: startDate, end: addDays(selectingDate, 1)}]
+          excludeDates: [selectingDate],
+          selectsDisabledDaysInRange: true,
+        });
+        expect(shallowDay.hasClass(rangeDayClassName)).to.be.true;
+      });
+
+      it("should not highlight for disabled dates within interval when selectsDisabledDaysInRange is false (default)", () => {
+        const startDate = newDate();
+        const selectingDate = addDays(startDate, 1);
+        const shallowDay = renderDay(selectingDate, {
+          startDate,
+          selectingDate,
+          selectsEnd: true,
+          excludeDateIntervals: [
+            { start: startDate, end: addDays(selectingDate, 1) },
+          ],
         });
         expect(shallowDay.hasClass(rangeDayClassName)).to.be.false;
+      });
+
+      it("should highlight for disabled dates within interval when selectsDisabledDaysInRange is true", () => {
+        const startDate = newDate();
+        const selectingDate = addDays(startDate, 1);
+        const shallowDay = renderDay(selectingDate, {
+          startDate,
+          selectingDate,
+          selectsEnd: true,
+          excludeDateIntervals: [
+            { start: startDate, end: addDays(selectingDate, 1) },
+          ],
+          selectsDisabledDaysInRange: true,
+        });
+        expect(shallowDay.hasClass(rangeDayClassName)).to.be.true;
       });
     });
   });
@@ -566,7 +626,11 @@ describe("Day", () => {
 
     it("should be disabled if date is within excluded interval", () => {
       const day = newDate();
-      const shallowDay = renderDay(day, { excludeDateIntervals: [{start: subDays(day, 1), end: addDays(day, 1)}] });
+      const shallowDay = renderDay(day, {
+        excludeDateIntervals: [
+          { start: subDays(day, 1), end: addDays(day, 1) },
+        ],
+      });
       expect(shallowDay.hasClass(className)).to.equal(true);
     });
 
@@ -578,7 +642,11 @@ describe("Day", () => {
 
     it("should have aria-disabled attribute with true value if date is within excluded interval", () => {
       const day = newDate();
-      const shallowDay = renderDay(day, { excludeDateIntervals: [{start: subDays(day, 1), end: addDays(day, 1)}] });
+      const shallowDay = renderDay(day, {
+        excludeDateIntervals: [
+          { start: subDays(day, 1), end: addDays(day, 1) },
+        ],
+      });
       expect(shallowDay.prop("aria-disabled")).to.equal(true);
     });
 
@@ -618,7 +686,9 @@ describe("Day", () => {
       const day = newDate();
       const shallowDay = renderDay(day, {
         ariaLabelPrefixWhenDisabled: ariaLabelPrefixWhenDisabled,
-        excludeDateIntervals: [{start: subDays(day, 1), end: addDays(day, 1)}]
+        excludeDateIntervals: [
+          { start: subDays(day, 1), end: addDays(day, 1) },
+        ],
       });
       expect(
         shallowDay.html().indexOf(`aria-label="${ariaLabelPrefixWhenDisabled}`)
@@ -675,7 +745,13 @@ describe("Day", () => {
     it("should not call onClick if day is within excluded interval", () => {
       const day = newDate();
       const dayNode = shallow(
-        <Day day={day} excludeDateIntervals={[{start: subDays(day, 1), end: addDays(day, 1)}]} onClick={onClick} />
+        <Day
+          day={day}
+          excludeDateIntervals={[
+            { start: subDays(day, 1), end: addDays(day, 1) },
+          ]}
+          onClick={onClick}
+        />
       );
       dayNode.find(".react-datepicker__day").simulate("click");
       expect(onClickCalled).to.be.false;
@@ -803,7 +879,7 @@ describe("Day", () => {
       });
       expect(shallowDay.hasClass(rangeDayClassName)).to.be.false;
     });
-    
+
     it("should not highlight for disabled (within excluded interval) dates", () => {
       const endDate = newDate();
       const selectingDate = subDays(endDate, 1);
@@ -811,7 +887,7 @@ describe("Day", () => {
         selectingDate,
         endDate,
         selectsRange: true,
-        excludeDateIntervals: [{start: selectingDate, end: endDate}]
+        excludeDateIntervals: [{ start: selectingDate, end: endDate }],
       });
       expect(shallowDay.hasClass(rangeDayClassName)).to.be.false;
     });


### PR DESCRIPTION
By default, disabled dates are not considered for highlighting when hovering over an end date when range selection is enabled (the disabled Day component does not get the `react-datepicker__day--in-selecting-range` class).

This PR adds a prop `selectsDisabledDaysInRange` for changing this behavior and allow for disabled dates to be highlighted on range hover.

By default `selectsDisabledDaysInRange` is set to false so the current functionality is maintained.

Tests and an example for using the prop were added as well.