### PR TITLE
Draft: Feature: add custom contents for times

### DIFF
--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -200,6 +200,7 @@ export default class Calendar extends React.Component {
     weekAriaLabelPrefix: PropTypes.string,
     monthAriaLabelPrefix: PropTypes.string,
     setPreSelection: PropTypes.func,
+    renderTimeContents: PropTypes.func,
   };
 
   constructor(props) {
@@ -964,6 +965,7 @@ export default class Calendar extends React.Component {
           locale={this.props.locale}
           handleOnKeyDown={this.props.handleOnKeyDown}
           showTimeSelectOnly={this.props.showTimeSelectOnly}
+          renderTimeContents={this.props.renderTimeContents}
         />
       );
     }

--- a/src/time.jsx
+++ b/src/time.jsx
@@ -54,6 +54,7 @@ export default class Time extends React.Component {
       PropTypes.shape({ locale: PropTypes.object }),
     ]),
     showTimeSelectOnly: PropTypes.bool,
+    renderTimeContents: PropTypes.func,
   };
 
   state = {
@@ -140,6 +141,13 @@ export default class Time extends React.Component {
     this.props.handleOnKeyDown(event);
   };
 
+  renderTimeContents = (time, format) => {
+    const formatTime = formatDate(time, format, this.props.locale);
+    return this.props.renderTimeContents
+      ? this.props.renderTimeContents(formatTime, time, format)
+      : formatTime;
+  };
+
   renderTimes = () => {
     let times = [];
     const format = this.props.format ? this.props.format : "p";
@@ -193,7 +201,7 @@ export default class Time extends React.Component {
           this.isSelectedTime(time, currH, currM) ? "true" : undefined
         }
       >
-        {formatDate(time, format, this.props.locale)}
+        {this.renderTimeContents(time, format)}
       </li>
     ));
   };


### PR DESCRIPTION
This PR aims to add a new a new function similar to `renderDayContents` for the time selection.

I have added the function and props. The tests are still missing, any help is very welcome.

It's my first commit, so if there is anything missing or "wrongly" done, please let me know.