### PR TITLE
Fix #4268: Retain the selected date when changing the time

### DIFF
--- a/src/inputTime.jsx
+++ b/src/inputTime.jsx
@@ -31,9 +31,14 @@ export default class inputTime extends React.Component {
 
   onTimeChange = (time) => {
     this.setState({ time });
-    const date = new Date();
+
+    const { date: propDate } = this.props;
+    const isPropDateValid = propDate instanceof Date && !isNaN(propDate);
+    const date = isPropDateValid ? propDate : new Date();
+
     date.setHours(time.split(":")[0]);
     date.setMinutes(time.split(":")[1]);
+
     this.props.onChange(date);
   };
 

--- a/test/time_input_test.test.js
+++ b/test/time_input_test.test.js
@@ -69,4 +69,49 @@ describe("timeInput", () => {
       new Date(new Date().setHours(14, 0, 0, 0)),
     );
   });
+
+  it("should trigger onChange event with the specified date prop if available", () => {
+    const mockOnChange = jest.fn();
+    const mockDate = new Date("2023-09-30");
+
+    const timeComponent = shallow(
+      <InputTimeComponent date={mockDate} onChange={mockOnChange} />,
+    );
+
+    const newTime = "13:00";
+    const input = timeComponent.find("input");
+    input.simulate("change", { target: { value: newTime } });
+
+    const expectedDate = new Date(mockDate);
+    const [expectedHours, expectedMinutes] = newTime.split(":");
+    expectedDate.setHours(expectedHours);
+    expectedDate.setMinutes(expectedMinutes);
+
+    expect(mockOnChange).toHaveBeenCalledWith(expectedDate);
+  });
+
+  it("should trigger onChange event with the default date when date prop is missing", () => {
+    const mockOnChange = jest.fn();
+    const mockCurrentDate = new Date("2023-09-30");
+    const dateSpy = jest
+      .spyOn(global, "Date")
+      .mockImplementation(() => mockCurrentDate);
+
+    const timeComponent = shallow(
+      <InputTimeComponent onChange={mockOnChange} />,
+    );
+
+    const newTime = "13:00";
+    const input = timeComponent.find("input");
+    input.simulate("change", { target: { value: newTime } });
+
+    const expectedDate = new Date(mockCurrentDate);
+    const [expectedHours, expectedMinutes] = newTime.split(":");
+    expectedDate.setHours(expectedHours);
+    expectedDate.setMinutes(expectedMinutes);
+
+    expect(mockOnChange).toHaveBeenCalledWith(expectedDate);
+
+    dateSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
Closes #4268

### Summary
This PR addresses an issue where the component was resetting the selected date of the component to the current date when changing the time. The fix ensures that the selected date remains unchanged when modifying the time, enhancing the user experience.

### Changes Made

- Implemented logic to preserve the selected date when updating the time.
- Refactored the onTimeChange function to check if the prop date is null before using the current date