### PR TITLE
added necessary step for getting correct css on calender

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,8 @@ To begin local development:
 
 1. `yarn install`
 2. `yarn build-dev`
-3. `yarn start`
+3. `yarn css:dev`
+4. `yarn start`
 
 The last step starts documentation app as a simple webserver on http://localhost:3000.
 


### PR DESCRIPTION
When I followed the steps without doing yard css:dev or the equivalent npm command the dropdown calender had no CSS applied, so I added this step to ensure that anyone that runs it locally won't be confused