### PR TITLE
🐛🚀 Fix and Enhance Date Range Selection

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -590,79 +590,107 @@ export default class DatePicker extends React.Component {
   };
 
   setSelected = (date, event, keepInput, monthSelectedIn) => {
-    let changedDate = date;
+    try {
+      let changedDate = date;
 
-    if (this.props.showYearPicker) {
-      if (
-        changedDate !== null &&
-        isYearDisabled(getYear(changedDate), this.props)
-      ) {
-        return;
-      }
-    } else if (this.props.showMonthYearPicker) {
-      if (changedDate !== null && isMonthDisabled(changedDate, this.props)) {
-        return;
-      }
-    } else {
-      if (changedDate !== null && isDayDisabled(changedDate, this.props)) {
-        return;
-      }
-    }
-
-    const { onChange, selectsRange, startDate, endDate } = this.props;
-
-    if (
-      !isEqual(this.props.selected, changedDate) ||
-      this.props.allowSameDay ||
-      selectsRange
-    ) {
-      if (changedDate !== null) {
+      if (this.props.showYearPicker) {
         if (
-          this.props.selected &&
-          (!keepInput ||
-            (!this.props.showTimeSelect &&
-              !this.props.showTimeSelectOnly &&
-              !this.props.showTimeInput))
+          changedDate !== null &&
+          isYearDisabled(getYear(changedDate), this.props)
         ) {
-          changedDate = setTime(changedDate, {
-            hour: getHours(this.props.selected),
-            minute: getMinutes(this.props.selected),
-            second: getSeconds(this.props.selected),
-          });
+          return;
         }
-        if (!this.props.inline) {
-          this.setState({
-            preSelection: changedDate,
-          });
-        }
-        if (!this.props.focusSelectedMonth) {
-          this.setState({ monthSelectedIn: monthSelectedIn });
-        }
-      }
-      if (selectsRange) {
-        const noRanges = !startDate && !endDate;
-        const hasStartRange = startDate && !endDate;
-        const isRangeFilled = startDate && endDate;
-        if (noRanges) {
-          onChange([changedDate, null], event);
-        } else if (hasStartRange) {
-          if (isBefore(changedDate, startDate)) {
-            onChange([changedDate, null], event);
-          } else {
-            onChange([startDate, changedDate], event);
-          }
-        }
-        if (isRangeFilled) {
-          onChange([changedDate, null], event);
+      } else if (this.props.showMonthYearPicker) {
+        if (changedDate !== null && isMonthDisabled(changedDate, this.props)) {
+          return;
         }
       } else {
-        onChange(changedDate, event);
+        if (changedDate !== null && isDayDisabled(changedDate, this.props)) {
+          return;
+        }
       }
-    }
 
-    if (!keepInput) {
-      this.props.onSelect(changedDate, event);
-      this.setState({ inputValue: null });
+      const {
+        onChange,
+        selectsRange,
+        startDate,
+        endDate,
+        selectsStart,
+        selectsEnd,
+      } = this.props;
+
+      if (
+        !isEqual(this.props.selected, changedDate) ||
+        this.props.allowSameDay ||
+        selectsRange
+      ) {
+        if (changedDate !== null) {
+          if (
+            this.props.selected &&
+            (!keepInput ||
+              (!this.props.showTimeSelect &&
+                !this.props.showTimeSelectOnly &&
+                !this.props.showTimeInput))
+          ) {
+            changedDate = setTime(changedDate, {
+              hour: getHours(this.props.selected),
+              minute: getMinutes(this.props.selected),
+              second: getSeconds(this.props.selected),
+            });
+          }
+          if (!this.props.inline) {
+            this.setState({
+              preSelection: changedDate,
+            });
+          }
+          if (!this.props.focusSelectedMonth) {
+            this.setState({ monthSelectedIn: monthSelectedIn });
+          }
+        }
+
+        if (selectsStart || selectsEnd) {
+          if (isValid(new Date(startDate)) && isValid(new Date(endDate))) {
+            if (
+              isAfter(new Date(changedDate), new Date(endDate)) &&
+              selectsStart
+            ) {
+              return;
+            } else if (
+              isBefore(new Date(changedDate), new Date(startDate)) &&
+              selectsEnd
+            ) {
+              return;
+            }
+          }
+        }
+
+        if (selectsRange) {
+          const noRanges = !startDate && !endDate;
+          const hasStartRange = startDate && !endDate;
+          const isRangeFilled = startDate && endDate;
+          if (noRanges) {
+            onChange([changedDate, null], event);
+          } else if (hasStartRange) {
+            if (isBefore(changedDate, startDate)) {
+              onChange([changedDate, null], event);
+            } else {
+              onChange([startDate, changedDate], event);
+            }
+          }
+          if (isRangeFilled) {
+            onChange([changedDate, null], event);
+          }
+        } else {
+          onChange(changedDate, event);
+        }
+      }
+
+      if (!keepInput) {
+        this.props.onSelect(changedDate, event);
+        this.setState({ inputValue: null });
+      }
+    } catch (error) {
+      console.log(error);
     }
   };
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -590,107 +590,103 @@ export default class DatePicker extends React.Component {
   };
 
   setSelected = (date, event, keepInput, monthSelectedIn) => {
-    try {
-      let changedDate = date;
+    let changedDate = date;
 
-      if (this.props.showYearPicker) {
+    if (this.props.showYearPicker) {
+      if (
+        changedDate !== null &&
+        isYearDisabled(getYear(changedDate), this.props)
+      ) {
+        return;
+      }
+    } else if (this.props.showMonthYearPicker) {
+      if (changedDate !== null && isMonthDisabled(changedDate, this.props)) {
+        return;
+      }
+    } else {
+      if (changedDate !== null && isDayDisabled(changedDate, this.props)) {
+        return;
+      }
+    }
+
+    const {
+      onChange,
+      selectsRange,
+      startDate,
+      endDate,
+      selectsStart,
+      selectsEnd,
+    } = this.props;
+
+    if (
+      !isEqual(this.props.selected, changedDate) ||
+      this.props.allowSameDay ||
+      selectsRange
+    ) {
+      if (changedDate !== null) {
         if (
-          changedDate !== null &&
-          isYearDisabled(getYear(changedDate), this.props)
+          this.props.selected &&
+          (!keepInput ||
+            (!this.props.showTimeSelect &&
+              !this.props.showTimeSelectOnly &&
+              !this.props.showTimeInput))
         ) {
-          return;
+          changedDate = setTime(changedDate, {
+            hour: getHours(this.props.selected),
+            minute: getMinutes(this.props.selected),
+            second: getSeconds(this.props.selected),
+          });
         }
-      } else if (this.props.showMonthYearPicker) {
-        if (changedDate !== null && isMonthDisabled(changedDate, this.props)) {
-          return;
+        if (!this.props.inline) {
+          this.setState({
+            preSelection: changedDate,
+          });
+        }
+        if (!this.props.focusSelectedMonth) {
+          this.setState({ monthSelectedIn: monthSelectedIn });
+        }
+      }
+
+      if (selectsStart || selectsEnd) {
+        if (isValid(new Date(startDate)) && isValid(new Date(endDate))) {
+          if (
+            isAfter(new Date(changedDate), new Date(endDate)) &&
+            selectsStart
+          ) {
+            return;
+          } else if (
+            isBefore(new Date(changedDate), new Date(startDate)) &&
+            selectsEnd
+          ) {
+            return;
+          }
+        }
+      }
+
+      if (selectsRange) {
+        const noRanges = !startDate && !endDate;
+        const hasStartRange = startDate && !endDate;
+        const isRangeFilled = startDate && endDate;
+        if (noRanges) {
+          onChange([changedDate, null], event);
+        } else if (hasStartRange) {
+          if (isBefore(changedDate, startDate)) {
+            onChange([changedDate, null], event);
+          } else {
+            onChange([startDate, changedDate], event);
+          }
+        }
+        if (isRangeFilled) {
+          onChange([changedDate, null], event);
         }
       } else {
-        if (changedDate !== null && isDayDisabled(changedDate, this.props)) {
-          return;
-        }
+        onChange(changedDate, event);
       }
+    }
 
-      const {
-        onChange,
-        selectsRange,
-        startDate,
-        endDate,
-        selectsStart,
-        selectsEnd,
-      } = this.props;
-
-      if (
-        !isEqual(this.props.selected, changedDate) ||
-        this.props.allowSameDay ||
-        selectsRange
-      ) {
-        if (changedDate !== null) {
-          if (
-            this.props.selected &&
-            (!keepInput ||
-              (!this.props.showTimeSelect &&
-                !this.props.showTimeSelectOnly &&
-                !this.props.showTimeInput))
-          ) {
-            changedDate = setTime(changedDate, {
-              hour: getHours(this.props.selected),
-              minute: getMinutes(this.props.selected),
-              second: getSeconds(this.props.selected),
-            });
-          }
-          if (!this.props.inline) {
-            this.setState({
-              preSelection: changedDate,
-            });
-          }
-          if (!this.props.focusSelectedMonth) {
-            this.setState({ monthSelectedIn: monthSelectedIn });
-          }
-        }
-
-        if (selectsStart || selectsEnd) {
-          if (isValid(new Date(startDate)) && isValid(new Date(endDate))) {
-            if (
-              isAfter(new Date(changedDate), new Date(endDate)) &&
-              selectsStart
-            ) {
-              return;
-            } else if (
-              isBefore(new Date(changedDate), new Date(startDate)) &&
-              selectsEnd
-            ) {
-              return;
-            }
-          }
-        }
-
-        if (selectsRange) {
-          const noRanges = !startDate && !endDate;
-          const hasStartRange = startDate && !endDate;
-          const isRangeFilled = startDate && endDate;
-          if (noRanges) {
-            onChange([changedDate, null], event);
-          } else if (hasStartRange) {
-            if (isBefore(changedDate, startDate)) {
-              onChange([changedDate, null], event);
-            } else {
-              onChange([startDate, changedDate], event);
-            }
-          }
-          if (isRangeFilled) {
-            onChange([changedDate, null], event);
-          }
-        } else {
-          onChange(changedDate, event);
-        }
-      }
-
-      if (!keepInput) {
-        this.props.onSelect(changedDate, event);
-        this.setState({ inputValue: null });
-      }
-    } catch (error) {
-      console.log(error);
+    if (!keepInput) {
+      this.props.onSelect(changedDate, event);
+      this.setState({ inputValue: null });
     }
   };
 

--- a/test/datepicker_test.test.js
+++ b/test/datepicker_test.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-deprecated */
 import React from "react";
 import ReactDOM from "react-dom";
 import { findDOMNode } from "react-dom";

--- a/test/timepicker_test.test.js
+++ b/test/timepicker_test.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-deprecated */
 import React from "react";
 import defer from "lodash/defer";
 import DatePicker from "../src/index.jsx";


### PR DESCRIPTION
### Steps to Reproduce 🕵️‍♂️

1. **Visit the documentation and date range selection example:**
   Navigate to the [date range picker example](https://reactdatepicker.com/#example-date-range) in the documentation.

2. **Observe the second input (for `endDate`):**
   Note that the days prior to the date selected in the first input are disabled, which may not be the desired behavior in some use cases.

3. **Select a start date (`startDate`) that is after the end date (`endDate`):**
   The invalid range is allowed, posing a usability concern as users can select a start date that is after their chosen end date, which might not be intuitive or may not validate against business logic.


### 🚨 Issue:
1. **📆 Invalid Date Ranges:** The component allows users to select invalid date ranges when using two inputs for range selection.
   
2. **🚫 Days Becoming Incorrectly Disabled:** Selecting certain date ranges results in days becoming incorrectly disabled in the UI.

#### 💡 Proposed Solutions:
1. **🔒 Prevent Invalid Range Selection:** Implement logic to prevent the user from selecting an invalid date range by doing nothing (or potentially showing an error message) when they attempt to select an end date that is earlier than the start date and vice versa.
   
   ```javascript
   if (selectsStart || selectsEnd) {
     if (isValid(new Date(startDate)) && isValid(new Date(endDate))) {
       if (isAfter(new Date(changedDate), new Date(endDate)) && selectsStart) {
         return;
       } else if (isBefore(new Date(changedDate), new Date(startDate)) && selectsEnd) {
         return;
       }
     }
   }
   ```
   
2. **🔄 Equalizing Start and End Dates:** Introduce logic that sets the end date equal to the start date if the user attempts to set a start date that is later than the end date, and vice versa.
   
3. **🔄 Resetting the Opposite Input:** If a user selects an invalid range, automatically reset the opposite input (reset end date if an invalid start date is selected, and vice versa).

4. **✨ Allow Invalid Ranges Prop:** Introduce a new prop `allowInvalidRanges`, which enables developers to control whether invalid date ranges can be set by the user. When `true`, invalid ranges are allowed, potentially enabling developers to handle this case in a way that suits their application, such as displaying a custom error message.

   ```javascript
   <DatePicker
     selected={startDate}
     onChange={(date) => setStartDate(date)}
     selectsStart
     startDate={startDate}
     endDate={endDate}
     allowInvalidRanges={false}
   />
   ```

#### 📝 Additional Notes:
- Developers must be able to select an approach that suits their application’s needs.
- The "days becoming incorrectly disabled" issue needs to be addressed to ensure user experience remains consistent and logical.
  
### 📋 Tasks:
- [ ] Implement logic to prevent invalid date range selection.
- [ ] Ensure days do not become incorrectly disabled.
- [ ] Implement logic to equalize start and end dates upon invalid selection.
- [ ] Implement logic to reset opposite input upon invalid selection.
- [ ] Implement `allowInvalidRanges` prop to provide additional flexibility for developers.
- [ ] Update documentation and examples to illustrate the usage of the new prop.

### 🧪 Tests:
- Ensure all existing tests pass.
- Add new tests for the introduced logic and prop to ensure future changes do not break this functionality.

NOTE: Temporarily disable linter rules in tests due to React 18 updates