### PR TITLE
Revert "fix: Inconsistent/broken behavior in `parseDate` "

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -496,7 +496,6 @@ export default class DatePicker extends React.Component {
       this.props.dateFormat,
       this.props.locale,
       this.props.strictParsing,
-      this.props.selected,
       this.props.minDate
     );
     // Use date from `selected` prop when manipulating only time for input value

--- a/test/date_utils_test.js
+++ b/test/date_utils_test.js
@@ -884,45 +884,21 @@ describe("date_utils", function () {
       expect(parseDate(value, dateFormat, null, true)).to.not.be.null;
     });
 
+    it("should parse date based on locale", () => {
+      const value = "26/05/1995";
+      const dateFormat = "P";
+
+      const expected = new Date("05/26/1995");
+      const actual = parseDate(value, dateFormat, "pt-BR", true);
+
+      assert(isEqual(actual, expected));
+    });
+
     it("should parse date that matches one of the formats", () => {
       const value = "01/15/2019";
-      const dateFormat = ["yyyy-MM-dd", "MM/dd/yyyy"];
+      const dateFormat = ["MM/dd/yyyy", "yyyy-MM-dd"];
 
       expect(parseDate(value, dateFormat, null, true)).to.not.be.null;
-    });
-
-    it("should prefer the first matching format in array (strict)", () => {
-      const value = "01/06/2019";
-      const valueLax = "1/6/2019";
-      const dateFormat = ["MM/dd/yyyy", "dd/MM/yyyy"];
-
-      const expected = new Date(2019, 0, 6);
-
-      assert(
-        isEqual(parseDate(value, dateFormat, null, true), expected),
-        "Value with exact format"
-      );
-      expect(
-        parseDate(valueLax, dateFormat, null, true),
-        "Value with lax format"
-      ).to.be.null;
-    });
-
-    it("should prefer the first matching format in array", () => {
-      const value = "01/06/2019";
-      const valueLax = "1/6/2019";
-      const dateFormat = ["MM/dd/yyyy", "dd/MM/yyyy"];
-
-      const expected = new Date(2019, 0, 6);
-
-      assert(
-        isEqual(parseDate(value, dateFormat, null, false), expected),
-        "Value with exact format"
-      );
-      assert(
-        isEqual(parseDate(valueLax, dateFormat, null, false), expected),
-        "Value with lax format"
-      );
     });
 
     it("should not parse date that does not match the format", () => {
@@ -940,55 +916,20 @@ describe("date_utils", function () {
     });
 
     it("should parse date without strict parsing", () => {
-      const value = "1/2/2020";
+      const value = "01/15/20";
       const dateFormat = "MM/dd/yyyy";
 
       expect(parseDate(value, dateFormat, null, false)).to.not.be.null;
     });
 
-    it("should parse date based on locale", () => {
-      const value = "26/05/1995";
-      const locale = "pt-BR";
-      const dateFormat = "P";
-
-      const expected = new Date(1995, 4, 26);
-      const actual = parseDate(value, dateFormat, locale, true);
-
-      assert(isEqual(actual, expected));
-    });
-
     it("should parse date based on locale without strict parsing", () => {
       const value = "26/05/1995";
-      const locale = "pt-BR";
       const dateFormat = "P";
 
-      const expected = new Date(1995, 4, 26);
-      const actual = parseDate(value, dateFormat, locale, false);
+      const expected = new Date("05/26/1995");
+      const actual = parseDate(value, dateFormat, "pt-BR", false);
 
       assert(isEqual(actual, expected));
-    });
-
-    it("should parse date based on locale w/o strict", () => {
-      const valuePt = "26. fev 1995";
-      const valueEn = "26. feb 1995";
-
-      const locale = "pt-BR";
-      const dateFormat = "d. MMM yyyy";
-
-      const expected = new Date(1995, 1, 26);
-
-      assert(
-        isEqual(parseDate(valuePt, dateFormat, locale, false), expected),
-        "valuePT with pt-BR"
-      );
-      assert(
-        isEqual(parseDate(valueEn, dateFormat, null, false), expected),
-        "valueEn with default (en-US)"
-      );
-      expect(
-        parseDate(valueEn, dateFormat, locale, false),
-        "valuePt with default (en-US)"
-      ).to.be.null;
     });
 
     it("should not parse date based on locale without a given locale", () => {
@@ -1002,11 +943,10 @@ describe("date_utils", function () {
 
     it("should parse date based on default locale", () => {
       const value = "26/05/1995";
-      const locale = "pt-BR";
       const dateFormat = "P";
 
-      const expected = new Date(1995, 4, 26);
-      setDefaultLocale(locale);
+      const expected = new Date("05/26/1995");
+      setDefaultLocale("pt-BR");
       const actual = parseDate(value, dateFormat, null, false);
       setDefaultLocale(null);
 

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -507,9 +507,9 @@ describe("DatePicker", () => {
       />
     );
 
-    TestUtils.Simulate.change(datePicker.input, {
-      target: { value: "01/02/2014" },
-    });
+    var input = ReactDOM.findDOMNode(datePicker.input);
+    input.value = utils.newDate("2014-01-02");
+    TestUtils.Simulate.change(input);
 
     expect(utils.getHours(date)).to.equal(10);
     expect(utils.getMinutes(date)).to.equal(11);
@@ -880,7 +880,7 @@ describe("DatePicker", () => {
       datePicker = TestUtils.renderIntoDocument(
         <DatePicker
           selected={new Date("1993-07-02")}
-          minDate={new Date("1800-01-01")}
+          minDate={new Date("1800/01/01")}
           open
         />
       );
@@ -889,11 +889,11 @@ describe("DatePicker", () => {
     it("should auto update calendar when the updated date text is after props.minDate", () => {
       TestUtils.Simulate.change(datePicker.input, {
         target: {
-          value: "01/01/1801",
+          value: "1801/01/01",
         },
       });
 
-      expect(datePicker.input.value).to.equal("01/01/1801");
+      expect(datePicker.input.value).to.equal("1801/01/01");
       expect(
         datePicker.calendar.componentNode.querySelector(
           ".react-datepicker__current-month"
@@ -965,7 +965,7 @@ describe("DatePicker", () => {
     it("should update the selected date on manual input", () => {
       var data = getOnInputKeyDownStuff();
       TestUtils.Simulate.change(data.nodeInput, {
-        target: { value: "2017-02-02" },
+        target: { value: "02/02/2017" },
       });
       TestUtils.Simulate.keyDown(data.nodeInput, getKey("Enter"));
       data.copyM = utils.newDate("2017-02-02");


### PR DESCRIPTION
Reverts Hacker0x01/react-datepicker#3903

Fixes https://github.com/Hacker0x01/react-datepicker/issues/3921, https://github.com/Hacker0x01/react-datepicker/issues/3952