### PR TITLE
Add one column month layout for month picker

### DIFF
--- a/docs-site/src/components/Examples/index.js
+++ b/docs-site/src/components/Examples/index.js
@@ -75,6 +75,7 @@ import StrictParsing from "../../examples/strictParsing";
 import MonthPicker from "../../examples/monthPicker";
 import YearPicker from "../../examples/yearPicker";
 import monthPickerFullName from "../../examples/monthPickerFullName";
+import monthPickerOneColumn from "../../examples/monthPickerOneColumn";
 import monthPickerTwoColumns from "../../examples/monthPickerTwoColumns";
 import monthPickerFourColumns from "../../examples/monthPickerFourColumns";
 import RangeMonthPicker from "../../examples/rangeMonthPicker";
@@ -313,6 +314,10 @@ export default class exampleComponents extends React.Component {
     {
       title: "Month Picker with Full Name",
       component: monthPickerFullName,
+    },
+    {
+      title: "Month Picker One Column Layout",
+      component: monthPickerOneColumn,
     },
     {
       title: "Month Picker Two Columns Layout",

--- a/docs-site/src/examples/monthPickerOneColumn.js
+++ b/docs-site/src/examples/monthPickerOneColumn.js
@@ -1,0 +1,13 @@
+() => {
+  const [startDate, setStartDate] = useState(new Date());
+  return (
+    <DatePicker
+      selected={startDate}
+      onChange={(date) => setStartDate(date)}
+      dateFormat="MM/yyyy"
+      showMonthYearPicker
+      showFullMonthYearPicker
+      showOneColumnMonthYearPicker
+    />
+  );
+};

--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -134,6 +134,7 @@ export default class Calendar extends React.Component {
     showTimeInput: PropTypes.bool,
     showMonthYearPicker: PropTypes.bool,
     showFullMonthYearPicker: PropTypes.bool,
+    showOneColumnMonthYearPicker: PropTypes.bool,
     showTwoColumnMonthYearPicker: PropTypes.bool,
     showFourColumnMonthYearPicker: PropTypes.bool,
     showYearPicker: PropTypes.bool,
@@ -886,6 +887,9 @@ export default class Calendar extends React.Component {
             disabledKeyboardNavigation={this.props.disabledKeyboardNavigation}
             showMonthYearPicker={this.props.showMonthYearPicker}
             showFullMonthYearPicker={this.props.showFullMonthYearPicker}
+            showOneColumnMonthYearPicker={
+              this.props.showOneColumnMonthYearPicker
+            }
             showTwoColumnMonthYearPicker={
               this.props.showTwoColumnMonthYearPicker
             }

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -96,6 +96,7 @@ export default class DatePicker extends React.Component {
       showPreviousMonths: false,
       showMonthYearPicker: false,
       showFullMonthYearPicker: false,
+      showOneColumnMonthYearPicker: false,
       showTwoColumnMonthYearPicker: false,
       showFourColumnMonthYearPicker: false,
       showYearPicker: false,
@@ -243,6 +244,7 @@ export default class DatePicker extends React.Component {
     showTimeInput: PropTypes.bool,
     showMonthYearPicker: PropTypes.bool,
     showFullMonthYearPicker: PropTypes.bool,
+    showOneColumnMonthYearPicker: PropTypes.bool,
     showTwoColumnMonthYearPicker: PropTypes.bool,
     showFourColumnMonthYearPicker: PropTypes.bool,
     showYearPicker: PropTypes.bool,
@@ -946,6 +948,7 @@ export default class DatePicker extends React.Component {
         showTimeInput={this.props.showTimeInput}
         showMonthYearPicker={this.props.showMonthYearPicker}
         showFullMonthYearPicker={this.props.showFullMonthYearPicker}
+        showOneColumnMonthYearPicker={this.props.showOneColumnMonthYearPicker}
         showTwoColumnMonthYearPicker={this.props.showTwoColumnMonthYearPicker}
         showFourColumnMonthYearPicker={this.props.showFourColumnMonthYearPicker}
         showYearPicker={this.props.showYearPicker}

--- a/src/month.jsx
+++ b/src/month.jsx
@@ -59,6 +59,7 @@ export default class Month extends React.Component {
     renderDayContents: PropTypes.func,
     showMonthYearPicker: PropTypes.bool,
     showFullMonthYearPicker: PropTypes.bool,
+    showOneColumnMonthYearPicker: PropTypes.bool,
     showTwoColumnMonthYearPicker: PropTypes.bool,
     showFourColumnMonthYearPicker: PropTypes.bool,
     showQuarterYearPicker: PropTypes.bool,
@@ -372,6 +373,7 @@ export default class Month extends React.Component {
   renderMonths = () => {
     const {
       showFullMonthYearPicker,
+      showOneColumnMonthYearPicker,
       showTwoColumnMonthYearPicker,
       showFourColumnMonthYearPicker,
       locale,
@@ -397,10 +399,26 @@ export default class Month extends React.Component {
       [8, 9],
       [10, 11],
     ];
+    const monthsOneColumn = [
+      [0],
+      [1],
+      [2],
+      [3],
+      [4],
+      [5],
+      [6],
+      [7],
+      [8],
+      [9],
+      [10],
+      [11],
+    ];
     const monthLayout = showFourColumnMonthYearPicker
       ? monthsFourColumns
       : showTwoColumnMonthYearPicker
       ? monthsTwoColumns
+      : showOneColumnMonthYearPicker
+      ? monthsOneColumn
       : monthsThreeColumns;
     return monthLayout.map((month, i) => (
       <div className="react-datepicker__month-wrapper" key={i}>

--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -238,6 +238,7 @@
 
 .react-datepicker__month {
   margin: $datepicker__margin;
+  min-width: 8rem;
   text-align: center;
 
   .react-datepicker__month-text,


### PR DESCRIPTION
I have a use case for showing an inline list of months in a single column layout; this was the simplest possible way of adding it and I'm open to making the column layout a parameter the user passes in when creating the component instead, perhaps with a utility function that produces the different possible layouts.

If it's not suitable or desired feel free to discard!