### PR TITLE
[FIX][Month picker] Selected month follows preselected month

### DIFF
--- a/src/month.jsx
+++ b/src/month.jsx
@@ -275,7 +275,8 @@ export default class Month extends React.Component {
     q === utils.getQuarter(utils.newDate());
 
   isSelectedMonth = (day, m, selected) =>
-    utils.getMonth(day) === m && utils.getYear(day) === utils.getYear(selected);
+    utils.getMonth(selected) === m &&
+    utils.getYear(day) === utils.getYear(selected);
 
   isSelectedQuarter = (day, q, selected) =>
     utils.getQuarter(day) === q &&


### PR DESCRIPTION
When selected month changes, the `react-datepicker__month-text--selected` class stays on the selected month.

### Before
 https://github.com/Hacker0x01/react-datepicker/assets/117300300/2540c7b8-efd5-420a-a372-909acb47107e  
 
 
### After
 https://github.com/Hacker0x01/react-datepicker/assets/117300300/bc434d39-9d83-4569-938a-3d9ccd4dd92a 






