### PR TITLE
Changed styling on &--keyboard-selected

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,8 @@ To begin local development:
 
 1. `yarn install`
 2. `yarn build-dev`
-3. `yarn start`
+3. `yarn css:dev`
+4. `yarn start`
 
 The last step starts documentation app as a simple webserver on http://localhost:3000.
 

--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -468,8 +468,8 @@
 
   &--keyboard-selected {
     border-radius: $datepicker__border-radius;
-    background-color: lighten($datepicker__selected-color, 5%);
-    color: #fff;
+    background-color: lighten($datepicker__selected-color, 45%);
+    color: rgb(0, 0, 0);
 
     &:hover {
       background-color: darken($datepicker__selected-color, 5%);


### PR DESCRIPTION
I made &--keyboard-selected lighter so that the issue of changing to a different month and having your actually selected numerical day still look like it's selected. Now &--keyboard-selected is a much lighter color. Before the difference was so small that it was confusing.