### PR TITLE
Use locale respecting dateFormat for default props

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -68,7 +68,7 @@ export default class DatePicker extends React.Component {
   static get defaultProps() {
     return {
       allowSameDay: false,
-      dateFormat: "MM/dd/yyyy",
+      dateFormat: "P",
       dateFormatCalendar: "LLLL yyyy",
       onChange() {},
       disabled: false,


### PR DESCRIPTION
"P" comes from [here](https://github.com/date-fns/date-fns/blob/928172c0262a378871bc9afb84e65558fa51c822/src/format/index.ts#L205)

For enUS remains "MM/dd/yyyy" per [here](https://github.com/date-fns/date-fns/blob/928172c0262a378871bc9afb84e65558fa51c822/src/locale/en-US/_lib/formatLong/index.ts#L8)

For other locales will now use correct format.

As discussed on https://github.com/Hacker0x01/react-datepicker/issues/3375 and https://github.com/Hacker0x01/react-datepicker/issues/3447