### PR TITLE
Feature/today button can be accessed with keyboard

### DIFF
--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -706,11 +706,13 @@ export default class Calendar extends React.Component {
       return;
     }
     return (
-      <div
-        className="react-datepicker__today-button"
-        onClick={(e) => this.handleTodayButtonClick(e)}
-      >
-        {this.props.todayButton}
+      <div className="react-datepicker__today-button">
+        <button
+          className="react-datepicker__today-button-trigger"
+          onClick={(e) => this.handleTodayButtonClick(e)}
+        >
+          {this.props.todayButton}
+        </button>
       </div>
     );
   };

--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -652,11 +652,18 @@
 .react-datepicker__today-button {
   background: $datepicker__background-color;
   border-top: 1px solid $datepicker__border-color;
-  cursor: pointer;
-  text-align: center;
-  font-weight: bold;
+  display: flex;
+  justify-content: center;
   padding: 5px 0;
   clear: left;
+
+  .react-datepicker__today-button-trigger {
+    font-size: $datepicker__font-size;
+    border: 0;
+    background-color: transparent;
+    cursor: pointer;
+    font-weight: bold;
+  }
 }
 
 .react-datepicker__portal {

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -336,7 +336,7 @@ describe("DatePicker", () => {
     TestUtils.Simulate.click(anyOtherDay); // will update the preSelection to next or previous day
 
     var todayBtn = datePicker.calendar.componentNode.querySelector(
-      ".react-datepicker__today-button"
+      ".react-datepicker__today-button-trigger"
     );
     TestUtils.Simulate.click(todayBtn); // will update the preSelection
 


### PR DESCRIPTION
Hello! This PR addresses issue https://github.com/Hacker0x01/react-datepicker/issues/3885

>The Today Button is not accessible via Tab key for keyboard users

Our apps have just been audited and not being able to reach the "Today" button with the keyboard has been flagged as an issue.

I believe this change backwards compatible.

- I've added a `button` element inside the existing `div` and moved the event handler on to the button.
- I've adjusted the styles so that anyone who has previously customised the today button shouldn't notice any changes.

Some considerations:

- I think I would have preferred to change the css class names so that the parent `div` would be `react-datepicker__today-button-container` and then the `button` could have used `react-datepicker__today-button` but that would break any existing custom styles.
- We could just pass a button as the todayButton prop (despite the prop type being specified as `string`) but the click handler would still be on the parent `div` - admittedly not a big deal.