### PR TITLE
fix: fix selects range acts as default picker

### DIFF
--- a/docs-site/src/examples/dateRangeWithShowDisabledNavigation.js
+++ b/docs-site/src/examples/dateRangeWithShowDisabledNavigation.js
@@ -1,11 +1,21 @@
 () => {
-  const [startDate, setStartDate] = useState(null);
+  const [startDate, setStartDate] = useState(new Date());
+  const [endDate, setEndDate] = useState(null);
+  const onChange = (dates) => {
+    const [start, end] = dates;
+    setStartDate(start);
+    setEndDate(end);
+  };
   return (
     <DatePicker
       selected={startDate}
-      onChange={(date) => setStartDate(date)}
+      onChange={onChange}
       minDate={new Date()}
       maxDate={addMonths(new Date(), 5)}
+      startDate={startDate}
+      endDate={endDate}
+      selectsRange
+      inline
       showDisabledMonthNavigation
     />
   );


### PR DESCRIPTION
**Purpose**: The [Date Range with disabled navigation shown](https://reactdatepicker.com/#example-date-range-with-disabled-navigation-shown) is supposed to be date range but it misses some props and acts as default date picker.