### PR TITLE
Fix class not applied on day component for datepicker with `selectsRange` prop

### DIFF
--- a/src/day.jsx
+++ b/src/day.jsx
@@ -185,10 +185,10 @@ export default class Day extends React.Component {
       return false;
     }
 
-    const { day, endDate, selectsEnd } = this.props;
+    const { day, endDate, selectsEnd, selectsRange } = this.props;
     const selectingDate = this.props.selectingDate ?? this.props.preSelection;
 
-    if (selectsEnd) {
+    if (selectsEnd || selectsRange) {
       return isSameDay(day, selectingDate);
     } else {
       return isSameDay(day, endDate);

--- a/test/day_test.js
+++ b/test/day_test.js
@@ -547,6 +547,36 @@ describe("Day", () => {
         expect(shallowDay.hasClass(rangeDayClassName)).to.be.true;
       });
     });
+
+    describe("for a date picker with selectsRange prop", () => {
+      it("should have a class if it is a start or end date", () => {
+        const startDate = newDate();
+        const midRangeDate = addDays(startDate, 1);
+        const endDate = addDays(startDate, 2);
+
+        const shallowStartDay = renderDay(startDate, {
+          startDate,
+          selectingDate: endDate,
+          selectsRange: true,
+        });
+        expect(shallowStartDay.hasClass(rangeDayStartClassName)).to.be.true;
+
+        const shallowMidRangeDay = renderDay(midRangeDate, {
+          startDate,
+          selectingDate: endDate,
+          selectsRange: true,
+        });
+        expect(shallowMidRangeDay.hasClass(rangeDayStartClassName)).to.be.false;
+        expect(shallowMidRangeDay.hasClass(rangeDayEndClassName)).to.be.false;
+
+        const shallowEndDay = renderDay(endDate, {
+          startDate,
+          selectingDate: endDate,
+          selectsRange: true,
+        });
+        expect(shallowEndDay.hasClass(rangeDayEndClassName)).to.be.true;
+      });
+    });
   });
 
   describe("today", () => {


### PR DESCRIPTION
- Apply the `react-datepicker__day--selecting-range-end` class on the day component while user is selecting the end date for the range
- Added unit test

I observed that for datepicker having the `selectsRange` prop, when the user is selecting a range only the `react-datepicker__day--selecting-range-start` is set on the day component starting the range. While the user is moving the mouse on other day components, the class `react-datepicker__day--selecting-range-end` would not be applied on the hovered day to indicate that he is selecting that day as the end date.

I would need this class to be applied to perform custom styling for achieving this kind of styling:

![chrome_z0vE4vZ9OU](https://user-images.githubusercontent.com/54319424/168497066-c69662c4-fca2-4bfb-8fba-618ab17350ca.png)

This would help me to not continue the blue line after the end date.