### PR TITLE
Fix aria label text when current focused date is same as user selected date

### DIFF
--- a/src/day.jsx
+++ b/src/day.jsx
@@ -21,6 +21,9 @@ export default class Day extends React.Component {
   static propTypes = {
     ariaLabelPrefixWhenEnabled: PropTypes.string,
     ariaLabelPrefixWhenDisabled: PropTypes.string,
+    ariaLabelPrefixWhenDateIsSame: PropTypes.string,
+    ariaLabelSuffixWhenDateIsNotSame: PropTypes.string,
+    ariaLabelSuffixWhenDateIsSame: PropTypes.string,
     disabledKeyboardNavigation: PropTypes.bool,
     day: PropTypes.instanceOf(Date).isRequired,
     dayClassName: PropTypes.func,
@@ -257,14 +260,23 @@ export default class Day extends React.Component {
       day,
       ariaLabelPrefixWhenEnabled = "Choose",
       ariaLabelPrefixWhenDisabled = "Not available",
+      ariaLabelPrefixWhenDateIsSame = "",
+      ariaLabelSuffixWhenDateIsNotSame = "",
+      ariaLabelSuffixWhenDateIsSame = "Selected",
     } = this.props;
 
     const prefix =
       this.isDisabled() || this.isExcluded()
         ? ariaLabelPrefixWhenDisabled
+        : this.isSameDay(this.props.selected)
+        ? ariaLabelPrefixWhenDateIsSame
         : ariaLabelPrefixWhenEnabled;
 
-    return `${prefix} ${formatDate(day, "PPPP", this.props.locale)}`;
+    const suffix = this.isSameDay(this.props.selected)
+      ? ariaLabelSuffixWhenDateIsSame
+      : ariaLabelSuffixWhenDateIsNotSame;
+
+    return `${prefix} ${formatDate(day, "PPPP", this.props.locale)} ${suffix}`;
   };
 
   getTabIndex = (selected, preSelection) => {

--- a/test/day_test.js
+++ b/test/day_test.js
@@ -658,9 +658,13 @@ describe("Day", () => {
 
   describe("aria-label", () => {
     const ariaLabelPrefixWhenEnabled =
-      "A prefix in my native language desbribing that the date can be selected";
+      "A prefix in my native language describing that the date can be selected";
     const ariaLabelPrefixWhenDisabled =
-      "A prefix in my native language desbribing that the date can not be selected";
+      "A prefix in my native language describing that the date can not be selected";
+    const ariaLabelPrefixWhenDateIsSame = "An empty prefix is expected";
+    const ariaLabelSuffixWhenDateIsSame =
+      "A suffix in my native language describing that the date is selected";
+    const ariaLabelSuffixWhenDateIsNotSame = "An empty suffix is expected";
 
     it("should have the correct provided prefix if date is not disabled", () => {
       const shallowDay = renderDay(newDate(), {
@@ -692,6 +696,41 @@ describe("Day", () => {
       });
       expect(
         shallowDay.html().indexOf(`aria-label="${ariaLabelPrefixWhenDisabled}`)
+      ).not.equal(-1);
+    });
+
+    it("should have the correct provided prefix if focused day is the current selected", () => {
+      const day = newDate();
+      const shallowDay = renderDay(day, {
+        ariaLabelPrefixWhenDateIsSame: ariaLabelPrefixWhenDateIsSame,
+        selected: day,
+      });
+      expect(
+        shallowDay
+          .html()
+          .indexOf(`aria-label="${ariaLabelPrefixWhenDateIsSame}`)
+      ).not.equal(-1);
+    });
+
+    it("should have the correct provided suffix if focused day is the current selected", () => {
+      const day = newDate();
+      const shallowDay = renderDay(day, {
+        ariaLabelSuffixWhenDateIsSame: ariaLabelSuffixWhenDateIsSame,
+        selected: day,
+      });
+      expect(
+        shallowDay.html().indexOf(ariaLabelSuffixWhenDateIsSame)
+      ).not.equal(-1);
+    });
+
+    it("should have the correct provided suffix if focused day is not the current selected", () => {
+      const day = newDate();
+      const shallowDay = renderDay(day, {
+        ariaLabelSuffixWhenDateIsNotSame: ariaLabelSuffixWhenDateIsNotSame,
+        selected: addDays(day, 1),
+      });
+      expect(
+        shallowDay.html().indexOf(ariaLabelSuffixWhenDateIsNotSame)
       ).not.equal(-1);
     });
 


### PR DESCRIPTION
**What does this PR do?**
This PR fixes wrong aria label text when focused day is the user selected date.

**Actual Result:**
Narrator Behavior: If May 24th date is selected, Narrator is announcing as "Choose Monday, May 24th, 2021, button,". Similarly when narrator focus is on other dates which is not selected narrator is announcing in same manner. (Eg., Choose Tuesday, May 25th, 2021, button,).

**Expected Result:**
For selected dates, Narrator should announce as "<Day>, <Date>, 2021, selected, button," (Eg: Monday, May 24th, 2021, Selected, button,) and for other dates it should announce as "Choose <day>, <date>, 2021, button,"

**Related Issue**
[# Issue 3160](https://github.com/Hacker0x01/react-datepicker/issues/3160)