### PR TITLE
[FEAT] Custom content renders for month, quarter and year

### DIFF
--- a/docs-site/src/components/Examples/index.js
+++ b/docs-site/src/components/Examples/index.js
@@ -72,6 +72,9 @@ import DontCloseOnSelect from "../../examples/dontCloseOnSelect";
 import RenderCustomHeader from "../../examples/renderCustomHeader";
 import RenderCustomHeaderTwoMonths from "../../examples/renderCustomHeaderTwoMonths";
 import RenderCustomDay from "../../examples/renderCustomDay";
+import RenderCustomMonth from "../../examples/renderCustomMonth";
+import RenderCustomQuarter from "../../examples/renderCustomQuarter";
+import RenderCustomYear from "../../examples/renderCustomYear";
 import TimeInput from "../../examples/timeInput";
 import StrictParsing from "../../examples/strictParsing";
 import MonthPicker from "../../examples/monthPicker";
@@ -169,6 +172,18 @@ export default class exampleComponents extends React.Component {
     {
       title: "Custom Day",
       component: RenderCustomDay,
+    },
+    {
+      title: "Custom Month",
+      component: RenderCustomMonth,
+    },
+    {
+      title: "Custom Quarter",
+      component: RenderCustomQuarter,
+    },
+    {
+      title: "Custom Year",
+      component: RenderCustomYear,
     },
     {
       title: "Custom calendar class name",

--- a/docs-site/src/examples/renderCustomMonth.js
+++ b/docs-site/src/examples/renderCustomMonth.js
@@ -1,0 +1,14 @@
+() => {
+  const renderMonthContent = (month, shortMonth, longMonth) => {
+    const tooltipText = `Tooltip for month: ${longMonth}`;
+    return <span title={tooltipText}>{shortMonth}</span>;
+  };
+  return (
+    <DatePicker
+      selected={new Date()}
+      renderMonthContent={renderMonthContent}
+      showMonthYearPicker
+      dateFormat="MM/yyyy"
+    />
+  );
+};

--- a/docs-site/src/examples/renderCustomQuarter.js
+++ b/docs-site/src/examples/renderCustomQuarter.js
@@ -1,0 +1,14 @@
+() => {
+  const renderQuarterContent = (quarter, shortQuarter) => {
+    const tooltipText = `Tooltip for quarter: ${quarter}`;
+    return <span title={tooltipText}>{shortQuarter}</span>;
+  };
+  return (
+    <DatePicker
+      selected={new Date()}
+      renderQuarterContent={renderQuarterContent}
+      showQuarterYearPicker
+      dateFormat="yyyy, QQQ"
+    />
+  );
+};

--- a/docs-site/src/examples/renderCustomYear.js
+++ b/docs-site/src/examples/renderCustomYear.js
@@ -1,0 +1,14 @@
+() => {
+  const renderYearContent = (year) => {
+    const tooltipText = `Tooltip for year: ${year}`;
+    return <span title={tooltipText}>{year}</span>;
+  };
+  return (
+    <DatePicker
+      selected={new Date()}
+      renderYearContent={renderYearContent}
+      showYearPicker
+      dateFormat="yyyy"
+    />
+  );
+};

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,151 +1,154 @@
 # `index` (component)
 
-| name                            | type                           | default value            | description |
-| ------------------------------- | ------------------------------ | ------------------------ | ----------- |
-| `adjustDateOnChange`            | `bool`                         |                          |             |
-| `allowSameDay`                  | `bool`                         | `false`                  |             |
-| `ariaDescribedBy`               | `string`                       |                          |             |
-| `ariaInvalid`                   | `string`                       |                          |             |
-| `ariaLabelClose`                | `string`                       |                          |             |
-| `ariaLabelledBy`                | `string`                       |                          |             |
-| `ariaRequired`                  | `string`                       |                          |             |
-| `autoComplete`                  | `string`                       |                          |             |
-| `autoFocus`                     | `bool`                         |                          |             |
-| `calendarClassName`             | `string`                       |                          |             |
-| `calendarContainer`             | `func`                         |                          |             |
-| `calendarStartDay`              | `number`                       | `undefined`              |             |
-| `children`                      | `node`                         |                          |             |
-| `chooseDayAriaLabelPrefix`      | `string`                       |                          |             |
-| `className`                     | `string`                       |                          |             |
-| `clearButtonClassName`          | `string`                       |                          |             |
-| `clearButtonTitle`              | `string`                       |                          |             |
-| `closeOnScroll`                 | `union(bool\|func)`            |                          |             |
-| `customInput`                   | `element`                      |                          |             |
-| `customInputRef`                | `string`                       |                          |             |
-| `customTimeInput`               | `element`                      | `null`                   |             |
-| `dateFormat`                    | `union(string\|array)`         | `"MM/dd/yyyy"`           |             |
-| `dateFormatCalendar`            | `string`                       | `"LLLL yyyy"`            |             |
-| `dayClassName`                  | `func`                         |                          |             |
-| `disabled`                      | `bool`                         | `false`                  |             |
-| `disabledDayAriaLabelPrefix`    | `string`                       |                          |             |
-| `disabledKeyboardNavigation`    | `bool`                         | `false`                  |             |
-| `dropdownMode`                  | `enum("scroll"\|"select")`     | `"scroll"`               |             |
-| `enableTabLoop`                 | `bool`                         | `true`                   |             |
-| `endDate`                       | `instanceOfDate`               |                          |             |
-| `excludeDateIntervals`          | `arrayOf[object Object]`       |                          |             |
-| `excludeDates`                  | `array`                        |                          |             |
-| `excludeScrollbar`              | `bool`                         | `true`                   |             |
-| `excludeTimes`                  | `array`                        |                          |             |
-| `filterDate`                    | `func`                         |                          |             |
-| `filterTime`                    | `func`                         |                          |             |
-| `fixedHeight`                   | `bool`                         |                          |             |
-| `focusSelectedMonth`            | `bool`                         | `false`                  |             |
-| `forceShowMonthNavigation`      | `bool`                         |                          |             |
-| `form`                          | `string`                       |                          |             |
-| `formatWeekDay`                 | `func`                         |                          |             |
-| `formatWeekNumber`              | `func`                         |                          |             |
-| `highlightDates`                | `array`                        |                          |             |
-| `id`                            | `string`                       |                          |             |
-| `includeDateIntervals`          | `array`                        |                          |             |
-| `includeDates`                  | `array`                        |                          |             |
-| `includeTimes`                  | `array`                        |                          |             |
-| `injectTimes`                   | `array`                        |                          |             |
-| `inline`                        | `bool`                         |                          |             |
-| `isClearable`                   | `bool`                         |                          |             |
-| `locale`                        | `union(string\|shape)`         |                          |             |
-| `maxDate`                       | `instanceOfDate`               |                          |             |
-| `maxTime`                       | `instanceOfDate`               |                          |             |
-| `minDate`                       | `instanceOfDate`               |                          |             |
-| `minTime`                       | `instanceOfDate`               |                          |             |
-| `monthAriaLabelPrefix`          | `string`                       |                          |             |
-| `monthClassName`                | `func`                         |                          |             |
-| `monthsShown`                   | `number`                       | `1`                      |             |
-| `name`                          | `string`                       |                          |             |
-| `nextMonthAriaLabel`            | `string`                       | `"Next Month"`           |             |
-| `nextMonthButtonLabel`          | `union(string\|node)`          | `"Next Month"`           |             |
-| `nextYearAriaLabel`             | `string`                       | `"Next Year"`            |             |
-| `nextYearButtonLabel`           | `string`                       | `"Next Year"`            |             |
-| `onBlur`                        | `func`                         | `() {}`                  |             |
-| `onCalendarClose`               | `func`                         | `() {}`                  |             |
-| `onCalendarOpen`                | `func`                         | `() {}`                  |             |
-| `onChange`                      | `func`                         | `() {}`                  |             |
-| `onChangeRaw`                   | `func`                         |                          |             |
-| `onClickOutside`                | `func`                         | `() {}`                  |             |
-| `onDayMouseEnter`               | `func`                         |                          |             |
-| `onFocus`                       | `func`                         | `() {}`                  |             |
-| `onInputClick`                  | `func`                         | `() {}`                  |             |
-| `onInputError`                  | `func`                         | `() {}`                  |             |
-| `onKeyDown`                     | `func`                         | `() {}`                  |             |
-| `onMonthChange`                 | `func`                         | `() {}`                  |             |
-| `onMonthMouseLeave`             | `func`                         |                          |             |
-| `onSelect`                      | `func`                         | `() {}`                  |             |
-| `onWeekSelect`                  | `func`                         |                          |             |
-| `onYearChange`                  | `func`                         | `() {}`                  |             |
-| `onYearMouseEnter`              | `func`                         |                          |             |
-| `onYearMouseLeave`              | `func`                         |                          |             |
-| `open`                          | `bool`                         |                          |             |
-| `openToDate`                    | `instanceOfDate`               |                          |             |
-| `peekNextMonth`                 | `bool`                         |                          |             |
-| `placeholderText`               | `string`                       |                          |             |
-| `popperClassName`               | `string`                       |                          |             |
-| `popperContainer`               | `func`                         |                          |             |
-| `popperModifiers`               | `arrayOf[object Object]`       |                          |             |
-| `popperPlacement`               | `enumpopperPlacementPositions` |                          |             |
-| `popperProps`                   | `object`                       |                          |             |
-| `portalHost`                    | `instanceOfShadowRoot`         |                          |             |
-| `portalId`                      | `string`                       |                          |             |
-| `preventOpenOnFocus`            | `bool`                         | `false`                  |             |
-| `previousMonthAriaLabel`        | `string`                       | `"Previous Month"`       |             |
-| `previousMonthButtonLabel`      | `union(string\|node)`          | `"Previous Month"`       |             |
-| `previousYearAriaLabel`         | `string`                       | `"Previous Year"`        |             |
-| `previousYearButtonLabel`       | `string`                       | `"Previous Year"`        |             |
-| `readOnly`                      | `bool`                         | `false`                  |             |
-| `renderCustomHeader`            | `func`                         |                          |             |
-| `renderDayContents`             | `func`                         | `(date) { return date;}` |             |
-| `required`                      | `bool`                         |                          |             |
-| `scrollableMonthYearDropdown`   | `bool`                         |                          |             |
-| `scrollableYearDropdown`        | `bool`                         |                          |             |
-| `selected`                      | `instanceOfDate`               |                          |             |
-| `selectsDisabledDaysInRange`    | `bool`                         | `false`                  |             |
-| `selectsEnd`                    | `bool`                         |                          |             |
-| `selectsRange`                  | `bool`                         |                          |             |
-| `selectsStart`                  | `bool`                         |                          |             |
-| `shouldCloseOnSelect`           | `bool`                         | `true`                   |             |
-| `showDisabledMonthNavigation`   | `bool`                         |                          |             |
-| `showFourColumnMonthYearPicker` | `bool`                         | `false`                  |             |
-| `showFullMonthYearPicker`       | `bool`                         | `false`                  |             |
-| `showIcon`                      | `bool`                         |                          |             |
-| `showMonthDropdown`             | `bool`                         |                          |             |
-| `showMonthYearDropdown`         | `bool`                         |                          |             |
-| `showMonthYearPicker`           | `bool`                         | `false`                  |             |
-| `showPopperArrow`               | `bool`                         | `true`                   |             |
-| `showPreviousMonths`            | `bool`                         | `false`                  |             |
-| `showQuarterYearPicker`         | `bool`                         | `false`                  |             |
-| `showTimeInput`                 | `bool`                         | `false`                  |             |
-| `showTimeSelect`                | `bool`                         | `false`                  |             |
-| `showTimeSelectOnly`            | `bool`                         |                          |             |
-| `showTwoColumnMonthYearPicker`  | `bool`                         | `false`                  |             |
-| `showWeekNumbers`               | `bool`                         |                          |             |
-| `showYearDropdown`              | `bool`                         |                          |             |
-| `showYearPicker`                | `bool`                         | `false`                  |             |
-| `startDate`                     | `instanceOfDate`               |                          |             |
-| `startOpen`                     | `bool`                         |                          |             |
-| `strictParsing`                 | `bool`                         | `false`                  |             |
-| `tabIndex`                      | `number`                       |                          |             |
-| `timeCaption`                   | `string`                       | `"Time"`                 |             |
-| `timeClassName`                 | `func`                         |                          |             |
-| `timeFormat`                    | `string`                       |                          |             |
-| `timeInputLabel`                | `string`                       | `"Time"`                 |             |
-| `timeIntervals`                 | `number`                       | `30`                     |             |
-| `title`                         | `string`                       |                          |             |
-| `todayButton`                   | `node`                         |                          |             |
-| `useShortMonthInDropdown`       | `bool`                         |                          |             |
-| `useWeekdaysShort`              | `bool`                         |                          |             |
-| `value`                         | `string`                       |                          |             |
-| `weekAriaLabelPrefix`           | `string`                       |                          |             |
-| `weekDayClassName`              | `func`                         |                          |             |
-| `weekLabel`                     | `string`                       |                          |             |
-| `withPortal`                    | `bool`                         | `false`                  |             |
-| `wrapperClassName`              | `string`                       |                          |             |
-| `yearDropdownItemNumber`        | `number`                       |                          |             |
-| `yearItemNumber`                | `number`                       | `12`                     |             |
+| name                            | type                           | default value      | description |
+| ------------------------------- | ------------------------------ | ------------------ | ----------- |
+| `adjustDateOnChange`            | `bool`                         |                    |             |
+| `allowSameDay`                  | `bool`                         | `false`            |             |
+| `ariaDescribedBy`               | `string`                       |                    |             |
+| `ariaInvalid`                   | `string`                       |                    |             |
+| `ariaLabelClose`                | `string`                       |                    |             |
+| `ariaLabelledBy`                | `string`                       |                    |             |
+| `ariaRequired`                  | `string`                       |                    |             |
+| `autoComplete`                  | `string`                       |                    |             |
+| `autoFocus`                     | `bool`                         |                    |             |
+| `calendarClassName`             | `string`                       |                    |             |
+| `calendarContainer`             | `func`                         |                    |             |
+| `calendarStartDay`              | `number`                       | `undefined`        |             |
+| `children`                      | `node`                         |                    |             |
+| `chooseDayAriaLabelPrefix`      | `string`                       |                    |             |
+| `className`                     | `string`                       |                    |             |
+| `clearButtonClassName`          | `string`                       |                    |             |
+| `clearButtonTitle`              | `string`                       |                    |             |
+| `closeOnScroll`                 | `union(bool\|func)`            |                    |             |
+| `customInput`                   | `element`                      |                    |             |
+| `customInputRef`                | `string`                       |                    |             |
+| `customTimeInput`               | `element`                      | `null`             |             |
+| `dateFormat`                    | `union(string\|array)`         | `"MM/dd/yyyy"`     |             |
+| `dateFormatCalendar`            | `string`                       | `"LLLL yyyy"`      |             |
+| `dayClassName`                  | `func`                         |                    |             |
+| `disabled`                      | `bool`                         | `false`            |             |
+| `disabledDayAriaLabelPrefix`    | `string`                       |                    |             |
+| `disabledKeyboardNavigation`    | `bool`                         | `false`            |             |
+| `dropdownMode`                  | `enum("scroll"\|"select")`     | `"scroll"`         |             |
+| `enableTabLoop`                 | `bool`                         | `true`             |             |
+| `endDate`                       | `instanceOfDate`               |                    |             |
+| `excludeDateIntervals`          | `arrayOf[object Object]`       |                    |             |
+| `excludeDates`                  | `array`                        |                    |             |
+| `excludeScrollbar`              | `bool`                         | `true`             |             |
+| `excludeTimes`                  | `array`                        |                    |             |
+| `filterDate`                    | `func`                         |                    |             |
+| `filterTime`                    | `func`                         |                    |             |
+| `fixedHeight`                   | `bool`                         |                    |             |
+| `focusSelectedMonth`            | `bool`                         | `false`            |             |
+| `forceShowMonthNavigation`      | `bool`                         |                    |             |
+| `form`                          | `string`                       |                    |             |
+| `formatWeekDay`                 | `func`                         |                    |             |
+| `formatWeekNumber`              | `func`                         |                    |             |
+| `highlightDates`                | `array`                        |                    |             |
+| `id`                            | `string`                       |                    |             |
+| `includeDateIntervals`          | `array`                        |                    |             |
+| `includeDates`                  | `array`                        |                    |             |
+| `includeTimes`                  | `array`                        |                    |             |
+| `injectTimes`                   | `array`                        |                    |             |
+| `inline`                        | `bool`                         |                    |             |
+| `isClearable`                   | `bool`                         |                    |             |
+| `locale`                        | `union(string\|shape)`         |                    |             |
+| `maxDate`                       | `instanceOfDate`               |                    |             |
+| `maxTime`                       | `instanceOfDate`               |                    |             |
+| `minDate`                       | `instanceOfDate`               |                    |             |
+| `minTime`                       | `instanceOfDate`               |                    |             |
+| `monthAriaLabelPrefix`          | `string`                       |                    |             |
+| `monthClassName`                | `func`                         |                    |             |
+| `monthsShown`                   | `number`                       | `1`                |             |
+| `name`                          | `string`                       |                    |             |
+| `nextMonthAriaLabel`            | `string`                       | `"Next Month"`     |             |
+| `nextMonthButtonLabel`          | `union(string\|node)`          | `"Next Month"`     |             |
+| `nextYearAriaLabel`             | `string`                       | `"Next Year"`      |             |
+| `nextYearButtonLabel`           | `string`                       | `"Next Year"`      |             |
+| `onBlur`                        | `func`                         | `() {}`            |             |
+| `onCalendarClose`               | `func`                         | `() {}`            |             |
+| `onCalendarOpen`                | `func`                         | `() {}`            |             |
+| `onChange`                      | `func`                         | `() {}`            |             |
+| `onChangeRaw`                   | `func`                         |                    |             |
+| `onClickOutside`                | `func`                         | `() {}`            |             |
+| `onDayMouseEnter`               | `func`                         |                    |             |
+| `onFocus`                       | `func`                         | `() {}`            |             |
+| `onInputClick`                  | `func`                         | `() {}`            |             |
+| `onInputError`                  | `func`                         | `() {}`            |             |
+| `onKeyDown`                     | `func`                         | `() {}`            |             |
+| `onMonthChange`                 | `func`                         | `() {}`            |             |
+| `onMonthMouseLeave`             | `func`                         |                    |             |
+| `onSelect`                      | `func`                         | `() {}`            |             |
+| `onWeekSelect`                  | `func`                         |                    |             |
+| `onYearChange`                  | `func`                         | `() {}`            |             |
+| `onYearMouseEnter`              | `func`                         |                    |             |
+| `onYearMouseLeave`              | `func`                         |                    |             |
+| `open`                          | `bool`                         |                    |             |
+| `openToDate`                    | `instanceOfDate`               |                    |             |
+| `peekNextMonth`                 | `bool`                         |                    |             |
+| `placeholderText`               | `string`                       |                    |             |
+| `popperClassName`               | `string`                       |                    |             |
+| `popperContainer`               | `func`                         |                    |             |
+| `popperModifiers`               | `arrayOf[object Object]`       |                    |             |
+| `popperPlacement`               | `enumpopperPlacementPositions` |                    |             |
+| `popperProps`                   | `object`                       |                    |             |
+| `portalHost`                    | `instanceOfShadowRoot`         |                    |             |
+| `portalId`                      | `string`                       |                    |             |
+| `preventOpenOnFocus`            | `bool`                         | `false`            |             |
+| `previousMonthAriaLabel`        | `string`                       | `"Previous Month"` |             |
+| `previousMonthButtonLabel`      | `union(string\|node)`          | `"Previous Month"` |             |
+| `previousYearAriaLabel`         | `string`                       | `"Previous Year"`  |             |
+| `previousYearButtonLabel`       | `string`                       | `"Previous Year"`  |             |
+| `readOnly`                      | `bool`                         | `false`            |             |
+| `renderCustomHeader`            | `func`                         |                    |             |
+| `renderDayContents`             | `func`                         |                    |             |
+| `renderMonthContent`            | `func`                         |                    |             |
+| `renderQuarterContent`          | `func`                         |                    |             |
+| `renderYearContent`             | `func`                         |                    |             |
+| `required`                      | `bool`                         |                    |             |
+| `scrollableMonthYearDropdown`   | `bool`                         |                    |             |
+| `scrollableYearDropdown`        | `bool`                         |                    |             |
+| `selected`                      | `instanceOfDate`               |                    |             |
+| `selectsDisabledDaysInRange`    | `bool`                         | `false`            |             |
+| `selectsEnd`                    | `bool`                         |                    |             |
+| `selectsRange`                  | `bool`                         |                    |             |
+| `selectsStart`                  | `bool`                         |                    |             |
+| `shouldCloseOnSelect`           | `bool`                         | `true`             |             |
+| `showDisabledMonthNavigation`   | `bool`                         |                    |             |
+| `showFourColumnMonthYearPicker` | `bool`                         | `false`            |             |
+| `showFullMonthYearPicker`       | `bool`                         | `false`            |             |
+| `showIcon`                      | `bool`                         |                    |             |
+| `showMonthDropdown`             | `bool`                         |                    |             |
+| `showMonthYearDropdown`         | `bool`                         |                    |             |
+| `showMonthYearPicker`           | `bool`                         | `false`            |             |
+| `showPopperArrow`               | `bool`                         | `true`             |             |
+| `showPreviousMonths`            | `bool`                         | `false`            |             |
+| `showQuarterYearPicker`         | `bool`                         | `false`            |             |
+| `showTimeInput`                 | `bool`                         | `false`            |             |
+| `showTimeSelect`                | `bool`                         | `false`            |             |
+| `showTimeSelectOnly`            | `bool`                         |                    |             |
+| `showTwoColumnMonthYearPicker`  | `bool`                         | `false`            |             |
+| `showWeekNumbers`               | `bool`                         |                    |             |
+| `showYearDropdown`              | `bool`                         |                    |             |
+| `showYearPicker`                | `bool`                         | `false`            |             |
+| `startDate`                     | `instanceOfDate`               |                    |             |
+| `startOpen`                     | `bool`                         |                    |             |
+| `strictParsing`                 | `bool`                         | `false`            |             |
+| `tabIndex`                      | `number`                       |                    |             |
+| `timeCaption`                   | `string`                       | `"Time"`           |             |
+| `timeClassName`                 | `func`                         |                    |             |
+| `timeFormat`                    | `string`                       |                    |             |
+| `timeInputLabel`                | `string`                       | `"Time"`           |             |
+| `timeIntervals`                 | `number`                       | `30`               |             |
+| `title`                         | `string`                       |                    |             |
+| `todayButton`                   | `node`                         |                    |             |
+| `useShortMonthInDropdown`       | `bool`                         |                    |             |
+| `useWeekdaysShort`              | `bool`                         |                    |             |
+| `value`                         | `string`                       |                    |             |
+| `weekAriaLabelPrefix`           | `string`                       |                    |             |
+| `weekDayClassName`              | `func`                         |                    |             |
+| `weekLabel`                     | `string`                       |                    |             |
+| `withPortal`                    | `bool`                         | `false`            |             |
+| `wrapperClassName`              | `string`                       |                    |             |
+| `yearDropdownItemNumber`        | `number`                       |                    |             |
+| `yearItemNumber`                | `number`                       | `12`               |             |

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,107 +1,151 @@
 # `index` (component)
 
-| name                         | type                           | default value      | description |
-| ---------------------------- | ------------------------------ | ------------------ | ----------- |
-| `adjustDateOnChange`         | `bool`                         |                    |             |
-| `allowSameDay`               | `bool`                         | `false`            |             |
-| `ariaDescribedBy`            | `string`                       |                    |             |
-| `ariaInvalid`                | `string`                       |                    |             |
-| `ariaLabelClose`             | `string`                       |                    |             |
-| `ariaLabelledBy`             | `string`                       |                    |             |
-| `ariaRequired`               | `string`                       |                    |             |
-| `autoComplete`               | `string`                       |                    |             |
-| `autoFocus`                  | `bool`                         |                    |             |
-| `calendarClassName`          | `string`                       |                    |             |
-| `calendarContainer`          | `func`                         |                    |             |
-| `calendarStartDay`           | `number`                       | `undefined`        |             |
-| `children`                   | `node`                         |                    |             |
-| `chooseDayAriaLabelPrefix`   | `string`                       |                    |             |
-| `className`                  | `string`                       |                    |             |
-| `clearButtonClassName`       | `string`                       |                    |             |
-| `clearButtonTitle`           | `string`                       |                    |             |
-| `closeOnScroll`              | `union(bool\|func)`            |                    |             |
-| `customInput`                | `element`                      |                    |             |
-| `customInputRef`             | `string`                       |                    |             |
-| `customTimeInput`            | `element`                      | `null`             |             |
-| `dateFormat`                 | `union(string\|array)`         | `"MM/dd/yyyy"`     |             |
-| `dateFormatCalendar`         | `string`                       | `"LLLL yyyy"`      |             |
-| `dayClassName`               | `func`                         |                    |             |
-| `disabled`                   | `bool`                         | `false`            |             |
-| `disabledDayAriaLabelPrefix` | `string`                       |                    |             |
-| `disabledKeyboardNavigation` | `bool`                         | `false`            |             |
-| `dropdownMode`               | `enum("scroll"\|"select")`     | `"scroll"`         |             |
-| `enableTabLoop`              | `bool`                         | `true`             |             |
-| `endDate`                    | `instanceOfDate`               |                    |             |
-| `excludeDateIntervals`       | `arrayOf[object Object]`       |                    |             |
-| `excludeDates`               | `array`                        |                    |             |
-| `excludeScrollbar`           | `bool`                         | `true`             |             |
-| `excludeTimes`               | `array`                        |                    |             |
-| `filterDate`                 | `func`                         |                    |             |
-| `filterTime`                 | `func`                         |                    |             |
-| `fixedHeight`                | `bool`                         |                    |             |
-| `focusSelectedMonth`         | `bool`                         | `false`            |             |
-| `forceShowMonthNavigation`   | `bool`                         |                    |             |
-| `form`                       | `string`                       |                    |             |
-| `formatWeekDay`              | `func`                         |                    |             |
-| `formatWeekNumber`           | `func`                         |                    |             |
-| `highlightDates`             | `array`                        |                    |             |
-| `id`                         | `string`                       |                    |             |
-| `includeDateIntervals`       | `array`                        |                    |             |
-| `includeDates`               | `array`                        |                    |             |
-| `includeTimes`               | `array`                        |                    |             |
-| `injectTimes`                | `array`                        |                    |             |
-| `inline`                     | `bool`                         |                    |             |
-| `isClearable`                | `bool`                         |                    |             |
-| `locale`                     | `union(string\|shape)`         |                    |             |
-| `maxDate`                    | `instanceOfDate`               |                    |             |
-| `maxTime`                    | `instanceOfDate`               |                    |             |
-| `minDate`                    | `instanceOfDate`               |                    |             |
-| `minTime`                    | `instanceOfDate`               |                    |             |
-| `monthAriaLabelPrefix`       | `string`                       |                    |             |
-| `monthClassName`             | `func`                         |                    |             |
-| `monthsShown`                | `number`                       | `1`                |             |
-| `name`                       | `string`                       |                    |             |
-| `nextMonthAriaLabel`         | `string`                       | `"Next Month"`     |             |
-| `nextMonthButtonLabel`       | `union(string\|node)`          | `"Next Month"`     |             |
-| `nextYearAriaLabel`          | `string`                       | `"Next Year"`      |             |
-| `nextYearButtonLabel`        | `string`                       | `"Next Year"`      |             |
-| `onBlur`                     | `func`                         | `() {}`            |             |
-| `onCalendarClose`            | `func`                         | `() {}`            |             |
-| `onCalendarOpen`             | `func`                         | `() {}`            |             |
-| `onChange`                   | `func`                         | `() {}`            |             |
-| `onChangeRaw`                | `func`                         |                    |             |
-| `onClickOutside`             | `func`                         | `() {}`            |             |
-| `onDayMouseEnter`            | `func`                         |                    |             |
-| `onFocus`                    | `func`                         | `() {}`            |             |
-| `onInputClick`               | `func`                         | `() {}`            |             |
-| `onInputError`               | `func`                         | `() {}`            |             |
-| `onKeyDown`                  | `func`                         | `() {}`            |             |
-| `onMonthChange`              | `func`                         | `() {}`            |             |
-| `onMonthMouseLeave`          | `func`                         |                    |             |
-| `onSelect`                   | `func`                         | `() {}`            |             |
-| `onWeekSelect`               | `func`                         |                    |             |
-| `onYearChange`               | `func`                         | `() {}`            |             |
-| `onYearMouseEnter`           | `func`                         |                    |             |
-| `onYearMouseLeave`           | `func`                         |                    |             |
-| `open`                       | `bool`                         |                    |             |
-| `openToDate`                 | `instanceOfDate`               |                    |             |
-| `peekNextMonth`              | `bool`                         |                    |             |
-| `placeholderText`            | `string`                       |                    |             |
-| `popperClassName`            | `string`                       |                    |             |
-| `popperContainer`            | `func`                         |                    |             |
-| `popperModifiers`            | `arrayOf[object Object]`       |                    |             |
-| `popperPlacement`            | `enumpopperPlacementPositions` |                    |             |
-| `popperProps`                | `object`                       |                    |             |
-| `portalHost`                 | `instanceOfShadowRoot`         |                    |             |
-| `portalId`                   | `string`                       |                    |             |
-| `preventOpenOnFocus`         | `bool`                         | `false`            |             |
-| `previousMonthAriaLabel`     | `string`                       | `"Previous Month"` |             |
-| `previousMonthButtonLabel`   | `union(string\|node)`          | `"Previous Month"` |             |
-| `previousYearAriaLabel`      | `string`                       | `"Previous Year"`  |             |
-| `previousYearButtonLabel`    | `string`                       | `"Previous Year"`  |             |
-| `readOnly`                   | `bool`                         | `false`            |             |
-| `renderCustomHeader`         | `func`                         |                    |             |
-| `renderDayContents`          | `func`                         | `(date) {          |
-
-return date;
-}`|| |`required`|`bool`||| |`scrollableMonthYearDropdown`|`bool`||| |`scrollableYearDropdown`|`bool`||| |`selected`|`instanceOfDate`||| |`selectsDisabledDaysInRange`|`bool`|`false`|| |`selectsEnd`|`bool`||| |`selectsRange`|`bool`||| |`selectsStart`|`bool`||| |`shouldCloseOnSelect`|`bool`|`true`|| |`showDisabledMonthNavigation`|`bool`||| |`showFourColumnMonthYearPicker`|`bool`|`false`|| |`showFullMonthYearPicker`|`bool`|`false`|| |`showIcon`|`bool`||| |`showMonthDropdown`|`bool`||| |`showMonthYearDropdown`|`bool`||| |`showMonthYearPicker`|`bool`|`false`|| |`showPopperArrow`|`bool`|`true`|| |`showPreviousMonths`|`bool`|`false`|| |`showQuarterYearPicker`|`bool`|`false`|| |`showTimeInput`|`bool`|`false`|| |`showTimeSelect`|`bool`|`false`|| |`showTimeSelectOnly`|`bool`||| |`showTwoColumnMonthYearPicker`|`bool`|`false`|| |`showWeekNumbers`|`bool`||| |`showYearDropdown`|`bool`||| |`showYearPicker`|`bool`|`false`|| |`startDate`|`instanceOfDate`||| |`startOpen`|`bool`||| |`strictParsing`|`bool`|`false`|| |`tabIndex`|`number`||| |`timeCaption`|`string`|`"Time"`|| |`timeClassName`|`func`||| |`timeFormat`|`string`||| |`timeInputLabel`|`string`|`"Time"`|| |`timeIntervals`|`number`|`30`|| |`title`|`string`||| |`todayButton`|`node`||| |`useShortMonthInDropdown`|`bool`||| |`useWeekdaysShort`|`bool`||| |`value`|`string`||| |`weekAriaLabelPrefix`|`string`||| |`weekDayClassName`|`func`||| |`weekLabel`|`string`||| |`withPortal`|`bool`|`false`|| |`wrapperClassName`|`string`||| |`yearDropdownItemNumber`|`number`||| |`yearItemNumber`|`number`|`DEFAULT_YEAR_ITEM_NUMBER`||
+| name                            | type                           | default value            | description |
+| ------------------------------- | ------------------------------ | ------------------------ | ----------- |
+| `adjustDateOnChange`            | `bool`                         |                          |             |
+| `allowSameDay`                  | `bool`                         | `false`                  |             |
+| `ariaDescribedBy`               | `string`                       |                          |             |
+| `ariaInvalid`                   | `string`                       |                          |             |
+| `ariaLabelClose`                | `string`                       |                          |             |
+| `ariaLabelledBy`                | `string`                       |                          |             |
+| `ariaRequired`                  | `string`                       |                          |             |
+| `autoComplete`                  | `string`                       |                          |             |
+| `autoFocus`                     | `bool`                         |                          |             |
+| `calendarClassName`             | `string`                       |                          |             |
+| `calendarContainer`             | `func`                         |                          |             |
+| `calendarStartDay`              | `number`                       | `undefined`              |             |
+| `children`                      | `node`                         |                          |             |
+| `chooseDayAriaLabelPrefix`      | `string`                       |                          |             |
+| `className`                     | `string`                       |                          |             |
+| `clearButtonClassName`          | `string`                       |                          |             |
+| `clearButtonTitle`              | `string`                       |                          |             |
+| `closeOnScroll`                 | `union(bool\|func)`            |                          |             |
+| `customInput`                   | `element`                      |                          |             |
+| `customInputRef`                | `string`                       |                          |             |
+| `customTimeInput`               | `element`                      | `null`                   |             |
+| `dateFormat`                    | `union(string\|array)`         | `"MM/dd/yyyy"`           |             |
+| `dateFormatCalendar`            | `string`                       | `"LLLL yyyy"`            |             |
+| `dayClassName`                  | `func`                         |                          |             |
+| `disabled`                      | `bool`                         | `false`                  |             |
+| `disabledDayAriaLabelPrefix`    | `string`                       |                          |             |
+| `disabledKeyboardNavigation`    | `bool`                         | `false`                  |             |
+| `dropdownMode`                  | `enum("scroll"\|"select")`     | `"scroll"`               |             |
+| `enableTabLoop`                 | `bool`                         | `true`                   |             |
+| `endDate`                       | `instanceOfDate`               |                          |             |
+| `excludeDateIntervals`          | `arrayOf[object Object]`       |                          |             |
+| `excludeDates`                  | `array`                        |                          |             |
+| `excludeScrollbar`              | `bool`                         | `true`                   |             |
+| `excludeTimes`                  | `array`                        |                          |             |
+| `filterDate`                    | `func`                         |                          |             |
+| `filterTime`                    | `func`                         |                          |             |
+| `fixedHeight`                   | `bool`                         |                          |             |
+| `focusSelectedMonth`            | `bool`                         | `false`                  |             |
+| `forceShowMonthNavigation`      | `bool`                         |                          |             |
+| `form`                          | `string`                       |                          |             |
+| `formatWeekDay`                 | `func`                         |                          |             |
+| `formatWeekNumber`              | `func`                         |                          |             |
+| `highlightDates`                | `array`                        |                          |             |
+| `id`                            | `string`                       |                          |             |
+| `includeDateIntervals`          | `array`                        |                          |             |
+| `includeDates`                  | `array`                        |                          |             |
+| `includeTimes`                  | `array`                        |                          |             |
+| `injectTimes`                   | `array`                        |                          |             |
+| `inline`                        | `bool`                         |                          |             |
+| `isClearable`                   | `bool`                         |                          |             |
+| `locale`                        | `union(string\|shape)`         |                          |             |
+| `maxDate`                       | `instanceOfDate`               |                          |             |
+| `maxTime`                       | `instanceOfDate`               |                          |             |
+| `minDate`                       | `instanceOfDate`               |                          |             |
+| `minTime`                       | `instanceOfDate`               |                          |             |
+| `monthAriaLabelPrefix`          | `string`                       |                          |             |
+| `monthClassName`                | `func`                         |                          |             |
+| `monthsShown`                   | `number`                       | `1`                      |             |
+| `name`                          | `string`                       |                          |             |
+| `nextMonthAriaLabel`            | `string`                       | `"Next Month"`           |             |
+| `nextMonthButtonLabel`          | `union(string\|node)`          | `"Next Month"`           |             |
+| `nextYearAriaLabel`             | `string`                       | `"Next Year"`            |             |
+| `nextYearButtonLabel`           | `string`                       | `"Next Year"`            |             |
+| `onBlur`                        | `func`                         | `() {}`                  |             |
+| `onCalendarClose`               | `func`                         | `() {}`                  |             |
+| `onCalendarOpen`                | `func`                         | `() {}`                  |             |
+| `onChange`                      | `func`                         | `() {}`                  |             |
+| `onChangeRaw`                   | `func`                         |                          |             |
+| `onClickOutside`                | `func`                         | `() {}`                  |             |
+| `onDayMouseEnter`               | `func`                         |                          |             |
+| `onFocus`                       | `func`                         | `() {}`                  |             |
+| `onInputClick`                  | `func`                         | `() {}`                  |             |
+| `onInputError`                  | `func`                         | `() {}`                  |             |
+| `onKeyDown`                     | `func`                         | `() {}`                  |             |
+| `onMonthChange`                 | `func`                         | `() {}`                  |             |
+| `onMonthMouseLeave`             | `func`                         |                          |             |
+| `onSelect`                      | `func`                         | `() {}`                  |             |
+| `onWeekSelect`                  | `func`                         |                          |             |
+| `onYearChange`                  | `func`                         | `() {}`                  |             |
+| `onYearMouseEnter`              | `func`                         |                          |             |
+| `onYearMouseLeave`              | `func`                         |                          |             |
+| `open`                          | `bool`                         |                          |             |
+| `openToDate`                    | `instanceOfDate`               |                          |             |
+| `peekNextMonth`                 | `bool`                         |                          |             |
+| `placeholderText`               | `string`                       |                          |             |
+| `popperClassName`               | `string`                       |                          |             |
+| `popperContainer`               | `func`                         |                          |             |
+| `popperModifiers`               | `arrayOf[object Object]`       |                          |             |
+| `popperPlacement`               | `enumpopperPlacementPositions` |                          |             |
+| `popperProps`                   | `object`                       |                          |             |
+| `portalHost`                    | `instanceOfShadowRoot`         |                          |             |
+| `portalId`                      | `string`                       |                          |             |
+| `preventOpenOnFocus`            | `bool`                         | `false`                  |             |
+| `previousMonthAriaLabel`        | `string`                       | `"Previous Month"`       |             |
+| `previousMonthButtonLabel`      | `union(string\|node)`          | `"Previous Month"`       |             |
+| `previousYearAriaLabel`         | `string`                       | `"Previous Year"`        |             |
+| `previousYearButtonLabel`       | `string`                       | `"Previous Year"`        |             |
+| `readOnly`                      | `bool`                         | `false`                  |             |
+| `renderCustomHeader`            | `func`                         |                          |             |
+| `renderDayContents`             | `func`                         | `(date) { return date;}` |             |
+| `required`                      | `bool`                         |                          |             |
+| `scrollableMonthYearDropdown`   | `bool`                         |                          |             |
+| `scrollableYearDropdown`        | `bool`                         |                          |             |
+| `selected`                      | `instanceOfDate`               |                          |             |
+| `selectsDisabledDaysInRange`    | `bool`                         | `false`                  |             |
+| `selectsEnd`                    | `bool`                         |                          |             |
+| `selectsRange`                  | `bool`                         |                          |             |
+| `selectsStart`                  | `bool`                         |                          |             |
+| `shouldCloseOnSelect`           | `bool`                         | `true`                   |             |
+| `showDisabledMonthNavigation`   | `bool`                         |                          |             |
+| `showFourColumnMonthYearPicker` | `bool`                         | `false`                  |             |
+| `showFullMonthYearPicker`       | `bool`                         | `false`                  |             |
+| `showIcon`                      | `bool`                         |                          |             |
+| `showMonthDropdown`             | `bool`                         |                          |             |
+| `showMonthYearDropdown`         | `bool`                         |                          |             |
+| `showMonthYearPicker`           | `bool`                         | `false`                  |             |
+| `showPopperArrow`               | `bool`                         | `true`                   |             |
+| `showPreviousMonths`            | `bool`                         | `false`                  |             |
+| `showQuarterYearPicker`         | `bool`                         | `false`                  |             |
+| `showTimeInput`                 | `bool`                         | `false`                  |             |
+| `showTimeSelect`                | `bool`                         | `false`                  |             |
+| `showTimeSelectOnly`            | `bool`                         |                          |             |
+| `showTwoColumnMonthYearPicker`  | `bool`                         | `false`                  |             |
+| `showWeekNumbers`               | `bool`                         |                          |             |
+| `showYearDropdown`              | `bool`                         |                          |             |
+| `showYearPicker`                | `bool`                         | `false`                  |             |
+| `startDate`                     | `instanceOfDate`               |                          |             |
+| `startOpen`                     | `bool`                         |                          |             |
+| `strictParsing`                 | `bool`                         | `false`                  |             |
+| `tabIndex`                      | `number`                       |                          |             |
+| `timeCaption`                   | `string`                       | `"Time"`                 |             |
+| `timeClassName`                 | `func`                         |                          |             |
+| `timeFormat`                    | `string`                       |                          |             |
+| `timeInputLabel`                | `string`                       | `"Time"`                 |             |
+| `timeIntervals`                 | `number`                       | `30`                     |             |
+| `title`                         | `string`                       |                          |             |
+| `todayButton`                   | `node`                         |                          |             |
+| `useShortMonthInDropdown`       | `bool`                         |                          |             |
+| `useWeekdaysShort`              | `bool`                         |                          |             |
+| `value`                         | `string`                       |                          |             |
+| `weekAriaLabelPrefix`           | `string`                       |                          |             |
+| `weekDayClassName`              | `func`                         |                          |             |
+| `weekLabel`                     | `string`                       |                          |             |
+| `withPortal`                    | `bool`                         | `false`                  |             |
+| `wrapperClassName`              | `string`                       |                          |             |
+| `yearDropdownItemNumber`        | `number`                       |                          |             |
+| `yearItemNumber`                | `number`                       | `12`                     |             |

--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -191,6 +191,9 @@ export default class Calendar extends React.Component {
     nextYearButtonLabel: PropTypes.string,
     renderCustomHeader: PropTypes.func,
     renderDayContents: PropTypes.func,
+    renderMonthContent: PropTypes.func,
+    renderQuarterContent: PropTypes.func,
+    renderYearContent: PropTypes.func,
     onDayMouseEnter: PropTypes.func,
     onMonthMouseLeave: PropTypes.func,
     onYearMouseEnter: PropTypes.func,
@@ -922,6 +925,9 @@ export default class Calendar extends React.Component {
             setOpen={this.props.setOpen}
             shouldCloseOnSelect={this.props.shouldCloseOnSelect}
             renderDayContents={this.props.renderDayContents}
+            renderMonthContent={this.props.renderMonthContent}
+            renderQuarterContent={this.props.renderQuarterContent}
+            renderYearContent={this.props.renderYearContent}
             disabledKeyboardNavigation={this.props.disabledKeyboardNavigation}
             showMonthYearPicker={this.props.showMonthYearPicker}
             showFullMonthYearPicker={this.props.showFullMonthYearPicker}

--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -8,8 +8,6 @@ import addWeeks from "date-fns/addWeeks";
 import addMonths from "date-fns/addMonths";
 import addQuarters from "date-fns/addQuarters";
 import addYears from "date-fns/addYears";
-import subMinutes from "date-fns/subMinutes";
-import subHours from "date-fns/subHours";
 import subDays from "date-fns/subDays";
 import subWeeks from "date-fns/subWeeks";
 import subMonths from "date-fns/subMonths";
@@ -35,7 +33,6 @@ import min from "date-fns/min";
 import max from "date-fns/max";
 import differenceInCalendarDays from "date-fns/differenceInCalendarDays";
 import differenceInCalendarMonths from "date-fns/differenceInCalendarMonths";
-import differenceInCalendarWeeks from "date-fns/differenceInCalendarWeeks";
 import differenceInCalendarYears from "date-fns/differenceInCalendarYears";
 import startOfDay from "date-fns/startOfDay";
 import startOfWeek from "date-fns/startOfWeek";
@@ -272,16 +269,7 @@ export { addMinutes, addDays, addWeeks, addMonths, addQuarters, addYears };
 
 // *** Subtraction ***
 
-export {
-  addHours,
-  subMinutes,
-  subHours,
-  subDays,
-  subWeeks,
-  subMonths,
-  subQuarters,
-  subYears,
-};
+export { addHours, subDays, subWeeks, subMonths, subQuarters, subYears };
 
 // ** Date Comparison **
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -119,10 +119,6 @@ export default class DatePicker extends React.Component {
       timeInputLabel: "Time",
       enableTabLoop: true,
       yearItemNumber: DEFAULT_YEAR_ITEM_NUMBER,
-
-      renderDayContents(date) {
-        return date;
-      },
       focusSelectedMonth: false,
       showPopperArrow: true,
       excludeScrollbar: true,
@@ -282,6 +278,9 @@ export default class DatePicker extends React.Component {
     timeInputLabel: PropTypes.string,
     renderCustomHeader: PropTypes.func,
     renderDayContents: PropTypes.func,
+    renderMonthContent: PropTypes.func,
+    renderQuarterContent: PropTypes.func,
+    renderYearContent: PropTypes.func,
     wrapperClassName: PropTypes.string,
     focusSelectedMonth: PropTypes.bool,
     onDayMouseEnter: PropTypes.func,
@@ -1010,6 +1009,9 @@ export default class DatePicker extends React.Component {
         renderCustomHeader={this.props.renderCustomHeader}
         popperProps={this.props.popperProps}
         renderDayContents={this.props.renderDayContents}
+        renderMonthContent={this.props.renderMonthContent}
+        renderQuarterContent={this.props.renderQuarterContent}
+        renderYearContent={this.props.renderYearContent}
         onDayMouseEnter={this.props.onDayMouseEnter}
         onMonthMouseLeave={this.props.onMonthMouseLeave}
         onYearMouseEnter={this.props.onYearMouseEnter}

--- a/src/month.jsx
+++ b/src/month.jsx
@@ -103,6 +103,8 @@ export default class Month extends React.Component {
     setOpen: PropTypes.func,
     shouldCloseOnSelect: PropTypes.bool,
     renderDayContents: PropTypes.func,
+    renderMonthContent: PropTypes.func,
+    renderQuarterContent: PropTypes.func,
     showMonthYearPicker: PropTypes.bool,
     showFullMonthYearPicker: PropTypes.bool,
     showTwoColumnMonthYearPicker: PropTypes.bool,
@@ -618,12 +620,28 @@ export default class Month extends React.Component {
     );
   };
 
+  getMonthContent = (m) => {
+    const { showFullMonthYearPicker, renderMonthContent, locale } = this.props;
+    const shortMonthText = utils.getMonthShortInLocale(m, locale);
+    const fullMonthText = utils.getMonthInLocale(m, locale);
+    if (renderMonthContent) {
+      return renderMonthContent(m, shortMonthText, fullMonthText);
+    }
+    return showFullMonthYearPicker ? fullMonthText : shortMonthText;
+  };
+
+  getQuarterContent = (q) => {
+    const { renderQuarterContent, locale } = this.props;
+    const shortQuarter = utils.getQuarterShortInLocale(q, locale);
+    return renderQuarterContent
+      ? renderQuarterContent(q, shortQuarter)
+      : shortQuarter;
+  };
+
   renderMonths = () => {
     const {
-      showFullMonthYearPicker,
       showTwoColumnMonthYearPicker,
       showFourColumnMonthYearPicker,
-      locale,
       day,
       selected,
     } = this.props;
@@ -655,9 +673,7 @@ export default class Month extends React.Component {
             aria-current={this.isCurrentMonth(day, m) ? "date" : undefined}
             aria-selected={this.isSelectedMonth(day, m, selected)}
           >
-            {showFullMonthYearPicker
-              ? utils.getMonthInLocale(m, locale)
-              : utils.getMonthShortInLocale(m, locale)}
+            {this.getMonthContent(m)}
           </div>
         ))}
       </div>
@@ -686,7 +702,7 @@ export default class Month extends React.Component {
             tabIndex={this.getQuarterTabIndex(q)}
             aria-current={this.isCurrentQuarter(day, q) ? "date" : undefined}
           >
-            {utils.getQuarterShortInLocale(q, this.props.locale)}
+            {this.getQuarterContent(q)}
           </div>
         ))}
       </div>

--- a/src/year.jsx
+++ b/src/year.jsx
@@ -20,6 +20,7 @@ export default class Year extends React.Component {
     onYearMouseEnter: PropTypes.func.isRequired,
     onYearMouseLeave: PropTypes.func.isRequired,
     selectingDate: PropTypes.instanceOf(Date),
+    renderYearContent: PropTypes.func,
     selectsEnd: PropTypes.bool,
     selectsStart: PropTypes.bool,
     selectsRange: PropTypes.bool,
@@ -223,6 +224,10 @@ export default class Year extends React.Component {
     });
   };
 
+  getYearContent = (y) => {
+    return this.props.renderYearContent ? this.props.renderYearContent(y) : y;
+  };
+
   render() {
     const yearsList = [];
     const { date, yearItemNumber, onYearMouseEnter, onYearMouseLeave } =
@@ -249,7 +254,7 @@ export default class Year extends React.Component {
           key={y}
           aria-current={this.isCurrentYear(y) ? "date" : undefined}
         >
-          {y}
+          {this.getYearContent(y)}
         </div>
       );
     }

--- a/test/month_test.js
+++ b/test/month_test.js
@@ -841,6 +841,40 @@ describe("Month", () => {
     expect(month.text()).to.equal("Feb");
   });
 
+  describe("custom renders", () => {
+    it("should render custom month content", () => {
+      function renderMonthContent() {
+        return <span>custom render</span>;
+      }
+      const monthComponent = mount(
+        <Month
+          day={utils.newDate()}
+          renderMonthContent={renderMonthContent}
+          showMonthYearPicker
+        />
+      );
+      const month = monthComponent.find(".react-datepicker__month-text").at(0);
+      expect(month.find("span").at(0).text()).to.equal("custom render");
+    });
+
+    it("should render custom quarter content", () => {
+      function renderQuarterContent() {
+        return <span>custom render</span>;
+      }
+      const monthComponent = mount(
+        <Month
+          day={utils.newDate()}
+          renderQuarterContent={renderQuarterContent}
+          showQuarterYearPicker
+        />
+      );
+      const quarter = monthComponent
+        .find(".react-datepicker__quarter-text")
+        .at(0);
+      expect(quarter.find("span").at(0).text()).to.equal("custom render");
+    });
+  });
+
   describe("Keyboard navigation", () => {
     const renderQuarters = (props) =>
       shallow(<Month showQuarterYearPicker {...props} />);

--- a/test/year_picker_test.js
+++ b/test/year_picker_test.js
@@ -199,6 +199,17 @@ describe("YearPicker", () => {
     }
   });
 
+  it("should render custom year content", () => {
+    function renderYearContent() {
+      return <span>custom render</span>;
+    }
+    const yearComponent = mount(
+      <Year date={utils.newDate()} renderYearContent={renderYearContent} />
+    );
+    const year = yearComponent.find(".react-datepicker__year-text").at(0);
+    expect(year.find("span").at(0).text()).to.equal("custom render");
+  });
+
   describe("range", () => {
     it("should add range classes", () => {
       const yearComponent = mount(


### PR DESCRIPTION
I work for an organization that requires this UI for day, month and year elements in selected / selecting range.

| Day | Month | Year |
|---|---|---|
|![Screenshot 2023-06-22 at 15 35 47](https://github.com/Hacker0x01/react-datepicker/assets/117300300/217f4cb8-a558-4f6c-8afc-864200c7607c)|![Screenshot 2023-06-22 at 15 42 29](https://github.com/Hacker0x01/react-datepicker/assets/117300300/1523a95b-d0b7-4419-aecc-1269b0e192b0)|![Screenshot 2023-06-23 at 11 19 34](https://github.com/Hacker0x01/react-datepicker/assets/117300300/f9b6ca9a-b564-48d8-a0cd-824229197748)|

To do this UI, it required to use custom content renders:
- One div `.react-datepicker__{precision}` for the background.
- Another div `.react-datepicker__{precision}-content` to wrap the text in some kind of chip.

This PR aims to offer custom render for month, quarter and year content in the same way as custom day content render.


### Question:

- Should these props be singular or plural ? renderYearContent / renderYearContent**s**
_I prefer the singular form as the element has only one content._
