### PR TITLE
Fix to use disabledKeyboardNavigation for date ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "css:modules:dev": "sass --style expanded src/stylesheets/datepicker-cssmodules.scss | tee dist/react-datepicker-cssmodules.css dist/react-datepicker.module.css",
     "build:js": "rollup -c",
     "js:dev": "rollup -cw",
-    "prepare": "husky install"
+    "prepare": "yarn run build && husky install"
   },
   "lint-staged": {
     "*.{js,jsx,json,css,scss,md}": [

--- a/src/day.jsxgit l
+++ b/src/day.jsxgit l
@@ -130,6 +130,14 @@ export default class Day extends React.Component {
     const selectingDate = this.props.selectingDate ?? this.props.preSelection;
 
     if (
+      this.props.disabledKeyboardNavigation &&
+      !this.props.selectingDate &&
+      !isEqual(this.props.selected, this.props.preSelection)
+    ) {
+      return false;
+    }
+
+    if (
       !(selectsStart || selectsEnd || selectsRange) ||
       !selectingDate ||
       (!selectsDisabledDaysInRange && this.isDisabled())


### PR DESCRIPTION
Fixes the issue described in:
https://github.com/Hacker0x01/react-datepicker/issues/4015#issuecomment-1561806887