### PR TITLE
fix contributing docs minimum node version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Start reading our code, and you'll get the hang of it. We optimize for readabili
 
 Local development configuration is pretty snappy. Here's how to get set up:
 
-1. Install/use node >=11.10.1
+1. Install/use node >=16.0.0
 1. Run `yarn link` from project root
 1. Run `cd docs-site && yarn link react-datepicker`
 1. Run `yarn install` from project root


### PR DESCRIPTION
When I was setting up node 11.10.1 did not work, I think that changing to 16.0.0 would cover required packages

<img width="565" alt="Screen Shot 2022-12-29 at 3 48 58 PM" src="https://user-images.githubusercontent.com/45493180/210011016-2a46a671-bf6c-4c40-91e6-e254cc6c964c.png">


<img width="560" alt="Screen Shot 2022-12-29 at 3 49 38 PM" src="https://user-images.githubusercontent.com/45493180/210011028-c301b3e6-d067-4796-9880-342bffb019e7.png">


<img width="569" alt="Screen Shot 2022-12-29 at 3 50 26 PM" src="https://user-images.githubusercontent.com/45493180/210011036-fae31359-c37d-4de9-a16a-09204f75b5a4.png">
