### PR TITLE
Fix year dropdown scroll on open

### DIFF
--- a/src/year_dropdown_options.jsx
+++ b/src/year_dropdown_options.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { createRef } from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
 import { getYear } from "./date_utils";
@@ -50,6 +50,15 @@ export default class YearDropdownOptions extends React.Component {
         this.props.maxDate
       ),
     };
+    this.dropdownRef = createRef();
+  }
+
+  componentDidMount() {
+    const dropdownCurrent = this.dropdownRef.current;
+    if (dropdownCurrent) {
+      dropdownCurrent.scrollTop =
+        dropdownCurrent.scrollHeight / 2 - dropdownCurrent.clientHeight / 2;
+    }
   }
 
   renderOptions = () => {
@@ -136,6 +145,10 @@ export default class YearDropdownOptions extends React.Component {
         this.props.scrollableYearDropdown,
     });
 
-    return <div className={dropdownClass}>{this.renderOptions()}</div>;
+    return (
+      <div className={dropdownClass} ref={this.dropdownRef}>
+        {this.renderOptions()}
+      </div>
+    );
   }
 }

--- a/test/year_dropdown_options_test.js
+++ b/test/year_dropdown_options_test.js
@@ -364,4 +364,25 @@ describe("YearDropdownOptions with scrollable dropwdown", () => {
     );
     expect(yearDropdown.state().yearsList.length).to.equal(51);
   });
+
+  it("should scroll year dropdown to the middle on open", () => {
+    const onCancelSpy = sandbox.spy();
+    const onChangeSpy = sandbox.spy();
+    const yearDropdownInstance = mount(
+      <YearDropdownOptions
+        onCancel={onCancelSpy}
+        onChange={onChangeSpy}
+        scrollableYearDropdown
+        year={2015}
+        yearDropdownItemNumber={25}
+      />
+    ).instance();
+
+    yearDropdownInstance.dropdownRef.current = {
+      scrollHeight: 800,
+      clientHeight: 400,
+    };
+    yearDropdownInstance.componentDidMount();
+    expect(yearDropdownInstance.dropdownRef.current.scrollTop).to.equal(200);
+  });
 });


### PR DESCRIPTION
Related issue:https://github.com/Hacker0x01/react-datepicker/issues/3318

Scroll the year to current selected year for scrollable year dropdown on open.

Before:
![image](https://user-images.githubusercontent.com/12154828/145165484-55628b75-ac6a-4953-85bf-6106cfb33fdb.png)

After: 
![image](https://user-images.githubusercontent.com/12154828/145165539-97d5c0a1-f5e3-4471-a6f7-dbe6429a93c7.png)
