### PR TITLE
Fix #4259: Add the aria-disabled on the Time component's disabled time units 

### DIFF
--- a/src/time.jsx
+++ b/src/time.jsx
@@ -100,6 +100,14 @@ export default class Time extends React.Component {
   isSelectedTime = (time) =>
     this.props.selected && isSameMinute(this.props.selected, time);
 
+  isDisabledTime = (time) =>
+    ((this.props.minTime || this.props.maxTime) &&
+      isTimeInDisabledRange(time, this.props)) ||
+    ((this.props.excludeTimes ||
+      this.props.includeTimes ||
+      this.props.filterTime) &&
+      isTimeDisabled(time, this.props));
+
   liClasses = (time) => {
     let classes = [
       "react-datepicker__time-list-item",
@@ -110,14 +118,7 @@ export default class Time extends React.Component {
       classes.push("react-datepicker__time-list-item--selected");
     }
 
-    if (
-      ((this.props.minTime || this.props.maxTime) &&
-        isTimeInDisabledRange(time, this.props)) ||
-      ((this.props.excludeTimes ||
-        this.props.includeTimes ||
-        this.props.filterTime) &&
-        isTimeDisabled(time, this.props))
-    ) {
+    if (this.isDisabledTime(time)) {
       classes.push("react-datepicker__time-list-item--disabled");
     }
     if (
@@ -216,6 +217,7 @@ export default class Time extends React.Component {
           tabIndex={time === timeToFocus ? 0 : -1}
           role="option"
           aria-selected={this.isSelectedTime(time) ? "true" : undefined}
+          aria-disabled={this.isDisabledTime(time) ? "true" : undefined}
         >
           {formatDate(time, format, this.props.locale)}
         </li>

--- a/test/exclude_times_test.test.js
+++ b/test/exclude_times_test.test.js
@@ -24,5 +24,10 @@ describe("DatePicker", () => {
       ".react-datepicker__time-list-item--disabled",
     );
     expect(disabledTimeItems.length).toBe(4);
+
+    const ariaDisabledTimeItems = Array.from(disabledTimeItems).filter(
+      (time) => time.getAttribute("aria-disabled") === "true",
+    );
+    expect(ariaDisabledTimeItems.length).toBe(4);
   });
 });

--- a/test/exclude_times_test.test.js
+++ b/test/exclude_times_test.test.js
@@ -25,9 +25,9 @@ describe("DatePicker", () => {
     );
     expect(disabledTimeItems.length).toBe(4);
 
-    const ariaDisabledTimeItems = Array.from(disabledTimeItems).filter(
-      (time) => time.getAttribute("aria-disabled") === "true",
-    );
-    expect(ariaDisabledTimeItems.length).toBe(4);
+    const allDisabledTimeItemsHaveAriaDisabled = Array.from(
+      disabledTimeItems,
+    ).every((time) => time.getAttribute("aria-disabled") === "true");
+    expect(allDisabledTimeItemsHaveAriaDisabled).toBe(true);
   });
 });

--- a/test/filter_times_test.test.js
+++ b/test/filter_times_test.test.js
@@ -12,5 +12,7 @@ describe("TimeComponent", () => {
     expect(
       timeComponent.find(".react-datepicker__time-list-item--disabled"),
     ).toHaveLength(2);
+
+    expect(timeComponent.find('[aria-disabled="true"]')).toHaveLength(2);
   });
 });

--- a/test/filter_times_test.test.js
+++ b/test/filter_times_test.test.js
@@ -14,9 +14,9 @@ describe("TimeComponent", () => {
     );
     expect(disabledTimeItems.length).toBe(2);
 
-    const ariaDisabledTimeItems = Array.from(disabledTimeItems).filter(
-      (time) => time.getAttribute("aria-disabled") === "true",
-    );
-    expect(ariaDisabledTimeItems.length).toBe(2);
+    const allDisabledTimeItemsHaveAriaDisabled = Array.from(
+      disabledTimeItems,
+    ).every((time) => time.getAttribute("aria-disabled") === "true");
+    expect(allDisabledTimeItemsHaveAriaDisabled).toBe(true);
   });
 });

--- a/test/filter_times_test.test.js
+++ b/test/filter_times_test.test.js
@@ -1,6 +1,5 @@
 import React from "react";
 import { render } from "@testing-library/react";
-import { mount } from "enzyme";
 import { getHours } from "../src/date_utils";
 import TimeComponent from "../src/time";
 

