### PR TITLE
fix: remove extraneous state update

### DIFF
--- a/src/month.jsx
+++ b/src/month.jsx
@@ -252,7 +252,6 @@ export default class Month extends React.Component {
       switch (eventKey) {
         case "Enter":
           this.onMonthClick(event, month);
-          this.props.setPreSelection(this.props.selected);
           break;
         case "ArrowRight":
           this.handleMonthNavigation(


### PR DESCRIPTION
This PR addresses [issue #3674](https://github.com/Hacker0x01/react-datepicker/issues/3674).

The `onMonthClick` handler already sets the proper value for the `preSelection` date to the one navigated to via keyboard. The extraneous line updates `preSelection` again, but to an incorrect date that lags behind the intended date due to its reliance on `this.props.selected`. Without this change, keyboard navigation only works every other date selection.

https://user-images.githubusercontent.com/2702149/174904494-2321efbd-8909-4564-88a0-be60ab05e394.mov


