### PR TITLE
ensure provided onMonthChange handlers are called when month change is caused by keyboard navigation

### DIFF
--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -29,6 +29,7 @@ import {
   getWeekdayShortInLocale,
   getWeekdayMinInLocale,
   isSameDay,
+  isSameMonth,
   monthDisabledBefore,
   monthDisabledAfter,
   yearDisabledBefore,
@@ -233,9 +234,16 @@ export default class Calendar extends React.Component {
       (!isSameDay(this.props.preSelection, prevProps.preSelection) ||
         this.props.monthSelectedIn !== prevProps.monthSelectedIn)
     ) {
-      this.setState({
-        date: this.props.preSelection,
-      });
+      const hasMonthChanged = !isSameMonth(
+        this.state.date,
+        this.props.preSelection
+      );
+      this.setState(
+        {
+          date: this.props.preSelection,
+        },
+        () => hasMonthChanged && this.handleCustomMonthChange(this.state.date)
+      );
     } else if (
       this.props.openToDate &&
       !isSameDay(this.props.openToDate, prevProps.openToDate)
@@ -329,10 +337,7 @@ export default class Calendar extends React.Component {
   };
 
   handleMonthChange = (date) => {
-    if (this.props.onMonthChange) {
-      this.props.onMonthChange(date);
-      this.setState({ isRenderAriaLiveMessage: true });
-    }
+    this.handleCustomMonthChange(date);
     if (this.props.adjustDateOnChange) {
       if (this.props.onSelect) {
         this.props.onSelect(date);
@@ -343,6 +348,13 @@ export default class Calendar extends React.Component {
     }
 
     this.props.setPreSelection && this.props.setPreSelection(date);
+  };
+
+  handleCustomMonthChange = (date) => {
+    if (this.props.onMonthChange) {
+      this.props.onMonthChange(date);
+      this.setState({ isRenderAriaLiveMessage: true });
+    }
   };
 
   handleMonthYearChange = (date) => {

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -752,6 +752,29 @@ describe("DatePicker", () => {
       utils.formatDate(data.datePicker.state.preSelection, data.testFormat)
     ).to.equal(utils.formatDate(data.copyM, data.testFormat));
   });
+  it("should call onMonthchange when keyboard navigation moves preSelection to different month", () => {
+    var onMonthChangeSpy = sandbox.spy();
+    var opts = { onMonthChange: onMonthChangeSpy };
+    var data = getOnInputKeyDownStuff(opts);
+    TestUtils.Simulate.keyDown(data.nodeInput, getKey("ArrowDown"));
+    TestUtils.Simulate.keyDown(
+      getSelectedDayNode(data.datePicker),
+      getKey("PageDown")
+    );
+
+    expect(onMonthChangeSpy.calledOnce).to.be.true;
+  });
+  it("should call onSelect only once when keyboard navigation moves selection to different month", () => {
+    var onSelectSpy = sandbox.spy();
+    var opts = { onSelect: onSelectSpy, adjustDateOnChange: true };
+    var data = getOnInputKeyDownStuff(opts);
+    TestUtils.Simulate.keyDown(data.nodeInput, getKey("ArrowDown"));
+    TestUtils.Simulate.keyDown(
+      getSelectedDayNode(data.datePicker),
+      getKey("PageDown")
+    );
+    expect(onSelectSpy.calledOnce).to.be.true;
+  });
   it("should not preSelect date if not between minDate and maxDate", () => {
     var data = getOnInputKeyDownStuff({
       minDate: utils.subDays(utils.newDate(), 1),


### PR DESCRIPTION
Currently, externaly provided onMonthChange handlers are not called when the current month is changed via the keyboard navigation.

This change detects if the preSelection coming from the keyboard navigation will move the date of the calendar over a month border and calls onMonthChange handlers if necessary.