### PR TITLE
fix: add tab loop to datepicker with withPortal

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -41,6 +41,7 @@ import {
   DEFAULT_YEAR_ITEM_NUMBER,
   isSameDay,
 } from "./date_utils";
+import TabLoop from "./tab_loop";
 import onClickOutside from "react-onclickoutside";
 
 export { default as CalendarContainer } from "./calendar_container";
@@ -719,6 +720,14 @@ export default class DatePicker extends React.Component {
     }
   };
 
+  onPortalKeyDown = (event) => {
+    this.props.onKeyDown(event);
+    if (event.key === "Escape") {
+      event.preventDefault();
+      this.setOpen(false);
+    }
+  };
+
   // keyDown events passed down to day.jsx
   onDayKeyDown = (event) => {
     this.props.onKeyDown(event);
@@ -1071,7 +1080,14 @@ export default class DatePicker extends React.Component {
 
     if (this.props.withPortal) {
       let portalContainer = this.state.open ? (
-        <div className="react-datepicker__portal">{calendar}</div>
+        <TabLoop enableTabLoop={this.props.enableTabLoop}>
+          <div
+            onKeyDown={this.onPortalKeyDown}
+            className="react-datepicker__portal"
+          >
+            {calendar}
+          </div>
+        </TabLoop>
       ) : null;
 
       if (this.state.open && this.props.portalId) {


### PR DESCRIPTION
I'm currently using this date picker with the `withPortal` prop. I noticed that currently, when rendered like this, there is no `TabLoop` enabled at all which allows you to tab out of the date picker under the overlay. This PR uses the `TabLoop` component to wrap the portal's contents.

This PR also adds a keyDown handler to allow to close the date picker using the `Escape` key. (It was ignored previously, particularly when focus was in the header).