### PR TITLE
fixed bug with disabled year when minDate provided

### DIFF
--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -508,11 +508,10 @@ export function isQuarterDisabled(
 export function isYearDisabled(year, { minDate, maxDate } = {}) {
   const date = new Date(year, 0, 1);
 
-  if (minDate && isSameYear(date, minDate)) {
-    return false;
-  }
-
-  return isOutOfBounds(date, { minDate, maxDate }) || false;
+  return !!(
+    (minDate && differenceInCalendarDays(getEndOfYear(date), minDate) < 0) ||
+    (maxDate && differenceInCalendarDays(getStartOfYear(date), maxDate) > 0)
+  );
 }
 
 export function isQuarterInRange(startDate, endDate, q, day) {

--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -510,7 +510,7 @@ export function isYearDisabled(year, { minDate, maxDate } = {}) {
 
   return !!(
     (minDate && differenceInCalendarDays(getEndOfYear(date), minDate) < 0) ||
-    (maxDate && differenceInCalendarDays(getStartOfYear(date), maxDate) > 0)
+    (maxDate && differenceInCalendarDays(date, maxDate) > 0)
   );
 }
 

--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -40,6 +40,7 @@ import startOfWeek from "date-fns/startOfWeek";
 import startOfMonth from "date-fns/startOfMonth";
 import startOfQuarter from "date-fns/startOfQuarter";
 import startOfYear from "date-fns/startOfYear";
+import endOfYear from "date-fns/endOfYear";
 import endOfDay from "date-fns/endOfDay";
 import endOfWeek from "date-fns/endOfWeek";
 import endOfMonth from "date-fns/endOfMonth";
@@ -259,6 +260,10 @@ export function getEndOfWeek(date) {
 
 export function getEndOfMonth(date) {
   return endOfMonth(date);
+}
+
+export function getEndOfYear(date) {
+  return endOfYear(date);
 }
 
 // ** Date Math **
@@ -502,6 +507,11 @@ export function isQuarterDisabled(
 
 export function isYearDisabled(year, { minDate, maxDate } = {}) {
   const date = new Date(year, 0, 1);
+
+  if (minDate && isSameYear(date, minDate)) {
+    return false;
+  }
+
   return isOutOfBounds(date, { minDate, maxDate }) || false;
 }
 

--- a/test/date_utils_test.js
+++ b/test/date_utils_test.js
@@ -26,7 +26,10 @@ import {
   parseDate,
   isMonthinRange,
   isQuarterInRange,
+  getYear,
   getStartOfYear,
+  getEndOfYear,
+  isYearDisabled,
   getYearsPeriod,
   setDefaultLocale,
   yearsDisabledAfter,
@@ -447,6 +450,95 @@ describe("date_utils", function () {
       };
       isMonthDisabled(day, { filterDate });
       expect(isEqual(day, dayClone)).to.be.true;
+    });
+  });
+
+  describe("isYearDisabled", () => {
+    it("should be enabled by default", () => {
+      const day = newDate();
+      expect(isYearDisabled(getYear(day))).to.be.false;
+    });
+
+    describe("min date provided only", () => {
+      it("should be enabled if min date is same year", () => {
+        const day = newDate();
+        expect(isYearDisabled(getYear(day), { minDate: getStartOfYear(day) }))
+          .to.be.false;
+        expect(isYearDisabled(getYear(day), { minDate: getEndOfYear(day) })).to
+          .be.false;
+      });
+
+      it("should be enabled if min date is previous year", () => {
+        const day = newDate();
+        expect(isYearDisabled(getYear(day), { minDate: subDays(day, 400) })).to
+          .be.false;
+      });
+
+      it("should be disabled if min date is next year", () => {
+        const day = newDate();
+        expect(isYearDisabled(getYear(day), { minDate: addDays(day, 400) })).to
+          .be.true;
+      });
+    });
+
+    describe("max date provided only", () => {
+      it("should be enabled if max date is same year", () => {
+        const day = newDate();
+        expect(isYearDisabled(getYear(day), { maxDate: getStartOfYear(day) }))
+          .to.be.false;
+        expect(isYearDisabled(getYear(day), { maxDate: getEndOfYear(day) })).to
+          .be.false;
+      });
+
+      it("should be disabled if max date is previous year", () => {
+        const day = newDate();
+        expect(isYearDisabled(getYear(day), { maxDate: subDays(day, 400) })).to
+          .be.true;
+      });
+
+      it("should be enabled if min date is next year", () => {
+        const day = newDate();
+        expect(isYearDisabled(getYear(day), { maxDate: addDays(day, 400) })).to
+          .be.false;
+      });
+    });
+
+    describe("both min and max dates provided", () => {
+      it("should be enabled if min and max dates are same year", () => {
+        const day = newDate();
+        expect(
+          isYearDisabled(getYear(day), {
+            minDate: getStartOfYear(day),
+            maxDate: getEndOfYear(day),
+          })
+        ).to.be.false;
+      });
+
+      it("should be enabled if current year is in range", () => {
+        const day = newDate();
+        expect(
+          isYearDisabled(getYear(day), {
+            minDate: subDays(day, 400),
+            maxDate: addDays(day, 400),
+          })
+        ).to.be.false;
+      });
+
+      it("should be disabled if current year is out of range", () => {
+        const day = newDate();
+        expect(
+          isYearDisabled(getYear(day), {
+            minDate: addDays(day, 400),
+            maxDate: addDays(day, 401),
+          })
+        ).to.be.true;
+        expect(
+          isYearDisabled(getYear(day), {
+            minDate: subDays(day, 401),
+            maxDate: subDays(day, 400),
+          })
+        ).to.be.true;
+      });
     });
   });
 


### PR DESCRIPTION
Example of wrong behaviour:

<img width="890" alt="image" src="https://user-images.githubusercontent.com/40503291/160030975-cb628229-1757-4915-9e85-f1b00b11f7b2.png">

If minDate provided and its year equals current year, current year tab is disabled. 

After this fix:

<img width="871" alt="image" src="https://user-images.githubusercontent.com/40503291/160031095-a6974da2-1a90-43c5-905d-591a66addf90.png">

Here is open issue https://github.com/Hacker0x01/react-datepicker/issues/2912. I haven't found any problems with month though working locally.