### PR TITLE
fix: Inconsistent/broken behavior in `parseDate` 

### DIFF
--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -59,10 +59,6 @@ import longFormatters from "date-fns/esm/_lib/format/longFormatters";
 
 export const DEFAULT_YEAR_ITEM_NUMBER = 12;
 
-// This RegExp catches symbols escaped by quotes, and also
-// sequences of symbols P, p, and the combinations like `PPPPPPPppppp`
-var longFormattingTokensRegExp = /P+p+|P+|p+|''|'(''|[^'])+('|$)|./g;
-
 // ** Date Constructors **
 
 export function newDate(value) {
@@ -103,27 +99,7 @@ export function parseDate(value, dateFormat, locale, strictParsing, minDate) {
       isValid(parsedDate) &&
       value === formatDate(parsedDate, dateFormat, locale);
   } else if (!isValid(parsedDate)) {
-    dateFormat = dateFormat
-      .match(longFormattingTokensRegExp)
-      .map(function (substring) {
-        var firstCharacter = substring[0];
-        if (firstCharacter === "p" || firstCharacter === "P") {
-          var longFormatter = longFormatters[firstCharacter];
-          return localeObject
-            ? longFormatter(substring, localeObject.formatLong)
-            : firstCharacter;
-        }
-        return substring;
-      })
-      .join("");
-
-    if (value.length > 0) {
-      parsedDate = parse(value, dateFormat.slice(0, value.length), new Date());
-    }
-
-    if (!isValid(parsedDate)) {
-      parsedDate = new Date(value);
-    }
+    parsedDate = new Date(value);
   }
 
   return isValid(parsedDate) && strictParsingValueMatch ? parsedDate : null;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -493,6 +493,7 @@ export default class DatePicker extends React.Component {
       this.props.dateFormat,
       this.props.locale,
       this.props.strictParsing,
+      this.props.selected,
       this.props.minDate
     );
     // Use date from `selected` prop when manipulating only time for input value

--- a/test/date_utils_test.js
+++ b/test/date_utils_test.js
@@ -884,16 +884,6 @@ describe("date_utils", function () {
       expect(parseDate(value, dateFormat, null, true)).to.not.be.null;
     });
 
-    it("should parse date based on locale", () => {
-      const value = "26/05/1995";
-      const dateFormat = "P";
-
-      const expected = new Date("05/26/1995");
-      const actual = parseDate(value, dateFormat, "pt-BR", true);
-
-      assert(isEqual(actual, expected));
-    });
-
     it("should parse date that matches one of the formats", () => {
       const value = "01/15/2019";
       const dateFormat = ["MM/dd/yyyy", "yyyy-MM-dd"];
@@ -922,12 +912,24 @@ describe("date_utils", function () {
       expect(parseDate(value, dateFormat, null, false)).to.not.be.null;
     });
 
-    it("should parse date based on locale without strict parsing", () => {
+    it("should parse date based on locale", () => {
       const value = "26/05/1995";
+      const locale = "pt-BR";
       const dateFormat = "P";
 
-      const expected = new Date("05/26/1995");
-      const actual = parseDate(value, dateFormat, "pt-BR", false);
+      const expected = new Date(1995, 4, 26);
+      const actual = parseDate(value, dateFormat, locale, true);
+
+      assert(isEqual(actual, expected));
+    });
+
+    it("should parse date based on locale without strict parsing", () => {
+      const value = "26/05/1995";
+      const locale = "pt-BR";
+      const dateFormat = "P";
+
+      const expected = new Date(1995, 4, 26);
+      const actual = parseDate(value, dateFormat, locale, false);
 
       assert(isEqual(actual, expected));
     });
@@ -943,10 +945,11 @@ describe("date_utils", function () {
 
     it("should parse date based on default locale", () => {
       const value = "26/05/1995";
+      const locale = "pt-BR";
       const dateFormat = "P";
 
-      const expected = new Date("05/26/1995");
-      setDefaultLocale("pt-BR");
+      const expected = new Date(1995, 4, 26);
+      setDefaultLocale(locale);
       const actual = parseDate(value, dateFormat, null, false);
       setDefaultLocale(null);
 

--- a/test/date_utils_test.js
+++ b/test/date_utils_test.js
@@ -886,9 +886,43 @@ describe("date_utils", function () {
 
     it("should parse date that matches one of the formats", () => {
       const value = "01/15/2019";
-      const dateFormat = ["MM/dd/yyyy", "yyyy-MM-dd"];
+      const dateFormat = ["yyyy-MM-dd", "MM/dd/yyyy"];
 
       expect(parseDate(value, dateFormat, null, true)).to.not.be.null;
+    });
+
+    it("should prefer the first matching format in array (strict)", () => {
+      const value = "01/06/2019";
+      const valueLax = "1/6/2019";
+      const dateFormat = ["MM/dd/yyyy", "dd/MM/yyyy"];
+
+      const expected = new Date(2019, 0, 6);
+
+      assert(
+        isEqual(parseDate(value, dateFormat, null, true), expected),
+        "Value with exact format"
+      );
+      expect(
+        parseDate(valueLax, dateFormat, null, true),
+        "Value with lax format"
+      ).to.be.null;
+    });
+
+    it("should prefer the first matching format in array", () => {
+      const value = "01/06/2019";
+      const valueLax = "1/6/2019";
+      const dateFormat = ["MM/dd/yyyy", "dd/MM/yyyy"];
+
+      const expected = new Date(2019, 0, 6);
+
+      assert(
+        isEqual(parseDate(value, dateFormat, null, false), expected),
+        "Value with exact format"
+      );
+      assert(
+        isEqual(parseDate(valueLax, dateFormat, null, false), expected),
+        "Value with lax format"
+      );
     });
 
     it("should not parse date that does not match the format", () => {

--- a/test/date_utils_test.js
+++ b/test/date_utils_test.js
@@ -934,6 +934,29 @@ describe("date_utils", function () {
       assert(isEqual(actual, expected));
     });
 
+    it("should parse date based on locale w/o strict", () => {
+      const valuePt = "26. fev 1995";
+      const valueEn = "26. feb 1995";
+
+      const locale = "pt-BR";
+      const dateFormat = "d. MMM yyyy";
+
+      const expected = new Date(1995, 1, 26);
+
+      assert(
+        isEqual(parseDate(valuePt, dateFormat, locale, false), expected),
+        "valuePT with pt-BR"
+      );
+      assert(
+        isEqual(parseDate(valueEn, dateFormat, null, false), expected),
+        "valueEn with default (en-US)"
+      );
+      expect(
+        parseDate(valueEn, dateFormat, locale, false),
+        "valuePt with default (en-US)"
+      ).to.be.null;
+    });
+
     it("should not parse date based on locale without a given locale", () => {
       const value = "26/05/1995";
       const dateFormat = "P";

--- a/test/date_utils_test.js
+++ b/test/date_utils_test.js
@@ -906,7 +906,7 @@ describe("date_utils", function () {
     });
 
     it("should parse date without strict parsing", () => {
-      const value = "01/15/20";
+      const value = "1/2/2020";
       const dateFormat = "MM/dd/yyyy";
 
       expect(parseDate(value, dateFormat, null, false)).to.not.be.null;

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -507,9 +507,9 @@ describe("DatePicker", () => {
       />
     );
 
-    var input = ReactDOM.findDOMNode(datePicker.input);
-    input.value = utils.newDate("2014-01-02");
-    TestUtils.Simulate.change(input);
+    TestUtils.Simulate.change(datePicker.input, {
+      target: { value: "01/02/2014" },
+    });
 
     expect(utils.getHours(date)).to.equal(10);
     expect(utils.getMinutes(date)).to.equal(11);
@@ -880,7 +880,7 @@ describe("DatePicker", () => {
       datePicker = TestUtils.renderIntoDocument(
         <DatePicker
           selected={new Date("1993-07-02")}
-          minDate={new Date("1800/01/01")}
+          minDate={new Date("1800-01-01")}
           open
         />
       );
@@ -889,11 +889,11 @@ describe("DatePicker", () => {
     it("should auto update calendar when the updated date text is after props.minDate", () => {
       TestUtils.Simulate.change(datePicker.input, {
         target: {
-          value: "1801/01/01",
+          value: "01/01/1801",
         },
       });
 
-      expect(datePicker.input.value).to.equal("1801/01/01");
+      expect(datePicker.input.value).to.equal("01/01/1801");
       expect(
         datePicker.calendar.componentNode.querySelector(
           ".react-datepicker__current-month"
@@ -965,7 +965,7 @@ describe("DatePicker", () => {
     it("should update the selected date on manual input", () => {
       var data = getOnInputKeyDownStuff();
       TestUtils.Simulate.change(data.nodeInput, {
-        target: { value: "02/02/2017" },
+        target: { value: "2017-02-02" },
       });
       TestUtils.Simulate.keyDown(data.nodeInput, getKey("Enter"));
       data.copyM = utils.newDate("2017-02-02");


### PR DESCRIPTION
**See the expanded commit messages for details.**

After this fix, the parsing behavior of `react-datepicker`…

a) is more consistent between locales/browsers/OS platforms
b) has fewer bugs
c) may feel slightly more "strict" in certain situations.

Item "c" results from parseDate no longer falling back (with string values for `props.dateFormat`) on free-form `new Date(value)` parsing of input values when `date-fns` has already declared the value as "invalid".

However, there's **still** a lot of flexibility in the parsing, as `date-fns/parse` provides very sensible flexibility based on localized RegExp configs, and also since `props.dateFormat` can be an Array of valid formattings.

It thus seems fairly sensible (and more deterministic) to fully place the responsibility of parsing on `date-fns` and not second-guesss its results.

(In fact the previous `new Date(value)` parsing causes surprising and deceptively incorrect "false positive" parsing in situations where the dateFormat was `dd.MM.yyyy` and users type in a date in this format `dd.MM.yy`. Then their input gets "helpfully" re-parsed as `MM.dd.yy`, which was most definitely not intended by the developer setting up the datepicker input.)