### PR TITLE
Accessibility: current date should use aria-current="date"

### DIFF
--- a/src/day.jsx
+++ b/src/day.jsx
@@ -223,6 +223,8 @@ export default class Day extends React.Component {
     );
   };
 
+  isCurrentDay = () => this.isSameDay(newDate());
+
   getClassNames = (date) => {
     const dayClassName = this.props.dayClassName
       ? this.props.dayClassName(date)
@@ -244,7 +246,7 @@ export default class Day extends React.Component {
           this.isSelectingRangeStart(),
         "react-datepicker__day--selecting-range-end":
           this.isSelectingRangeEnd(),
-        "react-datepicker__day--today": this.isSameDay(newDate()),
+        "react-datepicker__day--today": this.isCurrentDay(),
         "react-datepicker__day--weekend": this.isWeekend(),
         "react-datepicker__day--outside-month": this.isOutsideMonth(),
       },
@@ -343,7 +345,7 @@ export default class Day extends React.Component {
       aria-label={this.getAriaLabel()}
       role="button"
       aria-disabled={this.isDisabled()}
-      aria-current={this.isSameDay(newDate()) ? "date" : undefined}
+      aria-current={this.isCurrentDay() ? "date" : undefined}
     >
       {this.renderDayContents()}
     </div>

--- a/src/day.jsx
+++ b/src/day.jsx
@@ -343,6 +343,7 @@ export default class Day extends React.Component {
       aria-label={this.getAriaLabel()}
       role="button"
       aria-disabled={this.isDisabled()}
+      aria-current={this.isSameDay(newDate()) ? "date" : undefined}
     >
       {this.renderDayContents()}
     </div>

--- a/src/month.jsx
+++ b/src/month.jsx
@@ -362,6 +362,7 @@ export default class Month extends React.Component {
       showTwoColumnMonthYearPicker,
       showFourColumnMonthYearPicker,
       locale,
+      day,
     } = this.props;
     const monthsFourColumns = [
       [0, 1, 2, 3],
@@ -403,6 +404,12 @@ export default class Month extends React.Component {
             className={this.getMonthClassNames(m)}
             role="button"
             aria-label={this.getAriaLabel(m)}
+            aria-current={
+              utils.getYear(day) === utils.getYear(utils.newDate()) &&
+              m === utils.getMonth(utils.newDate())
+                ? "date"
+                : undefined
+            }
           >
             {showFullMonthYearPicker
               ? utils.getMonthInLocale(m, locale)

--- a/src/month.jsx
+++ b/src/month.jsx
@@ -137,6 +137,10 @@ export default class Month extends React.Component {
     );
   };
 
+  isCurrentMonth = (day, m) =>
+    utils.getYear(day) === utils.getYear(utils.newDate()) &&
+    m === utils.getMonth(utils.newDate());
+
   renderWeeks = () => {
     const weeks = [];
     var isFixedHeight = this.props.fixedHeight;
@@ -299,9 +303,7 @@ export default class Month extends React.Component {
         ),
         "react-datepicker__month--range-start": this.isRangeStartMonth(m),
         "react-datepicker__month--range-end": this.isRangeEndMonth(m),
-        "react-datepicker__month-text--today":
-          utils.getYear(day) === utils.getYear(utils.newDate()) &&
-          m === utils.getMonth(utils.newDate()),
+        "react-datepicker__month-text--today": this.isCurrentMonth(day, m),
       }
     );
   };
@@ -404,12 +406,7 @@ export default class Month extends React.Component {
             className={this.getMonthClassNames(m)}
             role="button"
             aria-label={this.getAriaLabel(m)}
-            aria-current={
-              utils.getYear(day) === utils.getYear(utils.newDate()) &&
-              m === utils.getMonth(utils.newDate())
-                ? "date"
-                : undefined
-            }
+            aria-current={this.isCurrentMonth(day, m) ? "date" : undefined}
           >
             {showFullMonthYearPicker
               ? utils.getMonthInLocale(m, locale)

--- a/src/year.jsx
+++ b/src/year.jsx
@@ -60,6 +60,8 @@ export default class Year extends React.Component {
 
   isSameDay = (y, other) => utils.isSameDay(y, other);
 
+  isCurrentYear = (y) => y === getYear(newDate());
+
   isKeyboardSelected = (y) => {
     const date = utils.getStartOfYear(utils.setYear(this.props.date, y));
     return (
@@ -107,7 +109,7 @@ export default class Year extends React.Component {
         (minDate || maxDate) && utils.isYearDisabled(y, this.props),
       "react-datepicker__year-text--keyboard-selected":
         this.isKeyboardSelected(y),
-      "react-datepicker__year-text--today": y === getYear(newDate()),
+      "react-datepicker__year-text--today": this.isCurrentYear(y),
     });
   };
 
@@ -139,7 +141,7 @@ export default class Year extends React.Component {
           tabIndex={this.getYearTabIndex(y)}
           className={this.getYearClassNames(y)}
           key={y}
-          aria-current={y === getYear(newDate()) ? "date" : undefined}
+          aria-current={this.isCurrentYear(y) ? "date" : undefined}
         >
           {y}
         </div>

--- a/src/year.jsx
+++ b/src/year.jsx
@@ -139,6 +139,7 @@ export default class Year extends React.Component {
           tabIndex={this.getYearTabIndex(y)}
           className={this.getYearClassNames(y)}
           key={y}
+          aria-current={y === getYear(newDate()) ? "date" : undefined}
         >
           {y}
         </div>

--- a/test/day_test.js
+++ b/test/day_test.js
@@ -528,9 +528,23 @@ describe("Day", () => {
       expect(shallowDay.hasClass(className)).to.equal(true);
     });
 
+    it("should apply the aria-current date attribute if today", () => {
+      const shallowDay = renderDay(newDate());
+      const currentAriaProp = shallowDay.prop("aria-current");
+
+      expect(currentAriaProp).to.equal("date");
+    });
+
     it("should not apply the today class if not today", () => {
       const shallowDay = renderDay(addDays(newDate(), 1));
       expect(shallowDay.hasClass(className)).to.equal(false);
+    });
+
+    it("should not apply the aria-current date attribute if not today", () => {
+      const shallowDay = renderDay(addDays(newDate(), 1));
+      const currentAriaProp = shallowDay.prop("aria-current");
+
+      expect(currentAriaProp).to.be.undefined;
     });
   });
 

--- a/test/day_test.js
+++ b/test/day_test.js
@@ -528,23 +528,23 @@ describe("Day", () => {
       expect(shallowDay.hasClass(className)).to.equal(true);
     });
 
-    it("should apply the aria-current date attribute if today", () => {
-      const shallowDay = renderDay(newDate());
-      const currentAriaProp = shallowDay.prop("aria-current");
-
-      expect(currentAriaProp).to.equal("date");
-    });
-
     it("should not apply the today class if not today", () => {
       const shallowDay = renderDay(addDays(newDate(), 1));
       expect(shallowDay.hasClass(className)).to.equal(false);
     });
 
+    it("should apply the aria-current date attribute if today", () => {
+      const shallowDay = renderDay(newDate());
+      const ariaCurrent = shallowDay.prop("aria-current");
+
+      expect(ariaCurrent).to.equal("date");
+    });
+
     it("should not apply the aria-current date attribute if not today", () => {
       const shallowDay = renderDay(addDays(newDate(), 1));
-      const currentAriaProp = shallowDay.prop("aria-current");
+      const ariaCurrent = shallowDay.prop("aria-current");
 
-      expect(currentAriaProp).to.be.undefined;
+      expect(ariaCurrent).to.be.undefined;
     });
   });
 

--- a/test/month_test.js
+++ b/test/month_test.js
@@ -265,6 +265,30 @@ describe("Month", () => {
     expect(months).to.have.length(0);
   });
 
+  it("should include aria-current property if month is current year's month", () => {
+    const date = new Date();
+    const monthComponent = mount(
+      <Month day={date} selected={date} showMonthYearPicker />
+    );
+    const ariaCurrent = monthComponent
+      .find(".react-datepicker__month-text--today")
+      .prop("aria-current");
+    expect(ariaCurrent).to.equal("date");
+  });
+
+  it("should not include aria-current property if month is not current year's month", () => {
+    const lastYearDate = new Date();
+    lastYearDate.setFullYear(lastYearDate.getFullYear() - 1);
+    const monthComponent = mount(
+      <Month day={lastYearDate} selected={lastYearDate} showMonthYearPicker />
+    );
+    const ariaCurrent = monthComponent
+      .find(".react-datepicker__month-text")
+      .at(0)
+      .prop("aria-current");
+    expect(ariaCurrent).to.be.undefined;
+  });
+
   it("should have the quarter picker CSS class", () => {
     const month = shallow(
       <Month showQuarterYearPicker day={utils.newDate()} />

--- a/test/year_picker_test.js
+++ b/test/year_picker_test.js
@@ -62,7 +62,7 @@ describe("YearPicker", () => {
     expect(year).to.equal(utils.getYear(date).toString());
   });
 
-  it("should has current year class when element of array equal of current year", () => {
+  it("should have current year class when element of array equal of current year", () => {
     const date = new Date();
     const yearComponent = mount(<Year date={date} />);
     const year = yearComponent
@@ -70,6 +70,25 @@ describe("YearPicker", () => {
       .at(0)
       .text();
     expect(year).to.equal(utils.getYear(date).toString());
+  });
+
+  it("should have aria-current date when element of array equal to current year", () => {
+    const date = new Date();
+    const yearComponent = mount(<Year date={date} />);
+    const ariaCurrent = yearComponent
+      .find(".react-datepicker__year-text--today")
+      .prop("aria-current");
+    expect(ariaCurrent).to.equal("date");
+  });
+
+  it("should not have aria-current date when element of array does not equal current year", () => {
+    const date = new Date("2015-01-01");
+    const yearComponent = mount(<Year date={date} />);
+    const ariaCurrent = yearComponent
+      .find(".react-datepicker__year-text")
+      .at(0)
+      .prop("aria-current");
+    expect(ariaCurrent).to.be.undefined;
   });
 
   it("should return disabled class if current date is out of bound of minDate and maxdate", () => {


### PR DESCRIPTION
**What does this PR do?**
This PR adds aria-current to the element which represents the current date/month/year.

Actual Result:
Narrator Behaviour: "Choose Wednesday September 29, 2021, button"

Expected Result:
Narrator Behaviour: "Choose Wednesday September 29, 2021, **current date**, button"

Related Issue
#3229 
