### PR TITLE
Added check for date-fns set

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -501,6 +501,7 @@ export default class DatePicker extends React.Component {
     // Use date from `selected` prop when manipulating only time for input value
     if (
       this.props.showTimeSelectOnly &&
+      this.props.selected &&
       !isSameDay(date, this.props.selected)
     ) {
       if (date == null) {


### PR DESCRIPTION
This fix is related to https://github.com/Hacker0x01/react-datepicker/issues/3952

Specifically when, we try and Input a custom time into a blank input field, the component crashes.

It appears to be because the `set` method is being called on a null object ( i.e the.props.selected )
