### PR TITLE
VPRB-221  Accessibility: [react-datepicker] add aria-selected to current selection

### DIFF
--- a/src/day.jsx
+++ b/src/day.jsx
@@ -225,6 +225,8 @@ export default class Day extends React.Component {
 
   isCurrentDay = () => this.isSameDay(newDate());
 
+  isSelected = () => this.isSameDay(this.props.selected);
+
   getClassNames = (date) => {
     const dayClassName = this.props.dayClassName
       ? this.props.dayClassName(date)
@@ -236,7 +238,7 @@ export default class Day extends React.Component {
       {
         "react-datepicker__day--disabled": this.isDisabled(),
         "react-datepicker__day--excluded": this.isExcluded(),
-        "react-datepicker__day--selected": this.isSameDay(this.props.selected),
+        "react-datepicker__day--selected": this.isSelected(),
         "react-datepicker__day--keyboard-selected": this.isKeyboardSelected(),
         "react-datepicker__day--range-start": this.isRangeStart(),
         "react-datepicker__day--range-end": this.isRangeEnd(),
@@ -346,6 +348,7 @@ export default class Day extends React.Component {
       role="button"
       aria-disabled={this.isDisabled()}
       aria-current={this.isCurrentDay() ? "date" : undefined}
+      aria-selected={this.isSelected() ? "true" : undefined}
     >
       {this.renderDayContents()}
     </div>

--- a/src/month.jsx
+++ b/src/month.jsx
@@ -141,6 +141,9 @@ export default class Month extends React.Component {
     utils.getYear(day) === utils.getYear(utils.newDate()) &&
     m === utils.getMonth(utils.newDate());
 
+  isSelectedMonth = (day, selected, m) =>
+    utils.getMonth(day) === m && utils.getYear(day) === utils.getYear(selected);
+
   renderWeeks = () => {
     const weeks = [];
     var isFixedHeight = this.props.fixedHeight;
@@ -290,9 +293,11 @@ export default class Month extends React.Component {
         "react-datepicker__month--disabled":
           (minDate || maxDate) &&
           utils.isMonthDisabled(utils.setMonth(day, m), this.props),
-        "react-datepicker__month--selected":
-          utils.getMonth(day) === m &&
-          utils.getYear(day) === utils.getYear(selected),
+        "react-datepicker__month--selected": this.isSelectedMonth(
+          day,
+          selected,
+          m
+        ),
         "react-datepicker__month-text--keyboard-selected":
           utils.getMonth(preSelection) === m,
         "react-datepicker__month--in-range": utils.isMonthinRange(
@@ -365,6 +370,7 @@ export default class Month extends React.Component {
       showFourColumnMonthYearPicker,
       locale,
       day,
+      selected,
     } = this.props;
     const monthsFourColumns = [
       [0, 1, 2, 3],
@@ -407,6 +413,9 @@ export default class Month extends React.Component {
             role="button"
             aria-label={this.getAriaLabel(m)}
             aria-current={this.isCurrentMonth(day, m) ? "date" : undefined}
+            aria-selected={
+              this.isSelectedMonth(day, selected, m) ? "true" : undefined
+            }
           >
             {showFullMonthYearPicker
               ? utils.getMonthInLocale(m, locale)

--- a/src/month.jsx
+++ b/src/month.jsx
@@ -141,8 +141,12 @@ export default class Month extends React.Component {
     utils.getYear(day) === utils.getYear(utils.newDate()) &&
     m === utils.getMonth(utils.newDate());
 
-  isSelectedMonth = (day, selected, m) =>
+  isSelectedMonth = (day, m, selected) =>
     utils.getMonth(day) === m && utils.getYear(day) === utils.getYear(selected);
+
+  isSelectedQuarter = (day, q, selected) =>
+    utils.getQuarter(day) === q &&
+    utils.getYear(day) === utils.getYear(selected);
 
   renderWeeks = () => {
     const weeks = [];
@@ -295,8 +299,8 @@ export default class Month extends React.Component {
           utils.isMonthDisabled(utils.setMonth(day, m), this.props),
         "react-datepicker__month--selected": this.isSelectedMonth(
           day,
-          selected,
-          m
+          m,
+          selected
         ),
         "react-datepicker__month-text--keyboard-selected":
           utils.getMonth(preSelection) === m,
@@ -348,9 +352,11 @@ export default class Month extends React.Component {
         "react-datepicker__quarter--disabled":
           (minDate || maxDate) &&
           utils.isQuarterDisabled(utils.setQuarter(day, q), this.props),
-        "react-datepicker__quarter--selected":
-          utils.getQuarter(day) === q &&
-          utils.getYear(day) === utils.getYear(selected),
+        "react-datepicker__quarter--selected": this.isSelectedQuarter(
+          day,
+          q,
+          selected
+        ),
         "react-datepicker__quarter--in-range": utils.isQuarterInRange(
           startDate,
           endDate,
@@ -414,7 +420,7 @@ export default class Month extends React.Component {
             aria-label={this.getAriaLabel(m)}
             aria-current={this.isCurrentMonth(day, m) ? "date" : undefined}
             aria-selected={
-              this.isSelectedMonth(day, selected, m) ? "true" : undefined
+              this.isSelectedMonth(day, m, selected) ? "true" : undefined
             }
           >
             {showFullMonthYearPicker
@@ -427,6 +433,7 @@ export default class Month extends React.Component {
   };
 
   renderQuarters = () => {
+    const { day, selected } = this.props;
     const quarters = [1, 2, 3, 4];
     return (
       <div className="react-datepicker__quarter-wrapper">
@@ -437,6 +444,9 @@ export default class Month extends React.Component {
               this.onQuarterClick(ev, q);
             }}
             className={this.getQuarterClassNames(q)}
+            aria-selected={
+              this.isSelectedQuarter(day, q, selected) ? "true" : undefined
+            }
           >
             {utils.getQuarterShortInLocale(q, this.props.locale)}
           </div>

--- a/src/month_dropdown_options.jsx
+++ b/src/month_dropdown_options.jsx
@@ -9,18 +9,21 @@ export default class MonthDropdownOptions extends React.Component {
     monthNames: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
   };
 
+  isSelectedMonth = (i) => this.props.month === i;
+
   renderOptions = () => {
     return this.props.monthNames.map((month, i) => (
       <div
         className={
-          this.props.month === i
+          this.isSelectedMonth(i)
             ? "react-datepicker__month-option react-datepicker__month-option--selected_month"
             : "react-datepicker__month-option"
         }
         key={month}
         onClick={this.onChange.bind(this, i)}
+        aria-selected={this.isSelectedMonth(i) ? "true" : undefined}
       >
-        {this.props.month === i ? (
+        {this.isSelectedMonth(i) ? (
           <span className="react-datepicker__month-option--selected">✓</span>
         ) : (
           ""

--- a/src/month_year_dropdown_options.jsx
+++ b/src/month_year_dropdown_options.jsx
@@ -60,11 +60,12 @@ export default class MonthYearDropdownOptions extends React.Component {
         <div
           className={
             isSameMonthYear
-              ? "react-datepicker__month-year-option --selected_month-year"
+              ? "react-datepicker__month-year-option--selected_month-year"
               : "react-datepicker__month-year-option"
           }
           key={monthYearPoint}
           onClick={this.onChange.bind(this, monthYearPoint)}
+          aria-selected={isSameMonthYear ? "true" : undefined}
         >
           {isSameMonthYear ? (
             <span className="react-datepicker__month-year-option--selected">

--- a/src/time.jsx
+++ b/src/time.jsx
@@ -89,6 +89,11 @@ export default class Time extends React.Component {
     this.props.onChange(time);
   };
 
+  isSelectedTime = (time, currH, currM) =>
+    this.props.selected &&
+    currH === getHours(time) &&
+    currM === getMinutes(time);
+
   liClasses = (time, currH, currM) => {
     let classes = [
       "react-datepicker__time-list-item",
@@ -97,13 +102,10 @@ export default class Time extends React.Component {
         : undefined,
     ];
 
-    if (
-      this.props.selected &&
-      currH === getHours(time) &&
-      currM === getMinutes(time)
-    ) {
+    if (this.isSelectedTime(time, currH, currM)) {
       classes.push("react-datepicker__time-list-item--selected");
     }
+
     if (
       ((this.props.minTime || this.props.maxTime) &&
         isTimeInDisabledRange(time, this.props)) ||
@@ -185,6 +187,9 @@ export default class Time extends React.Component {
           this.handleOnKeyDown(ev, time);
         }}
         tabIndex="0"
+        aria-selected={
+          this.isSelectedTime(time, currH, currM) ? "true" : undefined
+        }
       >
         {formatDate(time, format, this.props.locale)}
       </li>

--- a/src/year_dropdown_options.jsx
+++ b/src/year_dropdown_options.jsx
@@ -72,6 +72,7 @@ export default class YearDropdownOptions extends React.Component {
         }
         key={year}
         onClick={this.onChange.bind(this, year)}
+        aria-selected={selectedYear === year ? "true" : undefined}
       >
         {selectedYear === year ? (
           <span className="react-datepicker__year-option--selected">✓</span>

--- a/test/day_test.js
+++ b/test/day_test.js
@@ -52,18 +52,43 @@ describe("Day", () => {
 
   describe("selected", () => {
     const className = "react-datepicker__day--selected";
+    let day;
 
-    it("should apply the selected class if selected", () => {
-      const day = newDate();
-      const shallowDay = renderDay(day, { selected: day });
-      expect(shallowDay.hasClass(className)).to.equal(true);
+    beforeEach(() => {
+      day = newDate();
     });
 
-    it("should not apply the selected class if not selected", () => {
-      const day = newDate();
-      const selected = addDays(day, 1);
-      const shallowDay = renderDay(day, { selected });
-      expect(shallowDay.hasClass(className)).to.equal(false);
+    describe("if selected", () => {
+      let shallowDay;
+      beforeEach(() => {
+        shallowDay = renderDay(day, { selected: day });
+      });
+
+      it("should apply the selected class", () => {
+        expect(shallowDay.hasClass(className)).to.equal(true);
+      });
+
+      it("should add aria-selected property with the value of true", () => {
+        const ariaSelected = shallowDay.prop("aria-selected");
+        expect(ariaSelected).to.equal("true");
+      });
+    });
+
+    describe("if not selected", () => {
+      let shallowDay;
+      beforeEach(() => {
+        const selected = addDays(day, 1);
+        shallowDay = renderDay(day, { selected });
+      });
+
+      it("should not apply the selected class", () => {
+        expect(shallowDay.hasClass(className)).to.equal(false);
+      });
+
+      it("should not add aria-selected property", () => {
+        const ariaSelected = shallowDay.prop("aria-selected");
+        expect(ariaSelected).to.be.undefined;
+      });
     });
   });
 

--- a/test/month_dropdown_test.js
+++ b/test/month_dropdown_test.js
@@ -53,14 +53,48 @@ describe("MonthDropdown", () => {
       expect(optionsView).to.exist;
     });
 
-    it("applies the 'selected' modifier class to the selected month", () => {
-      monthDropdown
-        .find(".react-datepicker__month-read-view")
-        .simulate("click");
-      var selectedMonth = monthDropdown.find(
-        ".react-datepicker__month-option--selected_month"
-      );
-      expect(selectedMonth.text()).to.contain("December");
+    describe("with the selected month", () => {
+      let selectedMonth;
+
+      beforeEach(() => {
+        monthDropdown
+          .find(".react-datepicker__month-read-view")
+          .simulate("click");
+        selectedMonth = monthDropdown.find(
+          ".react-datepicker__month-option--selected_month"
+        );
+      });
+
+      it("applies the 'selected' modifier class to the selected month", () => {
+        expect(selectedMonth.text()).to.contain("December");
+      });
+
+      it("adds aria-selected property to the selected month", () => {
+        const ariaSelected = selectedMonth.prop("aria-selected");
+        expect(ariaSelected).to.equal("true");
+      });
+    });
+
+    describe("with a not selected month", () => {
+      let notSelectedMonth;
+
+      beforeEach(() => {
+        monthDropdown
+          .find(".react-datepicker__month-read-view")
+          .simulate("click");
+        notSelectedMonth = monthDropdown
+          .find(".react-datepicker__month-option")
+          .at(0);
+      });
+
+      it("does not apply the 'selected' modifier class to the selected month", () => {
+        expect(notSelectedMonth.text()).to.not.contain("December");
+      });
+
+      it("does not add aria-selected property to the selected month", () => {
+        const ariaSelected = notSelectedMonth.prop("aria-selected");
+        expect(ariaSelected).to.be.undefined;
+      });
     });
 
     it("closes the dropdown when a month is clicked", () => {

--- a/test/month_test.js
+++ b/test/month_test.js
@@ -216,16 +216,54 @@ describe("Month", () => {
     expect(month.hasClass("react-datepicker__month--disabled")).to.equal(true);
   });
 
-  it("should return selected class if month is selected", () => {
-    const monthComponent = mount(
-      <Month
-        day={utils.newDate("2015-02-01")}
-        selected={utils.newDate("2015-02-01")}
-        showMonthYearPicker
-      />
-    );
-    const month = monthComponent.find(".react-datepicker__month-text").at(1);
-    expect(month.hasClass("react-datepicker__month--selected")).to.equal(true);
+  describe("if month is selected", () => {
+    let month;
+
+    beforeEach(() => {
+      const monthComponent = mount(
+        <Month
+          day={utils.newDate("2015-02-01")}
+          selected={utils.newDate("2015-02-01")}
+          showMonthYearPicker
+        />
+      );
+      month = monthComponent.find(".react-datepicker__month-text").at(1);
+    });
+
+    it("should return selected class", () => {
+      expect(month.hasClass("react-datepicker__month--selected")).to.equal(
+        true
+      );
+    });
+
+    it("should add the aria-selected property", () => {
+      expect(month.prop("aria-selected")).to.equal("true");
+    });
+  });
+
+  describe("if month is not selected", () => {
+    let month;
+
+    beforeEach(() => {
+      const monthComponent = mount(
+        <Month
+          day={utils.newDate("2015-02-01")}
+          selected={utils.newDate("2015-02-01")}
+          showMonthYearPicker
+        />
+      );
+      month = monthComponent.find(".react-datepicker__month-text").at(0);
+    });
+
+    it("should not have the selected class", () => {
+      expect(month.hasClass("react-datepicker__month--selected")).to.equal(
+        false
+      );
+    });
+
+    it("should not add the aria-selected property", () => {
+      expect(month.prop("aria-selected")).to.be.undefined;
+    });
   });
 
   it("should return month-in-range class if month is between the start date and end date", () => {

--- a/test/month_test.js
+++ b/test/month_test.js
@@ -369,20 +369,54 @@ describe("Month", () => {
     );
   });
 
-  it("should return selected class if quarter is selected", () => {
-    const monthComponent = mount(
-      <Month
-        day={utils.newDate("2015-02-01")}
-        selected={utils.newDate("2015-02-01")}
-        showQuarterYearPicker
-      />
-    );
-    const quarter = monthComponent
-      .find(".react-datepicker__quarter-text")
-      .at(0);
-    expect(quarter.hasClass("react-datepicker__quarter--selected")).to.equal(
-      true
-    );
+  describe("if quarter is selected", () => {
+    let quarter;
+
+    beforeEach(() => {
+      const monthComponent = mount(
+        <Month
+          day={utils.newDate("2015-02-01")}
+          selected={utils.newDate("2015-02-01")}
+          showQuarterYearPicker
+        />
+      );
+      quarter = monthComponent.find(".react-datepicker__quarter-text").at(0);
+    });
+
+    it("should return selected class", () => {
+      expect(quarter.hasClass("react-datepicker__quarter--selected")).to.equal(
+        true
+      );
+    });
+
+    it("should add aria-selected property", () => {
+      expect(quarter.prop("aria-selected")).to.equal("true");
+    });
+  });
+
+  describe("if quarter is not selected", () => {
+    let quarter;
+
+    beforeEach(() => {
+      const monthComponent = mount(
+        <Month
+          day={utils.newDate("2015-02-01")}
+          selected={utils.newDate("2015-02-01")}
+          showQuarterYearPicker
+        />
+      );
+      quarter = monthComponent.find(".react-datepicker__quarter-text").at(1);
+    });
+
+    it("should not return selected class", () => {
+      expect(quarter.hasClass("react-datepicker__quarter--selected")).to.equal(
+        false
+      );
+    });
+
+    it("should not add aria-selected property", () => {
+      expect(quarter.prop("aria-selected")).to.be.undefined;
+    });
   });
 
   it("should return quarter-in-range class if quarter is between the start date and end date", () => {

--- a/test/month_year_dropdown_test.js
+++ b/test/month_year_dropdown_test.js
@@ -106,10 +106,34 @@ describe("MonthYearDropdown", () => {
         .simulate("click");
 
       monthYearDropdown
-        .find(".react-datepicker__month-year-option")
-        .at(6)
+        .find(".react-datepicker__month-year-option--selected_month-year")
         .simulate("click");
       expect(handleChangeResult).to.be.null;
+    });
+
+    it("adds aria-selected to selected option", () => {
+      monthYearDropdown
+        .find(".react-datepicker__month-year-read-view")
+        .simulate("click");
+
+      const ariaSelected = monthYearDropdown
+        .find(".react-datepicker__month-year-option--selected_month-year")
+        .prop("aria-selected");
+
+      expect(ariaSelected).to.equal("true");
+    });
+
+    it("does not add aria-selected to non-selected option", () => {
+      monthYearDropdown
+        .find(".react-datepicker__month-year-read-view")
+        .simulate("click");
+
+      const ariaSelected = monthYearDropdown
+        .find(".react-datepicker__month-year-option")
+        .at(0)
+        .prop("aria-selected");
+
+      expect(ariaSelected).to.be.undefined;
     });
 
     it("calls the supplied onChange function when a different month year is clicked", () => {

--- a/test/time_format_test.js
+++ b/test/time_format_test.js
@@ -95,6 +95,36 @@ describe("TimeComponent", () => {
       ).to.be.true;
     });
 
+    it("should add the aria-selected property to the selected item", () => {
+      var timeComponent = mount(
+        <TimeComponent
+          format="HH:mm"
+          selected={new Date("1990-06-14 08:00")}
+          openToDate={new Date("1990-06-14 09:00")}
+        />
+      );
+
+      var timeListItem = timeComponent.find(
+        ".react-datepicker__time-list-item--selected"
+      );
+      expect(timeListItem.at(0).prop("aria-selected")).to.eq("true");
+    });
+
+    it("should not add the aria-selected property to a regular item", () => {
+      var timeComponent = mount(
+        <TimeComponent
+          format="HH:mm"
+          selected={new Date("1990-06-14 08:00")}
+          openToDate={new Date("1990-06-14 09:00")}
+        />
+      );
+
+      var timeListItem = timeComponent.find(
+        ".react-datepicker__time-list-item"
+      );
+      expect(timeListItem.at(0).prop("aria-selected")).to.be.undefined;
+    });
+
     it("when no selected time, should call calcCenterPosition with centerLi ref, closest to the opened time", () => {
       mount(
         <TimeComponent

--- a/test/year_dropdown_options_test.js
+++ b/test/year_dropdown_options_test.js
@@ -119,6 +119,49 @@ describe("YearDropdownOptions", () => {
     instance.handleClickOutside();
     expect(onCancelSpy.calledOnce).to.be.true;
   });
+
+  describe("selected", () => {
+    const className = "react-datepicker__year-option--selected_year";
+    let yearOptions;
+
+    beforeEach(() => {
+      yearOptions = yearDropdown.find(".react-datepicker__year-option");
+    });
+
+    describe("if selected", () => {
+      let selectedYearOption;
+      beforeEach(() => {
+        selectedYearOption = yearOptions.filterWhere((o) =>
+          o.hasClass(className)
+        );
+      });
+      it("should apply the selected class", () => {
+        expect(selectedYearOption.hasClass(className)).to.equal(true);
+      });
+
+      it("should add aria-selected property with the value of true", () => {
+        const ariaSelected = selectedYearOption.prop("aria-selected");
+        expect(ariaSelected).to.equal("true");
+      });
+    });
+
+    describe("if not selected", () => {
+      let selectedYearOption;
+      beforeEach(() => {
+        selectedYearOption = yearOptions
+          .filterWhere((o) => !o.hasClass(className))
+          .at(0);
+      });
+      it("should not apply the selected class", () => {
+        expect(selectedYearOption.hasClass(className)).to.equal(false);
+      });
+
+      it("should not add aria-selected property with the value of true", () => {
+        const ariaSelected = selectedYearOption.prop("aria-selected");
+        expect(ariaSelected).to.be.undefined;
+      });
+    });
+  });
 });
 
 describe("YearDropdownOptions with scrollable dropwdown", () => {


### PR DESCRIPTION
What does this PR do?
This PR adds aria-selected to the element which represents the current selection, i.e. has the `*--selected` class

It also groups up some of the tests into describe blocks to reduce code duplication and show that some tests are related

Actual Result:
Narrator Behaviour: "Choose Wednesday September 29, 2021, button"

Expected Result:
Narrator Behaviour: "Choose Wednesday September 29, 2021, button,  **selected**"

Related Issue:
#3160 