### PR TITLE
Bump `react-onclickoutside` to 6.12.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "classnames": "^2.2.6",
     "date-fns": "^2.24.0",
     "prop-types": "^15.7.2",
-    "react-onclickoutside": "^6.12.0",
+    "react-onclickoutside": "^6.12.1",
     "react-popper": "^2.2.5"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7880,7 +7880,7 @@ react-is@^16.13.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-onclickoutside@^6.12.0:
+react-onclickoutside@^6.12.1:
   version "6.12.1"
   resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.12.1.tgz#92dddd28f55e483a1838c5c2930e051168c1e96b"
   integrity sha512-a5Q7CkWznBRUWPmocCvE8b6lEYw1s6+opp/60dCunhO+G6E4tDTO2Sd2jKE+leEnnrLAE2Wj5DlDHNqj5wPv1Q==


### PR DESCRIPTION
- [the `react-onclickoutside` in v. 6.12.1 specifies React 18 in`peerDependencies` 
](https://github.com/Pomax/react-onclickoutside/blob/master/package.json#L82)
- as a result annoying incompatibility warning flies away ;-)