### PR TITLE
Fixes #3723: Calendar does not jump back to today's date when using inline and Today button

### DIFF
--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -693,9 +693,8 @@ export default class Calendar extends React.Component {
 
   handleTodayButtonClick = (e) => {
     this.props.onSelect(getStartOfToday(), e);
-    this.props.setPreSelection(getStartOfToday());
+    this.props.setPreSelection && this.props.setPreSelection(getStartOfToday());
   };
-
 
   renderTodayButton = () => {
     if (!this.props.todayButton || this.props.showTimeSelectOnly) {

--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -691,6 +691,12 @@ export default class Calendar extends React.Component {
     );
   };
 
+  handleTodayButtonClick = (e) => {
+    this.props.onSelect(getStartOfToday(), e);
+    this.props.setPreSelection(getStartOfToday());
+  };
+
+
   renderTodayButton = () => {
     if (!this.props.todayButton || this.props.showTimeSelectOnly) {
       return;
@@ -698,7 +704,7 @@ export default class Calendar extends React.Component {
     return (
       <div
         className="react-datepicker__today-button"
-        onClick={(e) => this.props.onSelect(getStartOfToday(), e)}
+        onClick={(e) => this.handleTodayButtonClick(e)}
       >
         {this.props.todayButton}
       </div>

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -319,6 +319,32 @@ describe("DatePicker", () => {
     ).to.equal(utils.formatDate(data.copyM, data.testFormat));
   });
 
+  it("should update the preSelection state when Today button is clicked after selecting a different day for inline mode", () => {
+    var datePicker = TestUtils.renderIntoDocument(
+      <DatePicker
+        todayButton="Today"
+        selected={utils.newDate()}
+        inline
+        onChange={(d) => {
+          var date = d;
+        }}
+      />
+    );
+
+    var today = getSelectedDayNode(datePicker);
+    var anyOtherDay = today.nextElementSibling || today.previousElementSibling;
+    TestUtils.Simulate.click(anyOtherDay); // will update the preSelection to next or previous day
+
+    var todayBtn = datePicker.calendar.componentNode.querySelector(
+      ".react-datepicker__today-button"
+    );
+    TestUtils.Simulate.click(todayBtn); // will update the preSelection
+
+    expect(
+      utils.formatDate(datePicker.state.preSelection, "yyyy-MM-dd")
+    ).to.equal(utils.formatDate(utils.newDate(), "yyyy-MM-dd"));
+  });
+
   it("should hide the calendar when pressing enter in the date input", () => {
     var datePicker = TestUtils.renderIntoDocument(<DatePicker />);
     var dateInput = datePicker.input;


### PR DESCRIPTION
Fixes #3723 
The `preSelection` value was not getting set to today's date on clicking Today button link.
Because of this, `isKeyboardSelected` was returning true and adding the `react-datepicker__day--keyboard-selected` class to the already selected date. This resulted in the Today button not jumping to today's date

Before the fix:
[Before the fix.webm](https://user-images.githubusercontent.com/35288242/187060267-5a6286d5-a342-438b-b471-83017986c6a3.webm)


After the fix:
[After the fix.webm](https://user-images.githubusercontent.com/35288242/187060269-57aa4986-cec8-48c0-a05c-712c3b6fd359.webm)

