### PR TITLE
fix(3635): a11y - Sets focus to input on select

### DIFF
--- a/test/datepicker_test.test.js
+++ b/test/datepicker_test.test.js
@@ -97,7 +97,7 @@ describe("DatePicker", () => {
     expect(datePicker.state.open).toBe(false);
   });
 
-  it("should close the popper and return focus to the date input.", (done) => {
+  it("should close the popper and return focus to the date input on Escape.", (done) => {
     // https://www.w3.org/TR/wai-aria-practices/examples/dialog-modal/datepicker-dialog.html
     // Date Picker Dialog | Escape | Closes the dialog and returns focus to the Choose Date button.
     var div = document.createElement("div");
@@ -119,6 +119,53 @@ describe("DatePicker", () => {
       expect(datePicker.calendar).toBeFalsy();
       expect(datePicker.state.preventFocus).toBe(false);
       expect(document.activeElement).toBe(div.querySelector("input"));
+      done();
+    });
+  });
+
+  it("should close the popper and return focus to the date input on Enter.", (done) => {
+    // https://www.w3.org/TR/wai-aria-practices/examples/dialog-modal/datepicker-dialog.html
+    // Date Picker Dialog | Date Grid | Enter | Closes the dialog and returns focus to the Choose Date button.
+    var div = document.createElement("div");
+    document.body.appendChild(div);
+    var datePicker = ReactDOM.render(<DatePicker />, div);
+
+    // user focuses the input field, the calendar opens
+    var dateInput = div.querySelector("input");
+    TestUtils.Simulate.focus(dateInput);
+
+    // user may tab or arrow down to the current day (or some other element in the popper)
+    var today = div.querySelector(".react-datepicker__day--today");
+    today.focus();
+
+    // user hits Enter
+    TestUtils.Simulate.keyDown(today, getKey("Enter"));
+    defer(() => {
+      expect(datePicker.calendar).toBeFalsy();
+      expect(datePicker.state.preventFocus).toBe(false);
+      expect(document.activeElement).toBe(div.querySelector("input"));
+      done();
+    });
+  });
+
+  it("should not close the popper and keep focus on selected date if showTimeSelect is enabled.", (done) => {
+    var div = document.createElement("div");
+    document.body.appendChild(div);
+    var datePicker = ReactDOM.render(<DatePicker showTimeSelect />, div);
+
+    // user focuses the input field, the calendar opens
+    var dateInput = div.querySelector("input");
+    TestUtils.Simulate.focus(dateInput);
+
+    // user may tab or arrow down to the current day (or some other element in the popper)
+    var today = div.querySelector(".react-datepicker__day--today");
+    today.focus();
+
+    // user hits Enter
+    TestUtils.Simulate.keyDown(today, getKey("Enter"));
+    defer(() => {
+      expect(datePicker.calendar).toBeTruthy();
+      expect(document.activeElement).toBe(today);
       done();
     });
   });
@@ -212,6 +259,24 @@ describe("DatePicker", () => {
     )[0];
     TestUtils.Simulate.click(ReactDOM.findDOMNode(day));
     expect(datePicker.state.open).toBe(true);
+  });
+
+  it("should keep focus within calendar when clicking a day on the calendar and shouldCloseOnSelect prop is false", () => {
+    var div = document.createElement("div");
+    document.body.appendChild(div);
+    ReactDOM.render(<DatePicker shouldCloseOnSelect={false} />, div);
+
+    // user focuses the input field, the calendar opens
+    var dateInput = div.querySelector("input");
+    TestUtils.Simulate.focus(dateInput);
+
+    // user may tab or arrow down to the current day (or some other element in the popper)
+    var today = div.querySelector(".react-datepicker__day--today");
+    today.focus();
+
+    // user hits Enter
+    TestUtils.Simulate.keyDown(today, getKey("Enter"));
+    expect(document.activeElement).toBe(today);
   });
 
   it("should set open to true if showTimeInput is true", () => {
@@ -325,6 +390,23 @@ describe("DatePicker", () => {
     expect(datePicker.calendar).toBeFalsy();
   });
 
+  it("should hide the calendar and keep focus on input when pressing escape in the date input", (done) => {
+    var div = document.createElement("div");
+    document.body.appendChild(div);
+    var datePicker = ReactDOM.render(<DatePicker />, div);
+
+    // user focuses the input field, the calendar opens
+    var dateInput = div.querySelector("input");
+    TestUtils.Simulate.focus(dateInput);
+
+    TestUtils.Simulate.keyDown(dateInput, getKey("Escape"));
+    defer(() => {
+      expect(datePicker.calendar).toBeFalsy();
+      expect(document.activeElement).toBe(dateInput);
+      done();
+    });
+  });
+
   it("should hide the calendar when the pressing Shift + Tab in the date input", () => {
     var datePicker = TestUtils.renderIntoDocument(
       <DatePicker onBlur={onBlurSpy} />,
@@ -401,6 +483,26 @@ describe("DatePicker", () => {
     );
     TestUtils.Simulate.click(clearButton);
     expect(datePicker.state.inputValue).toBeNull();
+  });
+
+  it("should return focus to input when clear button is used", (done) => {
+    var div = document.createElement("div");
+    document.body.appendChild(div);
+    var datePicker = ReactDOM.render(
+      <DatePicker selected={utils.newDate("2015-12-15")} isClearable />,
+      div,
+    );
+
+    var clearButton = TestUtils.findRenderedDOMComponentWithClass(
+      datePicker,
+      "react-datepicker__close-icon",
+    );
+    TestUtils.Simulate.click(clearButton);
+
+    defer(() => {
+      expect(document.activeElement).toBe(div.querySelector("input"));
+      done();
+    });
   });
 
   it("should set the title attribute on the clear button if clearButtonTitle is supplied", () => {

--- a/test/timepicker_test.test.js
+++ b/test/timepicker_test.test.js
@@ -1,4 +1,5 @@
 import React from "react";
+import defer from "lodash/defer";
 import DatePicker from "../src/index.jsx";
 import TestUtils from "react-dom/test-utils";
 import ReactDOM from "react-dom";
@@ -163,6 +164,21 @@ describe("TimePicker", () => {
     const lis = TestUtils.scryRenderedDOMComponentsWithTag(time, "li");
     TestUtils.Simulate.keyDown(lis[1], getKey(" "));
     expect(getInputString()).toBe("February 28, 2018 12:30 AM");
+  });
+
+  it("should return focus to input once time is selected", (done) => {
+    document.body.appendChild(div); // So we can check the dom later for activeElement
+    renderDatePicker("February 28, 2018 4:43 PM");
+    const dateInput = ReactDOM.findDOMNode(datePicker.input);
+    TestUtils.Simulate.focus(dateInput);
+    const time = TestUtils.findRenderedComponentWithType(datePicker, Time);
+    const lis = TestUtils.scryRenderedDOMComponentsWithTag(time, "li");
+    TestUtils.Simulate.keyDown(lis[1], getKey("Enter"));
+
+    defer(() => {
+      expect(document.activeElement).toBe(dateInput);
+      done();
+    });
   });
 
   it("should not select time when Escape is pressed", () => {


### PR DESCRIPTION
# Fixes: https://github.com/Hacker0x01/react-datepicker/issues/3635 : [Accessibility issue - when date picker closes focus does not return on input](https://github.com/Hacker0x01/react-datepicker/issues/3635) 

### Issue
When using the `Escape` or `Enter` keys as well as after selection with pointer, focus did not return to input.

Accessibility [guidelines](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepicker-dialog/) suggest that in these instances focus should return to the input.

### What were the specific changes made?

- Adds a `sendFocusBackToInput` method for handling returning focus. There were already two separate (nearly identical) implementations to handle this within `handleSelect` and `onPopperKeydown`. The `sendFocusBackToInput` is simply an abstraction to facilitate reuse in those instances as well as several others.
- Adds tests around possible consumer implementations.

### Additional notes/context
This work makes considerations not only for default implementations but as well as:
- `isClearable` - Clicking clear now returns focus to input
- `customInput` - This one Just Works ™️ as long as implemented as outlined in docs (ie with `forwardRef`)
- `shouldCloseOnSelect` - Don't hide calendar on date selection means we'll keep focus within picker
- `disabledKeyboardNavigation`- Pointer only
- `showTimeSelect` - When this prop is enabled the picker currently closes once a time is selected. This work just makes sure that focus only returns on that event and not on date selection.
- `inline` - Focus remains on picker
- `withPortal` - Again, Just works ™️ thanks to previous contributors. :) 
- Pressing `Escape` while in the input field - If picker was open and focus was on input, pressing `Escape` would send focus to `body`. Now returns to input.




https://github.com/Hacker0x01/react-datepicker/assets/78192/5c668e2e-4104-46af-8a64-768e0713889d

