### PR TITLE
Fix range selection highlight for month/quarter range picker

### DIFF
--- a/docs-site/src/components/Examples/index.js
+++ b/docs-site/src/components/Examples/index.js
@@ -83,6 +83,7 @@ import RangeMonthPicker from "../../examples/rangeMonthPicker";
 import RangeMonthPickerSelectsRange from "../../examples/rangeMonthPickerSelectsRange";
 import QuarterPicker from "../../examples/quarterPicker";
 import RangeQuarterPicker from "../../examples/rangeQuarterPicker";
+import RangeQuarterPickerSelectsRange from "../../examples/rangeQuarterPickerSelectsRange";
 import OnCalendarChangeStateCallbacks from "../../examples/onCalendarOpenStateCallbacks";
 import CustomTimeInput from "../../examples/customTimeInput";
 import CloseOnScroll from "../../examples/closeOnScroll";
@@ -410,6 +411,10 @@ export default class exampleComponents extends React.Component {
     {
       title: "Range Quarter Picker",
       component: RangeQuarterPicker,
+    },
+    {
+      title: "Range Quarter Picker for one quarter picker",
+      component: RangeQuarterPickerSelectsRange,
     },
     {
       title: "Read only datepicker",

--- a/docs-site/src/components/Examples/index.js
+++ b/docs-site/src/components/Examples/index.js
@@ -80,6 +80,7 @@ import monthPickerFullName from "../../examples/monthPickerFullName";
 import monthPickerTwoColumns from "../../examples/monthPickerTwoColumns";
 import monthPickerFourColumns from "../../examples/monthPickerFourColumns";
 import RangeMonthPicker from "../../examples/rangeMonthPicker";
+import RangeMonthPickerSelectsRange from "../../examples/rangeMonthPickerSelectsRange";
 import QuarterPicker from "../../examples/quarterPicker";
 import RangeQuarterPicker from "../../examples/rangeQuarterPicker";
 import OnCalendarChangeStateCallbacks from "../../examples/onCalendarOpenStateCallbacks";
@@ -401,6 +402,10 @@ export default class exampleComponents extends React.Component {
     {
       title: "Range Month Picker",
       component: RangeMonthPicker,
+    },
+    {
+      title: "Range Month Picker for one month picker",
+      component: RangeMonthPickerSelectsRange,
     },
     {
       title: "Range Quarter Picker",

--- a/docs-site/src/examples/rangeMonthPickerSelectsRange.js
+++ b/docs-site/src/examples/rangeMonthPickerSelectsRange.js
@@ -1,0 +1,21 @@
+() => {
+  const [startDate, setStartDate] = useState(new Date("2014/02/08"));
+  const [endDate, setEndDate] = useState(null);
+
+  const handleChange = ([newStartDate, newEndDate]) => {
+    setStartDate(newStartDate);
+    setEndDate(newEndDate);
+  };
+
+  return (
+    <DatePicker
+      selected={startDate}
+      onChange={handleChange}
+      selectsRange
+      startDate={startDate}
+      endDate={endDate}
+      dateFormat="MM/yyyy"
+      showMonthYearPicker
+    />
+  );
+};

--- a/docs-site/src/examples/rangeQuarterPickerSelectsRange.js
+++ b/docs-site/src/examples/rangeQuarterPickerSelectsRange.js
@@ -1,0 +1,21 @@
+() => {
+  const [startDate, setStartDate] = useState(new Date("2014/02/08"));
+  const [endDate, setEndDate] = useState(null);
+
+  const handleChange = ([newStartDate, newEndDate]) => {
+    setStartDate(newStartDate);
+    setEndDate(newEndDate);
+  };
+
+  return (
+    <DatePicker
+      selected={startDate}
+      onChange={handleChange}
+      selectsRange
+      startDate={startDate}
+      endDate={endDate}
+      dateFormat="yyyy, QQQ"
+      showQuarterYearPicker
+    />
+  );
+};

--- a/src/month.jsx
+++ b/src/month.jsx
@@ -130,6 +130,31 @@ export default class Month extends React.Component {
     return utils.isSameQuarter(utils.setQuarter(day, q), endDate);
   };
 
+  isInSelectingRangeMonth = (m) => {
+    const { day, selectsStart, selectsEnd, selectsRange, startDate, endDate } =
+      this.props;
+
+    const selectingDate = this.props.selectingDate ?? this.props.preSelection;
+
+    if (!(selectsStart || selectsEnd || selectsRange) || !selectingDate) {
+      return false;
+    }
+
+    if (selectsStart && endDate) {
+      return utils.isMonthinRange(selectingDate, endDate, m, day);
+    }
+
+    if (selectsEnd && startDate) {
+      return utils.isMonthinRange(startDate, selectingDate, m, day);
+    }
+
+    if (selectsRange && startDate && !endDate) {
+      return utils.isMonthinRange(startDate, selectingDate, m, day);
+    }
+
+    return false;
+  };
+
   isWeekInMonth = (startOfWeek) => {
     const day = this.props.day;
     const endOfWeek = utils.addDays(startOfWeek, 6);
@@ -244,6 +269,12 @@ export default class Month extends React.Component {
     );
   };
 
+  onMonthMouseEnter = (m) => {
+    this.handleDayMouseEnter(
+      utils.getStartOfMonth(utils.setMonth(this.props.day, m))
+    );
+  };
+
   handleMonthNavigation = (newMonth, newDate) => {
     if (this.isDisabled(newDate) || this.isExcluded(newDate)) return;
     this.props.setPreSelection(newDate);
@@ -348,10 +379,10 @@ export default class Month extends React.Component {
       `react-datepicker__month-${m}`,
       _monthClassName,
       {
-        "react-datepicker__month--disabled":
+        "react-datepicker__month-text--disabled":
           (minDate || maxDate || excludeDates || includeDates) &&
           utils.isMonthDisabled(labelDate, this.props),
-        "react-datepicker__month--selected": this.isSelectedMonth(
+        "react-datepicker__month-text--selected": this.isSelectedMonth(
           day,
           m,
           selected
@@ -359,14 +390,16 @@ export default class Month extends React.Component {
         "react-datepicker__month-text--keyboard-selected":
           !this.props.disabledKeyboardNavigation &&
           utils.getMonth(preSelection) === m,
-        "react-datepicker__month--in-range": utils.isMonthinRange(
+        "react-datepicker__month-text--in-selecting-range":
+          this.isInSelectingRangeMonth(m),
+        "react-datepicker__month-text--in-range": utils.isMonthinRange(
           startDate,
           endDate,
           m,
           day
         ),
-        "react-datepicker__month--range-start": this.isRangeStartMonth(m),
-        "react-datepicker__month--range-end": this.isRangeEndMonth(m),
+        "react-datepicker__month-text--range-start": this.isRangeStartMonth(m),
+        "react-datepicker__month-text--range-end": this.isRangeEndMonth(m),
         "react-datepicker__month-text--today": this.isCurrentMonth(day, m),
       }
     );
@@ -422,24 +455,25 @@ export default class Month extends React.Component {
       "react-datepicker__quarter-text",
       `react-datepicker__quarter-${q}`,
       {
-        "react-datepicker__quarter--disabled":
+        "react-datepicker__quarter-text--disabled":
           (minDate || maxDate) &&
           utils.isQuarterDisabled(utils.setQuarter(day, q), this.props),
-        "react-datepicker__quarter--selected": this.isSelectedQuarter(
+        "react-datepicker__quarter-text--selected": this.isSelectedQuarter(
           day,
           q,
           selected
         ),
         "react-datepicker__quarter-text--keyboard-selected":
           utils.getQuarter(preSelection) === q,
-        "react-datepicker__quarter--in-range": utils.isQuarterInRange(
+        "react-datepicker__quarter-text--in-range": utils.isQuarterInRange(
           startDate,
           endDate,
           q,
           day
         ),
-        "react-datepicker__quarter--range-start": this.isRangeStartQuarter(q),
-        "react-datepicker__quarter--range-end": this.isRangeEndQuarter(q),
+        "react-datepicker__quarter-text--range-start":
+          this.isRangeStartQuarter(q),
+        "react-datepicker__quarter-text--range-end": this.isRangeEndQuarter(q),
       }
     );
   };
@@ -489,6 +523,7 @@ export default class Month extends React.Component {
             onKeyDown={(ev) => {
               this.onMonthKeyDown(ev, m);
             }}
+            onMouseEnter={() => this.onMonthMouseEnter(m)}
             tabIndex={this.getTabIndex(m)}
             className={this.getMonthClassNames(m)}
             role="option"

--- a/src/month.jsx
+++ b/src/month.jsx
@@ -155,6 +155,31 @@ export default class Month extends React.Component {
     return false;
   };
 
+  isInSelectingRangeQuarter = (q) => {
+    const { day, selectsStart, selectsEnd, selectsRange, startDate, endDate } =
+      this.props;
+
+    const selectingDate = this.props.selectingDate ?? this.props.preSelection;
+
+    if (!(selectsStart || selectsEnd || selectsRange) || !selectingDate) {
+      return false;
+    }
+
+    if (selectsStart && endDate) {
+      return utils.isQuarterInRange(selectingDate, endDate, q, day);
+    }
+
+    if (selectsEnd && startDate) {
+      return utils.isQuarterInRange(startDate, selectingDate, q, day);
+    }
+
+    if (selectsRange && startDate && !endDate) {
+      return utils.isQuarterInRange(startDate, selectingDate, q, day);
+    }
+
+    return false;
+  };
+
   isWeekInMonth = (startOfWeek) => {
     const day = this.props.day;
     const endOfWeek = utils.addDays(startOfWeek, 6);
@@ -326,6 +351,12 @@ export default class Month extends React.Component {
     );
   };
 
+  onQuarterMouseEnter = (q) => {
+    this.handleDayMouseEnter(
+      utils.getStartOfQuarter(utils.setQuarter(this.props.day, q))
+    );
+  };
+
   handleQuarterNavigation = (newQuarter, newDate) => {
     if (this.isDisabled(newDate) || this.isExcluded(newDate)) return;
     this.props.setPreSelection(newDate);
@@ -465,6 +496,8 @@ export default class Month extends React.Component {
         ),
         "react-datepicker__quarter-text--keyboard-selected":
           utils.getQuarter(preSelection) === q,
+        "react-datepicker__quarter-text--in-selecting-range":
+          this.isInSelectingRangeQuarter(q),
         "react-datepicker__quarter-text--in-range": utils.isQuarterInRange(
           startDate,
           endDate,
@@ -556,6 +589,7 @@ export default class Month extends React.Component {
             onKeyDown={(ev) => {
               this.onQuarterKeyDown(ev, q);
             }}
+            onMouseEnter={() => this.onQuarterMouseEnter(q)}
             className={this.getQuarterClassNames(q)}
             aria-selected={this.isSelectedQuarter(day, q, selected)}
             tabIndex={this.getQuarterTabIndex(q)}

--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -396,31 +396,6 @@
   margin: $datepicker__day-margin;
 }
 
-.react-datepicker__month,
-.react-datepicker__quarter {
-  &--selected,
-  &--in-selecting-range,
-  &--in-range {
-    border-radius: $datepicker__border-radius;
-    background-color: $datepicker__selected-color;
-    color: #fff;
-
-    &:hover {
-      background-color: darken($datepicker__selected-color, 5%);
-    }
-  }
-
-  &--disabled {
-    color: $datepicker__muted-color;
-    pointer-events: none;
-
-    &:hover {
-      cursor: default;
-      background-color: transparent;
-    }
-  }
-}
-
 .react-datepicker__day,
 .react-datepicker__month-text,
 .react-datepicker__quarter-text,
@@ -494,22 +469,6 @@
     &:hover {
       background-color: transparent;
     }
-  }
-}
-
-.react-datepicker__month-text,
-.react-datepicker__quarter-text {
-  &.react-datepicker__month--selected,
-  &.react-datepicker__month--in-range,
-  &.react-datepicker__quarter--selected,
-  &.react-datepicker__quarter--in-range {
-    &:hover {
-      background-color: $datepicker__selected-color;
-    }
-  }
-
-  &:hover {
-    background-color: $datepicker__background-color;
   }
 }
 

--- a/test/month_test.js
+++ b/test/month_test.js
@@ -218,7 +218,9 @@ describe("Month", () => {
       />
     );
     const month = monthComponent.find(".react-datepicker__month-text").at(0);
-    expect(month.hasClass("react-datepicker__month--disabled")).to.equal(true);
+    expect(month.hasClass("react-datepicker__month-text--disabled")).to.equal(
+      true
+    );
   });
 
   it("should not return disabled class if current date is before minDate but same month", () => {
@@ -230,9 +232,9 @@ describe("Month", () => {
       />
     );
     const month = monthComponent.find(".react-datepicker__month-text").at(0);
-    expect(month.hasClass("react-datepicker__month--disabled")).to.not.equal(
-      true
-    );
+    expect(
+      month.hasClass("react-datepicker__month-text--disabled")
+    ).to.not.equal(true);
   });
 
   it("should not return disabled class if current date is after maxDate but same month", () => {
@@ -244,9 +246,9 @@ describe("Month", () => {
       />
     );
     const month = monthComponent.find(".react-datepicker__month-text").at(0);
-    expect(month.hasClass("react-datepicker__month--disabled")).to.not.equal(
-      true
-    );
+    expect(
+      month.hasClass("react-datepicker__month-text--disabled")
+    ).to.not.equal(true);
   });
 
   it("should return disabled class if specified excludeDate", () => {
@@ -267,7 +269,7 @@ describe("Month", () => {
 
     [(1, 3, 6, 9)].forEach((i) => {
       const month = monthTexts.at(i);
-      expect(month.hasClass("react-datepicker__month--disabled")).to.equal(
+      expect(month.hasClass("react-datepicker__month-text--disabled")).to.equal(
         true
       );
     });
@@ -291,13 +293,13 @@ describe("Month", () => {
     const monthTexts = monthComponent.find(".react-datepicker__month-text");
     for (let i = 0; i < 6; i++) {
       const month = monthTexts.at(i);
-      expect(month.hasClass("react-datepicker__month--disabled")).to.equal(
+      expect(month.hasClass("react-datepicker__month-text--disabled")).to.equal(
         false
       );
     }
     for (let i = 6; i < 12; i++) {
       const month = monthTexts.at(i);
-      expect(month.hasClass("react-datepicker__month--disabled")).to.equal(
+      expect(month.hasClass("react-datepicker__month-text--disabled")).to.equal(
         true
       );
     }
@@ -312,6 +314,121 @@ describe("Month", () => {
       />
     );
     return runAxe(monthComponent.getDOMNode());
+  });
+
+  describe("selecting range", () => {
+    it("should add in-selecting-range class if month is between the selecting date and end date", () => {
+      const monthComponent = mount(
+        <Month
+          preSelection={utils.newDate("2015-01-01")}
+          day={utils.newDate("2015-01-01")}
+          endDate={utils.newDate("2015-03-01")}
+          selectingDate={utils.newDate("2015-02-01")}
+          selectsStart
+          showMonthYearPicker
+        />
+      );
+      const months = monthComponent.find(
+        ".react-datepicker__month-text--in-selecting-range"
+      );
+      expect(months.length).to.equal(2);
+      expect(months.at(0).text()).to.eq("Feb");
+      expect(months.at(1).text()).to.eq("Mar");
+    });
+
+    it("should add in-selecting-range class if month is between the start date and selecting date", () => {
+      const monthComponent = mount(
+        <Month
+          preSelection={utils.newDate("2015-01-01")}
+          day={utils.newDate("2015-01-01")}
+          startDate={utils.newDate("2015-02-01")}
+          selectingDate={utils.newDate("2015-03-01")}
+          selectsEnd
+          showMonthYearPicker
+        />
+      );
+      const months = monthComponent.find(
+        ".react-datepicker__month-text--in-selecting-range"
+      );
+
+      expect(months.length).to.equal(2);
+      expect(months.at(0).text()).to.eq("Feb");
+      expect(months.at(1).text()).to.eq("Mar");
+    });
+
+    it("should use pre selection date if selecting date is not defined", () => {
+      const monthComponent = mount(
+        <Month
+          preSelection={utils.newDate("2015-03-01")}
+          day={utils.newDate("2015-01-01")}
+          startDate={utils.newDate("2015-02-01")}
+          selectsEnd
+          showMonthYearPicker
+        />
+      );
+      const months = monthComponent.find(
+        ".react-datepicker__month-text--in-selecting-range"
+      );
+
+      expect(months.length).to.equal(2);
+      expect(months.at(0).text()).to.eq("Feb");
+      expect(months.at(1).text()).to.eq("Mar");
+    });
+
+    it("should add in-selecting-range class for one month picker if month is between the start date and selecting date", () => {
+      const monthComponent = mount(
+        <Month
+          preSelection={utils.newDate("2015-01-01")}
+          day={utils.newDate("2015-01-01")}
+          startDate={utils.newDate("2015-02-01")}
+          selectingDate={utils.newDate("2015-03-01")}
+          selectsRange
+          showMonthYearPicker
+        />
+      );
+      const months = monthComponent.find(
+        ".react-datepicker__month-text--in-selecting-range"
+      );
+
+      expect(months.length).to.equal(2);
+      expect(months.at(0).text()).to.eq("Feb");
+      expect(months.at(1).text()).to.eq("Mar");
+    });
+
+    it("should not add in-selecting-range class for one month picker if the start date is not defined", () => {
+      const monthComponent = mount(
+        <Month
+          preSelection={utils.newDate("2015-01-01")}
+          day={utils.newDate("2015-01-01")}
+          selectingDate={utils.newDate("2015-03-01")}
+          selectsRange
+          showMonthYearPicker
+        />
+      );
+      const months = monthComponent.find(
+        ".react-datepicker__month-text--in-selecting-range"
+      );
+
+      expect(months.length).to.equal(0);
+    });
+
+    it("should not add in-selecting-range class for one month picker if the end date is defined", () => {
+      const monthComponent = mount(
+        <Month
+          preSelection={utils.newDate("2015-01-01")}
+          day={utils.newDate("2015-01-01")}
+          selectingDate={utils.newDate("2015-03-01")}
+          endDate={utils.newDate("2015-03-01")}
+          selectsRange
+          showMonthYearPicker
+        />
+      );
+      const months = monthComponent.find(
+        ".react-datepicker__month-text--in-selecting-range"
+      );
+
+      expect(months.length).to.equal(0);
+    });
   });
 
   describe("if month is selected", () => {
@@ -331,7 +448,7 @@ describe("Month", () => {
     });
 
     it("should return selected class", () => {
-      expect(month.hasClass("react-datepicker__month--selected")).to.equal(
+      expect(month.hasClass("react-datepicker__month-text--selected")).to.equal(
         true
       );
     });
@@ -359,7 +476,7 @@ describe("Month", () => {
     });
 
     it("should not have the selected class", () => {
-      expect(month.hasClass("react-datepicker__month--selected")).to.equal(
+      expect(month.hasClass("react-datepicker__month-text--selected")).to.equal(
         false
       );
     });
@@ -380,8 +497,8 @@ describe("Month", () => {
         showMonthYearPicker
       />
     );
-    const quarter = monthComponent.find(".react-datepicker__month-text").at(2);
-    expect(quarter.hasClass("react-datepicker__month--in-range")).to.equal(
+    const month = monthComponent.find(".react-datepicker__month-text").at(2);
+    expect(month.hasClass("react-datepicker__month-text--in-range")).to.equal(
       true
     );
   });
@@ -469,9 +586,9 @@ describe("Month", () => {
     const quarter = monthComponent
       .find(".react-datepicker__quarter-text")
       .at(0);
-    expect(quarter.hasClass("react-datepicker__quarter--disabled")).to.equal(
-      true
-    );
+    expect(
+      quarter.hasClass("react-datepicker__quarter-text--disabled")
+    ).to.equal(true);
   });
 
   describe("if quarter is selected", () => {
@@ -491,9 +608,9 @@ describe("Month", () => {
     });
 
     it("should return selected class", () => {
-      expect(quarter.hasClass("react-datepicker__quarter--selected")).to.equal(
-        true
-      );
+      expect(
+        quarter.hasClass("react-datepicker__quarter-text--selected")
+      ).to.equal(true);
     });
 
     it('should set aria-selected attribute to "true"', () => {
@@ -521,9 +638,9 @@ describe("Month", () => {
     });
 
     it("should not return selected class", () => {
-      expect(quarter.hasClass("react-datepicker__quarter--selected")).to.equal(
-        false
-      );
+      expect(
+        quarter.hasClass("react-datepicker__quarter-text--selected")
+      ).to.equal(false);
     });
 
     it('should set aria-selected attribute to "false"', () => {
@@ -545,9 +662,9 @@ describe("Month", () => {
     const quarter = monthComponent
       .find(".react-datepicker__quarter-text")
       .at(2);
-    expect(quarter.hasClass("react-datepicker__quarter--in-range")).to.equal(
-      true
-    );
+    expect(
+      quarter.hasClass("react-datepicker__quarter-text--in-range")
+    ).to.equal(true);
   });
 
   it("should enable keyboard focus on the preselected component", () => {
@@ -953,7 +1070,7 @@ describe("Month", () => {
 
       expect(
         monthComponent
-          .find(".react-datepicker__month--selected")
+          .find(".react-datepicker__month-text--selected")
           .hasClass("react-datepicker__month-text--keyboard-selected")
       ).to.equal(false);
     });

--- a/test/month_test.js
+++ b/test/month_test.js
@@ -316,7 +316,7 @@ describe("Month", () => {
     return runAxe(monthComponent.getDOMNode());
   });
 
-  describe("selecting range", () => {
+  describe("selecting month range", () => {
     it("should add in-selecting-range class if month is between the selecting date and end date", () => {
       const monthComponent = mount(
         <Month
@@ -428,6 +428,123 @@ describe("Month", () => {
       );
 
       expect(months.length).to.equal(0);
+    });
+  });
+
+  describe("selecting quarter range", () => {
+    it("should add in-selecting-range class if quarter is between the selecting date and end date", () => {
+      const monthComponent = mount(
+        <Month
+          preSelection={utils.newDate("2015-01-01")}
+          day={utils.newDate("2015-01-01")}
+          endDate={utils.newDate("2015-07-01")}
+          selectingDate={utils.newDate("2015-04-01")}
+          selectsStart
+          showQuarterYearPicker
+        />
+      );
+
+      const quarters = monthComponent.find(
+        ".react-datepicker__quarter-text--in-selecting-range"
+      );
+
+      expect(quarters.length).to.equal(2);
+      expect(quarters.at(0).text()).to.eq("Q2");
+      expect(quarters.at(1).text()).to.eq("Q3");
+    });
+
+    it("should add in-selecting-range class if quarter is between the start date and selecting date", () => {
+      const monthComponent = mount(
+        <Month
+          preSelection={utils.newDate("2015-01-01")}
+          day={utils.newDate("2015-01-01")}
+          startDate={utils.newDate("2015-04-01")}
+          selectingDate={utils.newDate("2015-07-01")}
+          selectsEnd
+          showQuarterYearPicker
+        />
+      );
+      const quarters = monthComponent.find(
+        ".react-datepicker__quarter-text--in-selecting-range"
+      );
+
+      expect(quarters.length).to.equal(2);
+      expect(quarters.at(0).text()).to.eq("Q2");
+      expect(quarters.at(1).text()).to.eq("Q3");
+    });
+
+    it("should use pre selection date if selecting date is not defined", () => {
+      const monthComponent = mount(
+        <Month
+          preSelection={utils.newDate("2015-07-01")}
+          day={utils.newDate("2015-01-01")}
+          startDate={utils.newDate("2015-04-01")}
+          selectsEnd
+          showQuarterYearPicker
+        />
+      );
+      const quarters = monthComponent.find(
+        ".react-datepicker__quarter-text--in-selecting-range"
+      );
+
+      expect(quarters.length).to.equal(2);
+      expect(quarters.at(0).text()).to.eq("Q2");
+      expect(quarters.at(1).text()).to.eq("Q3");
+    });
+
+    it("should add in-selecting-range class for one quarter picker if quarter is between the start date and selecting date", () => {
+      const monthComponent = mount(
+        <Month
+          preSelection={utils.newDate("2015-01-01")}
+          day={utils.newDate("2015-01-01")}
+          startDate={utils.newDate("2015-04-01")}
+          selectingDate={utils.newDate("2015-07-01")}
+          selectsRange
+          showQuarterYearPicker
+        />
+      );
+      const quarters = monthComponent.find(
+        ".react-datepicker__quarter-text--in-selecting-range"
+      );
+
+      expect(quarters.length).to.equal(2);
+      expect(quarters.at(0).text()).to.eq("Q2");
+      expect(quarters.at(1).text()).to.eq("Q3");
+    });
+
+    it("should not add in-selecting-range class for one quarter picker if the start date is not defined", () => {
+      const monthComponent = mount(
+        <Month
+          preSelection={utils.newDate("2015-01-01")}
+          day={utils.newDate("2015-01-01")}
+          selectingDate={utils.newDate("2015-04-01")}
+          selectsRange
+          showQuarterYearPicker
+        />
+      );
+      const quarters = monthComponent.find(
+        ".react-datepicker__quarter-text--in-selecting-range"
+      );
+
+      expect(quarters.length).to.equal(0);
+    });
+
+    it("should not add in-selecting-range class for one quarter picker if the end date is defined", () => {
+      const monthComponent = mount(
+        <Month
+          preSelection={utils.newDate("2015-01-01")}
+          day={utils.newDate("2015-01-01")}
+          selectingDate={utils.newDate("2015-04-01")}
+          endDate={utils.newDate("2015-07-01")}
+          selectsRange
+          showQuarterYearPicker
+        />
+      );
+      const quarters = monthComponent.find(
+        ".react-datepicker__quarter-text--in-selecting-range"
+      );
+
+      expect(quarters.length).to.equal(0);
     });
   });
 


### PR DESCRIPTION
1. Added missing `--in-selecting-range` modifier to month/quarter range picker.
2. Added examples of `selectsRange` for month/quarter range picker.
3. Changed `.react-datepicker__month--* `class to `.react-datepicker__month-text--*` because the `.react-datepicker__month` is a parent element of `.react-datepicker__month-text`. This change made it possible to reuse styles from `.react-datepicker__day`, reducing duplicated css.

https://github.com/Hacker0x01/react-datepicker/issues/3954
https://github.com/Hacker0x01/react-datepicker/issues/3904