### PR TITLE
Fix multi months on fixedHeight

### DIFF
--- a/src/day.jsx
+++ b/src/day.jsx
@@ -216,10 +216,17 @@ export default class Day extends React.Component {
     return weekday === 0 || weekday === 6;
   };
 
-  isOutsideMonth = () => {
+  isAfterMonth = () => {
     return (
       this.props.month !== undefined &&
-      this.props.month !== getMonth(this.props.day)
+      (this.props.month + 1) % 12 === getMonth(this.props.day)
+    );
+  };
+
+  isBeforeMonth = () => {
+    return (
+      this.props.month !== undefined &&
+      (getMonth(this.props.day) + 1) % 12 === this.props.month
     );
   };
 
@@ -250,7 +257,8 @@ export default class Day extends React.Component {
           this.isSelectingRangeEnd(),
         "react-datepicker__day--today": this.isCurrentDay(),
         "react-datepicker__day--weekend": this.isWeekend(),
-        "react-datepicker__day--outside-month": this.isOutsideMonth(),
+        "react-datepicker__day--outside-month":
+          this.isAfterMonth() || this.isBeforeMonth(),
       },
       this.getHighLightedClass("react-datepicker__day--highlighted")
     );
@@ -321,16 +329,10 @@ export default class Day extends React.Component {
   };
 
   renderDayContents = () => {
-    if (this.isOutsideMonth()) {
-      if (this.props.monthShowsDuplicateDaysEnd && getDate(this.props.day) < 10)
-        return null;
-      if (
-        this.props.monthShowsDuplicateDaysStart &&
-        getDate(this.props.day) > 20
-      )
-        return null;
-    }
-
+    if (this.props.monthShowsDuplicateDaysEnd && this.isAfterMonth())
+      return null;
+    if (this.props.monthShowsDuplicateDaysStart && this.isBeforeMonth())
+      return null;
     return this.props.renderDayContents
       ? this.props.renderDayContents(getDate(this.props.day), this.props.day)
       : getDate(this.props.day);

--- a/test/day_test.js
+++ b/test/day_test.js
@@ -602,13 +602,22 @@ describe("Day", () => {
     });
 
     it("should apply the outside-month class if not in same month", () => {
-      const day = newDate();
-      const shallowDay = renderDay(day, { month: getMonth(day) + 1 });
-      expect(shallowDay.hasClass(className)).to.equal(true);
+      const day1 = newDate("2020-12-02");
+      const day2 = newDate("2021-01-02");
+      const day3 = newDate("2021-04-02");
+      const day4 = newDate("2021-04-02");
+      const shallowDay1 = renderDay(day1, { month: 0 });
+      const shallowDay2 = renderDay(day2, { month: 11 });
+      const shallowDay3 = renderDay(day3, { month: 4 });
+      const shallowDay4 = renderDay(day4, { month: 2 });
+      expect(shallowDay1.hasClass(className)).to.equal(true);
+      expect(shallowDay2.hasClass(className)).to.equal(true);
+      expect(shallowDay3.hasClass(className)).to.equal(true);
+      expect(shallowDay4.hasClass(className)).to.equal(true);
     });
 
     it("should hide days outside month at end when duplicates", () => {
-      const day = newDate("2020-12-02");
+      const day = newDate("2021-03-17");
       const wrapper = mount(
         <Day day={day} month={getMonth(day) - 1} monthShowsDuplicateDaysEnd />
       );
@@ -616,13 +625,13 @@ describe("Day", () => {
     });
 
     it("should show days outside month at end when not duplicates", () => {
-      const day = newDate("2020-12-02");
+      const day = newDate("2020-03-17");
       const wrapper = mount(<Day day={day} month={getMonth(day) - 1} />);
       expect(wrapper.text()).to.equal(day.getDate().toString());
     });
 
     it("should hide days outside month at start when duplicates", () => {
-      const day = newDate("2020-10-30");
+      const day = newDate("2020-10-05");
       const wrapper = mount(
         <Day day={day} month={getMonth(day) + 1} monthShowsDuplicateDaysStart />
       );
@@ -630,7 +639,7 @@ describe("Day", () => {
     });
 
     it("should show days outside month at start when not duplicates", () => {
-      const day = newDate("2020-10-30");
+      const day = newDate("2020-10-05");
       const wrapper = mount(<Day day={day} month={getMonth(day) + 1} />);
       expect(wrapper.text()).to.equal(day.getDate().toString());
     });


### PR DESCRIPTION
Existing test cases missed to check a scenario when out of bound day is more than one week (i.e. when fixedHeight or peekNextMonth is set). This PR change hardcoded number of days to hide to a more generic one.

Related issue: https://github.com/Hacker0x01/react-datepicker/issues/3250
