### PR TITLE
modified &--keyboard-selected to be lighter in color than regular selected

### DIFF
--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -468,8 +468,8 @@
 
   &--keyboard-selected {
     border-radius: $datepicker__border-radius;
-    background-color: lighten($datepicker__selected-color, 5%);
-    color: #fff;
+    background-color: lighten($datepicker__selected-color, 45%);
+    color: rgb(0, 0, 0);
 
     &:hover {
       background-color: darken($datepicker__selected-color, 5%);


### PR DESCRIPTION
The keyboard selected styling was creating a ton of confusion as it always looked like the wrong date was selected when you changed months:

https://github.com/Hacker0x01/react-datepicker/issues/2930#issuecomment-1261099842

I just made that particular styling a little bit different so that it's clear that this selection status is not the same as the regular selection status. [modified colors](https://i.imgur.com/59nntuM.jpg)