### PR TITLE
fix(months): disabledKeyboardNavigation not hiding classname in month picker

### DIFF
--- a/src/month.jsx
+++ b/src/month.jsx
@@ -318,7 +318,7 @@ export default class Month extends React.Component {
           selected
         ),
         "react-datepicker__month-text--keyboard-selected":
-          utils.getMonth(preSelection) === m,
+            !this.props.disabledKeyboardNavigation && utils.getMonth(preSelection) === m,
         "react-datepicker__month--in-range": utils.isMonthinRange(
           startDate,
           endDate,

--- a/test/month_test.js
+++ b/test/month_test.js
@@ -784,4 +784,30 @@ describe("Month", () => {
       );
     });
   });
+
+  describe("if keyboard navigation is disabled", () => {
+    const renderMonth = (props) =>
+        mount(<Month showMonthYearPicker {...props} />);
+
+    it("should not have the selected class", () => {
+      let preSelected = utils.newDate("2015-08-01");
+      const setPreSelection = (param) => {
+        preSelected = param;
+      };
+
+      const monthComponent = renderMonth({
+        selected: utils.newDate("2015-08-01"),
+        day: utils.newDate("2015-08-01"),
+        setPreSelection: setPreSelection,
+        preSelection: preSelected,
+        disabledKeyboardNavigation: true,
+      });
+
+      expect(
+          monthComponent
+              .find(".react-datepicker__month--selected")
+              .hasClass("react-datepicker__month-text--keyboard-selected")
+      ).to.equal(false);
+    });
+  });
 });


### PR DESCRIPTION
Description bug:
This PR fixes the issue when using month picker with disabledKeyboardNavigation enabled still showing the keyboard navigation classes on the respective months resulting in weird styling.

Fixes this issue #3876 