### PR TITLE
Provide option to reset monthSelectedIn in setOpen

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -392,7 +392,7 @@ export default class DatePicker extends React.Component {
     this.cancelFocusInput();
   };
 
-  setOpen = (open, skipSetBlur = false) => {
+  setOpen = (open, skipSetBlur = false, resetMonthSelectedInIndex = false) => {
     this.setState(
       {
         open: open,
@@ -407,6 +407,9 @@ export default class DatePicker extends React.Component {
           this.setState(
             (prev) => ({
               focused: skipSetBlur ? prev.focused : false,
+              monthSelectedIn: resetMonthSelectedInIndex
+                ? undefined
+                : prev.monthSelectedIn,
             }),
             () => {
               !skipSetBlur && this.setBlur();


### PR DESCRIPTION
This change provides the option to reset the `monthSelectedIn` state in `setOpen` calls.
It's helpful when you'd like to close the date picker and avoid "stale" state of the selected month when opening it again (while it's not unmounted yet).

I did not see a reason to add a docs example or tests here since there are no tests for the setOpen API.