### PR TITLE
Fix week number for en locale

### DIFF
--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -18,7 +18,7 @@ import getMinutes from "date-fns/getMinutes";
 import getHours from "date-fns/getHours";
 import getDay from "date-fns/getDay";
 import getDate from "date-fns/getDate";
-import getWeek from "date-fns/getWeek";
+import getWeekOfDate from "date-fns/getWeek";
 import getMonth from "date-fns/getMonth";
 import getQuarter from "date-fns/getQuarter";
 import getYear from "date-fns/getYear";
@@ -212,7 +212,7 @@ export function getWeek(date, locale) {
   let localeObj =
     (locale && getLocaleObject(locale)) ||
     (getDefaultLocale() && getLocaleObject(getDefaultLocale()));
-  return getWeek(date, localeObj ? { locale: localeObj } : null);
+  return getWeekOfDate(date, localeObj ? { locale: localeObj } : null);
 }
 
 export function getDayOfWeekCode(day, locale) {

--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -18,7 +18,7 @@ import getMinutes from "date-fns/getMinutes";
 import getHours from "date-fns/getHours";
 import getDay from "date-fns/getDay";
 import getDate from "date-fns/getDate";
-import getISOWeek from "date-fns/getISOWeek";
+import getWeek from "date-fns/getWeek";
 import getMonth from "date-fns/getMonth";
 import getQuarter from "date-fns/getQuarter";
 import getYear from "date-fns/getYear";
@@ -212,7 +212,7 @@ export function getWeek(date, locale) {
   let localeObj =
     (locale && getLocaleObject(locale)) ||
     (getDefaultLocale() && getLocaleObject(getDefaultLocale()));
-  return getISOWeek(date, localeObj ? { locale: localeObj } : null);
+  return getWeek(date, localeObj ? { locale: localeObj } : null);
 }
 
 export function getDayOfWeekCode(day, locale) {


### PR DESCRIPTION
This fixes the week number of enUS locale. 

Related issue: https://github.com/Hacker0x01/react-datepicker/issues/3507

# Example of this error:

Given date: 4.1.2023

Expected:
- start of week: 1.1.2023, Sunday
- week: 1

Actual:
- start of week: 1.1.2023, Sunday
- week: 52

