### PR TITLE
added change to fix Select Time Only "Invalid Date" bug

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -17,6 +17,7 @@ import {
   getSeconds,
   getMinutes,
   getHours,
+  getTime,
   addDays,
   addMonths,
   addWeeks,
@@ -39,6 +40,7 @@ import {
   setDefaultLocale,
   getDefaultLocale,
   DEFAULT_YEAR_ITEM_NUMBER,
+  correctDateString,
   isSameDay,
 } from "./date_utils";
 import onClickOutside from "react-onclickoutside";
@@ -497,11 +499,19 @@ export default class DatePicker extends React.Component {
       this.props.showTimeSelectOnly &&
       !isSameDay(date, this.props.selected)
     ) {
-      date = set(this.props.selected, {
-        hours: getHours(date),
-        minutes: getMinutes(date),
-        seconds: getSeconds(date),
-      });
+      if (date == null) {
+        date = set(this.props.selected, {
+          hours: getHours(this.props.selected),
+          minutes: getMinutes(this.props.selected),
+          seconds: getSeconds(this.props.selected),
+        });
+      } else {
+        date = set(this.props.selected, {
+          hours: getHours(date),
+          minutes: getMinutes(date),
+          seconds: getSeconds(date),
+        });
+      }
     }
     if (date || !event.target.value) {
       this.setSelected(date, event, true);

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -17,7 +17,6 @@ import {
   getSeconds,
   getMinutes,
   getHours,
-  getTime,
   addDays,
   addMonths,
   addWeeks,
@@ -40,7 +39,6 @@ import {
   setDefaultLocale,
   getDefaultLocale,
   DEFAULT_YEAR_ITEM_NUMBER,
-  correctDateString,
   isSameDay,
 } from "./date_utils";
 import onClickOutside from "react-onclickoutside";


### PR DESCRIPTION
App would crash when an invalid time was provided to the Select Time Only input field

I fixed it by preventing a null date from being provided to the set function in handleChange

https://github.com/Hacker0x01/react-datepicker/issues/3759