### PR TITLE
fix: timepicker on 23 and 25-hour days

### DIFF
--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -839,5 +839,5 @@ export function startOfMinute(d) {
 }
 
 export function isSameMinute(d1, d2) {
-  return +startOfMinute(d1) === +startOfMinute(d2);
+  return startOfMinute(d1).getTime() === startOfMinute(d2).getTime();
 }

--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -831,17 +831,13 @@ export function getHoursInDay(d) {
   return Math.round((+startOfTheNextDay - +startOfDay) / 3_600_000);
 }
 
+export function startOfMinute(d) {
+  const seconds = d.getSeconds();
+  const milliseconds = d.getMilliseconds();
+
+  return toDate(d.getTime() - seconds * 1000 - milliseconds);
+}
+
 export function isSameMinute(d1, d2) {
-  const _date1 = toDate(d1);
-  const _date2 = toDate(d2);
-
-  const seconds1 = _date1.getSeconds();
-  const seconds2 = _date2.getSeconds();
-  const milliseconds1 = _date1.getMilliseconds();
-  const milliseconds2 = _date2.getMilliseconds();
-
-  return (
-    _date1.getTime() - seconds1 * 1000 - milliseconds1 ===
-    _date2.getTime() - seconds2 * 1000 - milliseconds2
-  );
+  return +startOfMinute(d1) === +startOfMinute(d2);
 }

--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -831,6 +831,18 @@ export function getHoursInDay(d) {
   return Math.round((+startOfTheNextDay - +startOfDay) / 3_600_000);
 }
 