--- a/test/filter_times_test.test.js
+++ b/test/filter_times_test.test.js
@@ -1,18 +1,23 @@
 import React from "react";
+import { render } from "@testing-library/react";
 import { mount } from "enzyme";
 import { getHours } from "../src/date_utils";
 import TimeComponent from "../src/time";
 
 describe("TimeComponent", () => {
   it("should disable times matched by filterTime prop", () => {
-    const timeComponent = mount(
+    const { container: timeComponent } = render(
       <TimeComponent filterTime={(time) => getHours(time) !== 17} />,
     );
 
-    expect(
-      timeComponent.find(".react-datepicker__time-list-item--disabled"),
-    ).toHaveLength(2);
+    const disabledTimeItems = timeComponent.querySelectorAll(
+      ".react-datepicker__time-list-item--disabled",
+    );
+    expect(disabledTimeItems.length).toBe(2);
 
-    expect(timeComponent.find('[aria-disabled="true"]')).toHaveLength(2);
+    const ariaDisabledTimeItems = Array.from(disabledTimeItems).filter(
+      (time) => time.getAttribute("aria-disabled") === "true",
+    );
+    expect(ariaDisabledTimeItems.length).toBe(2);
   });
 });

--- a/test/include_times_test.test.js
+++ b/test/include_times_test.test.js
@@ -20,5 +20,8 @@ describe("TimeComponent", () => {
       ".react-datepicker__time-list-item--disabled",
     );
     expect(disabledItems).toHaveLength(45);
+
+    const ariaDisabledTimes = timeComponent.find('[aria-disabled="true"]');
+    expect(ariaDisabledTimes).toHaveLength(45);
   });
 });

--- a/test/include_times_test.test.js
+++ b/test/include_times_test.test.js
@@ -21,9 +21,9 @@ describe("TimeComponent", () => {
     );
     expect(disabledTimeItems.length).toBe(45);
 
-    const ariaDisabledTimeItems = Array.from(disabledTimeItems).filter(
-      (time) => time.getAttribute("aria-disabled") === "true",
-    );
-    expect(ariaDisabledTimeItems.length).toBe(45);
+    const allDisabledTimeItemsHaveAriaDisabled = Array.from(
+      disabledTimeItems,
+    ).every((time) => time.getAttribute("aria-disabled") === "true");
+    expect(allDisabledTimeItemsHaveAriaDisabled).toBe(true);
   });
 });

--- a/test/include_times_test.test.js
+++ b/test/include_times_test.test.js
@@ -1,12 +1,12 @@
 import React from "react";
-import { mount } from "enzyme";
+import { render } from "@testing-library/react";
 import * as utils from "../src/date_utils";
 import TimeComponent from "../src/time";
 
 describe("TimeComponent", () => {
   it("should only enable times specified in includeTimes props", () => {
     const today = utils.getStartOfDay(utils.newDate());
-    const timeComponent = mount(
+    const { container: timeComponent } = render(
       <TimeComponent
         includeTimes={[
           utils.addMinutes(today, 60),
@@ -16,12 +16,14 @@ describe("TimeComponent", () => {
       />,
     );
 
-    const disabledItems = timeComponent.find(
+    const disabledTimeItems = timeComponent.querySelectorAll(
       ".react-datepicker__time-list-item--disabled",
     );
-    expect(disabledItems).toHaveLength(45);
+    expect(disabledTimeItems.length).toBe(45);
 
-    const ariaDisabledTimes = timeComponent.find('[aria-disabled="true"]');
-    expect(ariaDisabledTimes).toHaveLength(45);
+    const ariaDisabledTimeItems = Array.from(disabledTimeItems).filter(
+      (time) => time.getAttribute("aria-disabled") === "true",
+    );
+    expect(ariaDisabledTimeItems.length).toBe(45);
   });
 });


### PR DESCRIPTION
Closes #4259

### Summary
This PR addresses an issue where the Time component is missing the attribute `aria-disabled` on it's disabled items.

### Changes made
- Updated the Time component to add the `aria-disabled` attribute over it's disabled items
- Made the logic to find the disable time unit sharable in a reusable helper function
- Updated the corresponding test cases to also check for the existence of the `aria-disabled` attribute along with the class `.react-datepicker__time-list-item--disabled`
- Migrated the test cases to use `RTL` from `enzyme` as suggested by @martijnrusschen in the issue #4300 for React 18 upgrade