### PR TITLE
Improve time picker accessibility

### DIFF
--- a/src/time.jsx
+++ b/src/time.jsx
@@ -134,6 +134,21 @@ export default class Time extends React.Component {
       event.key = "Enter";
     }
 
+    if (
+      (event.key === "ArrowUp" || event.key === "ArrowLeft") &&
+      event.target.previousSibling
+    ) {
+      event.preventDefault();
+      event.target.previousSibling.focus();
+    }
+    if (
+      (event.key === "ArrowDown" || event.key === "ArrowRight") &&
+      event.target.nextSibling
+    ) {
+      event.preventDefault();
+      event.target.nextSibling.focus();
+    }
+
     if (event.key === "Enter") {
       this.handleClick(time);
     }
@@ -175,27 +190,39 @@ export default class Time extends React.Component {
       }
     }
 
-    return times.map((time, i) => (
-      <li
-        key={i}
-        onClick={this.handleClick.bind(this, time)}
-        className={this.liClasses(time, currH, currM)}
-        ref={(li) => {
-          if (isBefore(time, activeTime) || isEqual(time, activeTime)) {
-            this.centerLi = li;
+    // Determine which time to focus and scroll into view when component mounts
+    const timeToFocus = times.reduce((prev, time) => {
+      if (isBefore(time, activeTime) || isEqual(time, activeTime)) {
+        return time;
+      } else {
+        return prev;
+      }
+    }, times[0]);
+
+    return times.map((time, i) => {
+      return (
+        <li
+          key={i}
+          onClick={this.handleClick.bind(this, time)}
+          className={this.liClasses(time, currH, currM)}
+          ref={(li) => {
+            if (time === timeToFocus) {
+              this.centerLi = li;
+            }
+          }}
+          onKeyDown={(ev) => {
+            this.handleOnKeyDown(ev, time);
+          }}
+          tabIndex={time === timeToFocus ? "0" : "-1"}
+          role="option"
+          aria-selected={
+            this.isSelectedTime(time, currH, currM) ? "true" : undefined
           }
-        }}
-        onKeyDown={(ev) => {
-          this.handleOnKeyDown(ev, time);
-        }}
-        tabIndex="0"
-        aria-selected={
-          this.isSelectedTime(time, currH, currM) ? "true" : undefined
-        }
-      >
-        {formatDate(time, format, this.props.locale)}
-      </li>
-    ));
+        >
+          {formatDate(time, format, this.props.locale)}
+        </li>
+      );
+    });
   };
 
   render() {
@@ -231,7 +258,8 @@ export default class Time extends React.Component {
                 this.list = list;
               }}
               style={height ? { height } : {}}
-              tabIndex="0"
+              role="listbox"
+              aria-label={this.props.timeCaption}
             >
               {this.renderTimes()}
             </ul>

--- a/test/time_format_test.js
+++ b/test/time_format_test.js
@@ -110,6 +110,21 @@ describe("TimeComponent", () => {
       expect(timeListItem.at(0).prop("aria-selected")).to.eq("true");
     });
 
+    it("should enable keyboard focus on the selected item", () => {
+      var timeComponent = mount(
+        <TimeComponent
+          format="HH:mm"
+          selected={new Date("1990-06-14 08:00")}
+          openToDate={new Date("1990-06-14 09:00")}
+        />
+      );
+
+      var timeListItem = timeComponent.find(
+        ".react-datepicker__time-list-item--selected"
+      );
+      expect(timeListItem.at(0).prop("tabIndex")).to.equal("0");
+    });
+
     it("should not add the aria-selected property to a regular item", () => {
       var timeComponent = mount(
         <TimeComponent
@@ -123,6 +138,39 @@ describe("TimeComponent", () => {
         ".react-datepicker__time-list-item"
       );
       expect(timeListItem.at(0).prop("aria-selected")).to.be.undefined;
+    });
+
+    it("should disable keyboard focus on a regular item", () => {
+      var timeComponent = mount(
+        <TimeComponent
+          format="HH:mm"
+          selected={new Date("1990-06-14 08:00")}
+          openToDate={new Date("1990-06-14 09:00")}
+        />
+      );
+
+      var timeListItem = timeComponent.find(
+        ".react-datepicker__time-list-item"
+      );
+      expect(timeListItem.at(0).prop("tabIndex")).to.equal("-1");
+    });
+
+    it("when no selected time, should focus the time closest to the opened time", () => {
+      var timeComponent = mount(
+        <TimeComponent
+          format="HH:mm"
+          openToDate={new Date("1990-06-14 09:11")}
+        />
+      );
+
+      var timeListItem = timeComponent.find(
+        ".react-datepicker__time-list-item"
+      );
+      expect(
+        timeListItem
+          .findWhere((node) => node.type() && node.text() === "09:00")
+          .prop("tabIndex")
+      ).to.equal("0");
     });
 
     it("when no selected time, should call calcCenterPosition with centerLi ref, closest to the opened time", () => {


### PR DESCRIPTION
* Explicitly declare the Time picker as a listbox
* Add support for keyboard Arrow events to navigate the Time picker (per listbox [keyboard interaction requirements](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/listbox_role#keyboard_interactions))
* When Time picker focused, initially focus the currently selected time, or whatever time was initially scrolled into view, rather than always focusing the last time (fixes #3785)