### PR TITLE
Offset top crash fix 2

### DIFF
--- a/src/time.jsx
+++ b/src/time.jsx
@@ -28,7 +28,7 @@ export default class Time extends React.Component {
 
   static calcCenterPosition = (listHeight, centerLiRef) => {
     return (
-      centerLiRef.offsetTop - (listHeight / 2 - centerLiRef.clientHeight / 2)
+      centerLiRef?.offsetTop - (listHeight / 2 - centerLiRef?.clientHeight / 2)
     );
   };
 

--- a/src/time.jsx
+++ b/src/time.jsx
@@ -28,7 +28,7 @@ export default class Time extends React.Component {
 
   static calcCenterPosition = (listHeight, centerLiRef) => {
     return (
-      centerLiRef?.offsetTop - (listHeight / 2 - centerLiRef?.clientHeight / 2)
+      centerLiRef.offsetTop - (listHeight / 2 - centerLiRef.clientHeight / 2)
     );
   };
 
@@ -62,12 +62,14 @@ export default class Time extends React.Component {
 
   componentDidMount() {
     // code to ensure selected time will always be in focus within time window when it first appears
-    this.list.scrollTop = Time.calcCenterPosition(
-      this.props.monthRef
-        ? this.props.monthRef.clientHeight - this.header.clientHeight
-        : this.list.clientHeight,
-      this.centerLi
-    );
+    this.list.scrollTop =
+      this.centerLi &&
+      Time.calcCenterPosition(
+        this.props.monthRef
+          ? this.props.monthRef.clientHeight - this.header.clientHeight
+          : this.list.clientHeight,
+        this.centerLi
+      );
     if (this.props.monthRef && this.header) {
       this.setState({
         height: this.props.monthRef.clientHeight - this.header.clientHeight,


### PR DESCRIPTION
this PR fixes the crash that may occur on timezone change, when condition  'if (isBefore(time, activeTime) || isEqual(time, activeTime))' is false and  'this.centerLi' is undefined.