### PR TITLE
Fix to use disabledKeyboardNavigation for date ranges

### DIFF
--- a/src/day.jsx
+++ b/src/day.jsx
@@ -130,6 +130,14 @@ export default class Day extends React.Component {
     const selectingDate = this.props.selectingDate ?? this.props.preSelection;
 
     if (
+      this.props.disabledKeyboardNavigation &&
+      !this.props.selectingDate &&
+      !isEqual(this.props.selected, this.props.preSelection)
+    ) {
+      return false;
+    }
+
+    if (
       !(selectsStart || selectsEnd || selectsRange) ||
       !selectingDate ||
       (!selectsDisabledDaysInRange && this.isDisabled())


### PR DESCRIPTION
Fixes the issue described in:
https://github.com/Hacker0x01/react-datepicker/issues/4015#issuecomment-1561806887