### PR TITLE
fix: formatFunc should take source params

### DIFF
--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -377,7 +377,7 @@ export function getLocaleObject(localeSpec) {
 }
 
 export function getFormattedWeekdayInLocale(date, formatFunc, locale) {
-  return formatFunc(formatDate(date, "EEEE", locale));
+  return typeof formatFunc === "function" ? formatFunc(date, locale) : formatDate(date, "EEEE", locale));
 }
 
 export function getWeekdayMinInLocale(date, locale) {

--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -377,7 +377,7 @@ export function getLocaleObject(localeSpec) {
 }
 
 export function getFormattedWeekdayInLocale(date, formatFunc, locale) {
-  return typeof formatFunc === "function" ? formatFunc(date, locale) : formatDate(date, "EEEE", locale));
+  return typeof formatFunc === "function" ? formatFunc(date, locale) : formatDate(date, "EEEE", locale);
 }
 
 export function getWeekdayMinInLocale(date, locale) {

--- a/test/calendar_test.js
+++ b/test/calendar_test.js
@@ -162,10 +162,15 @@ describe("Calendar", function () {
   });
 
   it("should correctly format weekday using formatWeekDay prop", function () {
-    const calendar = getCalendar({ formatWeekDay: (day) => day[0] });
+    const mockFormattedWeekDay = "mockFormattedWeekDay";
+    const formatWeekDay = sinon.fake.returns(mockFormattedWeekDay);
+    const calendar = getCalendar({ formatWeekDay });
+    sinon.assert.alwaysCalledWith(formatWeekDay, sinon.match.date);
     calendar
       .find(".react-datepicker__day-name")
-      .forEach((dayName) => expect(dayName.text()).to.have.length(1));
+      .forEach((dayName) =>
+        expect(dayName.text()).to.equals(mockFormattedWeekDay)
+      );
   });
 
   it("should contain the correct class when using the weekDayClassName prop", () => {


### PR DESCRIPTION
`props.formatWeekDay` of `DatePicker` will be passed to `getFormattedWeekdayInLocale` via argument `formatFunc` as a callback.

The naming of the prop suggests that it is designed to provide flexibility for users to format the weekday. So I think the expected behavior is taking the source date and locale as input and returning the formatted value (i.e. As the replacement of the built-in `formatDate`). But now it  takes the formatted string as input.

### Expected Usage Example

```js
import DatePicker from 'react-datepicker';
import { format } from 'date-fns';

const myCustomFormatString = 'EEEEE'
const myCustomPrefix = '#'

function formatWeekDay(date, dateFnsLocale) {
  return myCustomPrefix + format(date, myCustomFormatString, { locale: dateFnsLocale })
}

function App () {
  // ...
  return (
    <DatePicker
      formatWeekDay={formatWeekDay}
      {/* ... */ }
    />
  )
}

```
