### PR TITLE
inverted navigation arrows for right to left languages

### DIFF
--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -483,6 +483,10 @@ export default class Calendar extends React.Component {
       clickHandler = null;
     }
 
+    if (this.props.showTimeSelect) {
+      classes.push("react-datepicker__navigation--previous--with-time");
+    }
+
     const isForYear =
       this.props.showMonthYearPicker ||
       this.props.showQuarterYearPicker ||

--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -186,6 +186,28 @@
   }
 }
 
+[dir="rtl"] .react-datepicker__navigation {
+  &--previous {
+    left: unset;
+    right: 2px;
+    transform: rotate(180deg);
+
+    &--with-time:not(&--with-today-button) {
+      right: 85px;
+    }
+  }
+
+  &--next {
+    left: 2px;
+    right: unset;
+    transform: rotate(180deg);
+
+    &--with-time:not(&--with-today-button) {
+      right: unset;
+    }
+  }
+}
+
 .react-datepicker__navigation-icon {
   position: relative;
   top: -1px;


### PR DESCRIPTION
When datepicker is rendered under dir="rtl" (for example in an application in arabic language) the navigation arrows used to increment/decrement the month were not inverted. 

The change consists in rendering the buttons in a different order by playing on the css.