+/**
+ * Returns the start of the minute for the given date
+ *
+ * NOTE: this function is a DST and timezone-safe analog of `date-fns/startOfMinute`
+ * do not make changes unless you know what you're doing
+ *
+ * See comments on https://github.com/Hacker0x01/react-datepicker/pull/4244
+ * for more details
+ *
+ * @param {Date} d date
+ * @returns {Date} start of the minute
+ */
 export function startOfMinute(d) {
   const seconds = d.getSeconds();
   const milliseconds = d.getMilliseconds();
@@ -838,6 +850,15 @@ export function startOfMinute(d) {
   return toDate(d.getTime() - seconds * 1000 - milliseconds);
 }
 
+/**
+ * Returns whether the given dates are in the same minute
+ *
+ * This function is a DST and timezone-safe analog of `date-fns/isSameMinute`
+ *
+ * @param {Date} d1
+ * @param {Date} d2
+ * @returns {boolean}
+ */
 export function isSameMinute(d1, d2) {
   return startOfMinute(d1).getTime() === startOfMinute(d2).getTime();
 }

--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -818,3 +818,30 @@ export function getYearsPeriod(
   const startPeriod = endPeriod - (yearItemNumber - 1);
   return { startPeriod, endPeriod };
 }
+
+export function getHoursInDay(d) {
+  const startOfDay = new Date(d.getFullYear(), d.getMonth(), d.getDate());
+  const startOfTheNextDay = new Date(
+    d.getFullYear(),
+    d.getMonth(),
+    d.getDate(),
+    24
+  );
+
+  return Math.round((+startOfTheNextDay - +startOfDay) / 3_600_000);
+}
+
+export function isSameMinute(d1, d2) {
+  const _date1 = toDate(d1);
+  const _date2 = toDate(d2);
+
+  const seconds1 = _date1.getSeconds();
+  const seconds2 = _date2.getSeconds();
+  const milliseconds1 = _date1.getMilliseconds();
+  const milliseconds2 = _date2.getMilliseconds();
+
+  return (
+    _date1.getTime() - seconds1 * 1000 - milliseconds1 ===
+    _date2.getTime() - seconds2 * 1000 - milliseconds2
+  );
+}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -686,10 +686,12 @@ export default class DatePicker extends React.Component {
     const selected = this.props.selected
       ? this.props.selected
       : this.getPreSelection();
-    let changedDate = setTime(selected, {
-      hour: getHours(time),
-      minute: getMinutes(time),
-    });
+    let changedDate = this.props.selected
+      ? time
+      : setTime(selected, {
+          hour: getHours(time),
+          minute: getMinutes(time),
+        });
 
     this.setState({
       preSelection: changedDate,

--- a/src/time.jsx
+++ b/src/time.jsx
@@ -183,22 +183,29 @@ export default class Time extends React.Component {
       }
     }
 
+    // Determine which time to focus and scroll into view when component mounts
+    const timeToFocus = times.reduce((prev, time) => {
+      if (time.getTime() <= activeDate.getTime()) {
+        return time;
+      }
+      return prev;
+    }, times[0]);
+
     return times.map((time, i) => {
-      const isActiveTime = isSameMinute(time, activeDate);
       return (
         <li
           key={i}
           onClick={this.handleClick.bind(this, time)}
           className={this.liClasses(time)}
           ref={(li) => {
-            if (isActiveTime) {
+            if (time === timeToFocus) {
               this.centerLi = li;
             }
           }}
           onKeyDown={(ev) => {
             this.handleOnKeyDown(ev, time);
           }}
-          tabIndex={isActiveTime ? 0 : -1}
+          tabIndex={time === timeToFocus ? 0 : -1}
           role="option"
           aria-selected={this.isSelectedTime(time) ? "true" : undefined}
         >

--- a/src/time.jsx
+++ b/src/time.jsx
@@ -89,15 +89,8 @@ export default class Time extends React.Component {
     this.props.onChange(time);
   };
 
-  isSelectedTime = (time) => {
-    const result =
-      this.props.selected && isSameMinute(this.props.selected, time);
-
-    if (result) {
-      console.log(this.props.selected, time);
-    }
-    return result;
-  };
+  isSelectedTime = (time) =>
+    this.props.selected && isSameMinute(this.props.selected, time);
 
   liClasses = (time) => {
     let classes = [

--- a/src/time.jsx
+++ b/src/time.jsx
@@ -3,17 +3,15 @@ import PropTypes from "prop-types";
 import {
   getHours,
   getMinutes,
-  setHours,
-  setMinutes,
   newDate,
   getStartOfDay,
   addMinutes,
   formatDate,
-  isBefore,
-  isEqual,
   isTimeInDisabledRange,
   isTimeDisabled,
   timesToInjectAfter,
+  getHoursInDay,
+  isSameMinute,
 } from "./date_utils";
 
 export default class Time extends React.Component {
@@ -91,20 +89,23 @@ export default class Time extends React.Component {
     this.props.onChange(time);
   };
 
-  isSelectedTime = (time, currH, currM) =>
-    this.props.selected &&
-    currH === getHours(time) &&
-    currM === getMinutes(time);
+  isSelectedTime = (time) => {
+    const result =
+      this.props.selected && isSameMinute(this.props.selected, time);
 
-  liClasses = (time, currH, currM) => {
+    if (result) {
+      console.log(this.props.selected, time);
+    }
+    return result;
+  };
+
+  liClasses = (time) => {
     let classes = [
       "react-datepicker__time-list-item",
-      this.props.timeClassName
-        ? this.props.timeClassName(time, currH, currM)
-        : undefined,
+      this.props.timeClassName ? this.props.timeClassName(time) : undefined,
     ];
 
-    if (this.isSelectedTime(time, currH, currM)) {
+    if (this.isSelectedTime(time)) {
       classes.push("react-datepicker__time-list-item--selected");
     }
 
@@ -160,19 +161,18 @@ export default class Time extends React.Component {
     const format = this.props.format ? this.props.format : "p";
     const intervals = this.props.intervals;
 
-    const base = getStartOfDay(newDate(this.props.selected));
-    const multiplier = 1440 / intervals;
+    const activeDate =
+      this.props.selected || this.props.openToDate || newDate();
+
+    const base = getStartOfDay(activeDate);
     const sortedInjectTimes =
       this.props.injectTimes &&
       this.props.injectTimes.sort(function (a, b) {
         return a - b;
       });
 
-    const activeDate =
-      this.props.selected || this.props.openToDate || newDate();
-    const currH = getHours(activeDate);
-    const currM = getMinutes(activeDate);
-    const activeTime = setHours(setMinutes(base, currM), currH);
+    const minutesInDay = 60 * getHoursInDay(activeDate);
+    const multiplier = minutesInDay / intervals;
 
     for (let i = 0; i < multiplier; i++) {
       const currentTime = addMinutes(base, i * intervals);
@@ -190,34 +190,24 @@ export default class Time extends React.Component {
       }
     }
 
-    // Determine which time to focus and scroll into view when component mounts
-    const timeToFocus = times.reduce((prev, time) => {
-      if (isBefore(time, activeTime) || isEqual(time, activeTime)) {
-        return time;
-      } else {
-        return prev;
-      }
-    }, times[0]);
-
     return times.map((time, i) => {
+      const isActiveTime = isSameMinute(time, activeDate);
       return (
         <li
           key={i}
           onClick={this.handleClick.bind(this, time)}
-          className={this.liClasses(time, currH, currM)}
+          className={this.liClasses(time)}
           ref={(li) => {
-            if (time === timeToFocus) {
+            if (isActiveTime) {
               this.centerLi = li;
             }
           }}
           onKeyDown={(ev) => {
             this.handleOnKeyDown(ev, time);
           }}
-          tabIndex={time === timeToFocus ? "0" : "-1"}
+          tabIndex={isActiveTime ? 0 : -1}
           role="option"
-          aria-selected={
-            this.isSelectedTime(time, currH, currM) ? "true" : undefined
-          }
+          aria-selected={this.isSelectedTime(time) ? "true" : undefined}
         >
           {formatDate(time, format, this.props.locale)}
         </li>

--- a/test/date_utils_test.test.js
+++ b/test/date_utils_test.test.js
@@ -4,6 +4,7 @@ import {
   addDays,
   subDays,
   isEqual,
+  isSameMinute,
   isSameDay,
   isSameMonth,
   isSameQuarter,
@@ -37,6 +38,7 @@ import {
   safeDateRangeFormat,
   getHolidaysMap,
   arraysAreEqual,
+  startOfMinute,
 } from "../src/date_utils";
 import setMinutes from "date-fns/setMinutes";
 import setHours from "date-fns/setHours";
@@ -1221,6 +1223,29 @@ describe("date_utils", () => {
       const array1 = ["India's Independence Day", "Christmas"];
       const array2 = ["New Year's day"];
       expect(arraysAreEqual(array1, array2)).toBe(false);
+    });
+  });
+
+  describe("isSameMinute", () => {
+    it("should return true if two dates are within the same minute", () => {
+      const d1 = new Date(2020, 10, 10, 10, 10, 10); // Nov 10, 2020 10:10:10
+      const d2 = new Date(2020, 10, 10, 10, 10, 20); // Nov 10, 2020 10:10:20
+      expect(isSameMinute(d1, d2)).toBe(true);
+    });
+
+    it("should return false if two dates aren't within the same minute", () => {
+      const d1 = new Date(2020, 10, 10, 10, 10, 10); // Nov 10, 2020 10:10:10
+      const d2 = new Date(2020, 10, 10, 10, 11, 10); // Nov 10, 2020 10:11:10
+      expect(isSameMinute(d1, d2)).toBe(false);
+    });
+  });
+
+  describe("startOfMinute", () => {
+    it("should properly find the start of the minute", () => {
+      const d = new Date(2020, 10, 10, 10, 10, 10); // Nov 10, 2020 10:10:10
+      const expected = new Date(2020, 10, 10, 10, 10, 0); // Nov 10, 2020 10:10:00
+
+      expect(startOfMinute(d)).toEqual(expected);
     });
   });
 });

--- a/test/time_format_test.test.js
+++ b/test/time_format_test.test.js
@@ -121,7 +121,7 @@ describe("TimeComponent", () => {
       var timeListItem = timeComponent.find(
         ".react-datepicker__time-list-item--selected",
       );
-      expect(timeListItem.at(0).prop("tabIndex")).toBe("0");
+      expect(timeListItem.at(0).prop("tabIndex")).toBe(0);
     });
 
     it("should not add the aria-selected property to a regular item", () => {
@@ -151,7 +151,7 @@ describe("TimeComponent", () => {
       var timeListItem = timeComponent.find(
         ".react-datepicker__time-list-item",
       );
-      expect(timeListItem.at(0).prop("tabIndex")).toBe("-1");
+      expect(timeListItem.at(0).prop("tabIndex")).toBe(-1);
     });
 
     it("when no selected time, should focus the time closest to the opened time", () => {
@@ -169,7 +169,7 @@ describe("TimeComponent", () => {
         timeListItem
           .findWhere((node) => node.type() && node.text() === "09:00")
           .prop("tabIndex"),
-      ).toBe("0");
+      ).toBe(0);
     });
 
     it("when no selected time, should call calcCenterPosition with centerLi ref, closest to the opened time", () => {

--- a/test/timepicker_test.test.js
+++ b/test/timepicker_test.test.js
@@ -57,10 +57,7 @@ describe("TimePicker", () => {
   });
 
   it("should show different colors for times", () => {
-    const handleTimeColors = (time, currH, currM) => {
-      if (!Number.isInteger(currH) || !Number.isInteger(currM)) {
-        return "wrong";
-      }
+    const handleTimeColors = (time) => {
       return time.getHours() < 12 ? "red" : "green";
     };
     const timePicker = TestUtils.renderIntoDocument(


### PR DESCRIPTION
This is a fix for  #4243.

## Notes

### Tests

I would gladly add tests but time zones are involved which makes things complicated. In Node.js timezone could be changed only with environment variable which requires significant changes in test running process if we want to test several of them.

### timeClassName prop

Signature of `timeClassName` changed as currH and currM don't make sense anymore. This is a potentially breaking change and also add inconvenience for the user willing to highlight selected time.

### Time range

Time range is also prone to DST bugs (if someone accidentally would set a date on the DST boundary) and the interface looks somewhat strange to me. I think it should either accept an array of ranges or start and end times in `HH:mm` format.