### PR TITLE
fix for crash that may occur on different timezones

### DIFF
--- a/src/time.jsx
+++ b/src/time.jsx
@@ -28,7 +28,7 @@ export default class Time extends React.Component {
 
   static calcCenterPosition = (listHeight, centerLiRef) => {
     return (
-      centerLiRef.offsetTop - (listHeight / 2 - centerLiRef.clientHeight / 2)
+      centerLiRef?.offsetTop - (listHeight / 2 - centerLiRef?.clientHeight / 2)
     );
   };
 


### PR DESCRIPTION
we have noticed that react-datepicker may crash with message: "cannot read properties of undefined offsetTop".
