### PR TITLE
prevent focusing of hidden duplicate days

### DIFF
--- a/src/day.jsx
+++ b/src/day.jsx
@@ -323,6 +323,13 @@ export default class Day extends React.Component {
       ) {
         shouldFocusDay = true;
       }
+      //day is one of the non rendered duplicate days
+      if (this.props.monthShowsDuplicateDaysEnd && this.isAfterMonth()) {
+        shouldFocusDay = false;
+      }
+      if (this.props.monthShowsDuplicateDaysStart && this.isBeforeMonth()) {
+        shouldFocusDay = false;
+      }
     }
 
     shouldFocusDay && this.dayEl.current.focus({ preventScroll: true });


### PR DESCRIPTION
When using the keyboard navigation to select a day that also exists as hidden duplicate on the next month while displaying multiple months, this hidden day will be focused instead of the visible day in the current month.

This pull request prevents that behavior.