### PR TITLE
Monthpicker month disabled class

### DIFF
--- a/docs-site/src/components/Examples/index.js
+++ b/docs-site/src/components/Examples/index.js
@@ -29,10 +29,12 @@ import LocaleWithTime from "../../examples/localeWithTime";
 import LocaleWithoutGlobalVariable from "../../examples/localeWithoutGlobalVariable";
 import ExcludeDates from "../../examples/excludeDates";
 import ExcludeDateIntervals from "../../examples/excludeDateIntervals";
+import ExcludeDatesMonthPicker from "../../examples/excludeDatesMonthPicker";
 import HighlightDates from "../../examples/highlightDates";
 import HighlightDatesRanges from "../../examples/highlightDatesRanges";
 import IncludeDates from "../../examples/includeDates";
 import IncludeDateIntervals from "../../examples/includeDateIntervals";
+import IncludeDatesMonthPicker from "../../examples/includeDatesMonthPicker";
 import FilterDates from "../../examples/filterDates";
 import DateRange from "../../examples/dateRange";
 import DateRangeInputWithClearButton from "../../examples/dateRangeInputWithClearButton";
@@ -231,6 +233,10 @@ export default class exampleComponents extends React.Component {
       component: ExcludeDateIntervals,
     },
     {
+      title: "Exclude Months in Month Picker",
+      component: ExcludeDatesMonthPicker,
+    },
+    {
       title: "Exclude Times",
       component: ExcludeTimes,
     },
@@ -265,6 +271,10 @@ export default class exampleComponents extends React.Component {
     {
       title: "Include date intervals",
       component: IncludeDateIntervals,
+    },
+    {
+      title: "Include Months in Month Picker",
+      component: IncludeDatesMonthPicker,
     },
     {
       title: "Include Times",

--- a/docs-site/src/examples/excludeDatesMonthPicker.js
+++ b/docs-site/src/examples/excludeDatesMonthPicker.js
@@ -1,0 +1,12 @@
+() => {
+  const [startDate, setStartDate] = useState(1659312000000);
+  return (
+    <DatePicker
+      selected={startDate}
+      onChange={(date) => setStartDate(date)}
+      dateFormat="MM/yyyy"
+      excludeDates={[1661990400000, 1664582400000, 1667260800000, 1672531200000]}
+      showMonthYearPicker
+    />
+  );
+};

--- a/docs-site/src/examples/includeDatesMonthPicker.js
+++ b/docs-site/src/examples/includeDatesMonthPicker.js
@@ -1,0 +1,12 @@
+() => {
+  const [startDate, setStartDate] = useState(1661990400000);
+  return (
+    <DatePicker
+      selected={startDate}
+      onChange={(date) => setStartDate(date)}
+      dateFormat="MM/yyyy"
+      includeDates={[1661990400000, 1664582400000, 1667260800000, 1672531200000]}
+      showMonthYearPicker
+    />
+  );
+};

--- a/src/month.jsx
+++ b/src/month.jsx
@@ -302,14 +302,16 @@ export default class Month extends React.Component {
       monthClassName,
     } = this.props;
     const _monthClassName = monthClassName ? monthClassName(day) : undefined;
+    const labelDate = utils.setMonth(day, m);
     return classnames(
       "react-datepicker__month-text",
       `react-datepicker__month-${m}`,
       _monthClassName,
       {
         "react-datepicker__month--disabled":
-          (minDate || maxDate) &&
-          utils.isMonthDisabled(utils.setMonth(day, m), this.props),
+          ((minDate || maxDate) && utils.isMonthDisabled(labelDate, this.props)) ||
+          this.isDisabled(labelDate) ||
+          this.isExcluded(labelDate),
         "react-datepicker__month--selected": this.isSelectedMonth(
           day,
           m,


### PR DESCRIPTION
This fix will allow disabled months in the Month picker, to be styled as disabled, based on IncludeDates and excludeDates