### PR TITLE
Fix same date time only prop

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -4,6 +4,7 @@ import Calendar from "./calendar";
 import Portal from "./portal";
 import PopperComponent, { popperPlacementPositions } from "./popper_component";
 import classnames from "classnames";
+import set from "date-fns/set";
 import startOfDay from "date-fns/startOfDay";
 import endOfDay from "date-fns/endOfDay";
 import {
@@ -38,6 +39,7 @@ import {
   setDefaultLocale,
   getDefaultLocale,
   DEFAULT_YEAR_ITEM_NUMBER,
+  isSameDay,
 } from "./date_utils";
 import onClickOutside from "react-onclickoutside";
 
@@ -483,13 +485,24 @@ export default class DatePicker extends React.Component {
       inputValue: event.target.value,
       lastPreSelectChange: PRESELECT_CHANGE_VIA_INPUT,
     });
-    const date = parseDate(
+    let date = parseDate(
       event.target.value,
       this.props.dateFormat,
       this.props.locale,
       this.props.strictParsing,
       this.props.minDate
     );
+    // Use date from `selected` prop when manipulating only time for input value
+    if (
+      this.props.showTimeSelectOnly &&
+      !isSameDay(date, this.props.selected)
+    ) {
+      date = set(this.props.selected, {
+        hours: getHours(date),
+        minutes: getMinutes(date),
+        seconds: getSeconds(date),
+      });
+    }
     if (date || !event.target.value) {
       this.setSelected(date, event, true);
     }

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -1900,4 +1900,35 @@ describe("DatePicker", () => {
       .text();
     expect(firstDay).to.equal("Su");
   });
+
+  describe("when update the datepicker input text while props.showTimeSelectOnly is set and dateFormat has only time related format", () => {
+    const format = "h:mm aa";
+
+    it("should keep selected date in state except new time", () => {
+      const selected = utils.newDate("2022-02-24 10:00:00");
+      let date;
+
+      const datePicker = TestUtils.renderIntoDocument(
+        <DatePicker
+          selected={selected}
+          onChange={(d) => {
+            console.log("trigger change", d);
+            date = d;
+          }}
+          showTimeSelect
+          showTimeSelectOnly
+          dateFormat={format}
+          timeFormat={format}
+        />
+      );
+
+      const input = ReactDOM.findDOMNode(datePicker.input);
+      input.value = "8:22 AM";
+      TestUtils.Simulate.change(input);
+
+      expect(utils.isSameDay(date, selected)).to.equal(true);
+      expect(utils.getHours(date)).to.equal(8);
+      expect(utils.getMinutes(date)).to.equal(22);
+    });
+  });
 });


### PR DESCRIPTION
Fix for [ISSUE-3593](https://github.com/Hacker0x01/react-datepicker/issues/3593)

When prop `showTimeSelectOnly` is set and `dateFormat` does have only time format (i.e.: _h:mm aa_), there is a problem with changing time input value. It is not preserving `selected` date.

This PR fixes this.

Example: 

```
const tomorrow = new Date();
tomorrow.setDate(today.getDate() + 1);
const [startDate, setStartDate] = useState(tomorrow);

return <DatePicker
  selected={startDate}
  onChange={(date) => setStartDate(date)}
  showTimeSelect
  showTimeSelectOnly
  dateFormat="h:mm aa"
  timeFormat="h:mm aa"
/>
```