### PR TITLE
Fix: reflect the `holidays` prop change

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -362,20 +362,18 @@ export default class DatePicker extends React.Component {
       ? this.props.endDate
       : newDate();
 
+  // Convert the date from string format to standard Date format
+  modifyHolidays = () =>
+    this.props.holidays?.reduce((accumulator, holiday) => {
+      const date = new Date(holiday.date);
+      if (!isValid(date)) {
+        return accumulator;
+      }
+
+      return [...accumulator, { ...holiday, date }];
+    }, []);
+
   calcInitialState = () => {
-    // Convert the date from string format to standard Date format
-    const modifiedHolidays = this.props.holidays?.reduce(
-      (accumulator, holiday) => {
-        const date = new Date(holiday.date);
-        if (!isValid(date)) {
-          return accumulator;
-        }
-
-        return [...accumulator, { ...holiday, date }];
-      },
-      [],
-    );
-
     const defaultPreSelection = this.getPreSelection();
     const minDate = getEffectiveMinDate(this.props);
     const maxDate = getEffectiveMaxDate(this.props);
@@ -395,7 +393,6 @@ export default class DatePicker extends React.Component {
       // transforming highlighted days (perhaps nested array)
       // to flat Map for faster access in day.jsx
       highlightDates: getHightLightDaysMap(this.props.highlightDates),
-      holidays: getHolidaysMap(modifiedHolidays),
       focused: false,
       // used to focus day in inline version after month has changed, but not on
       // initial render
@@ -972,7 +969,7 @@ export default class DatePicker extends React.Component {
         onClickOutside={this.handleCalendarClickOutside}
         formatWeekNumber={this.props.formatWeekNumber}
         highlightDates={this.state.highlightDates}
-        holidays={this.state.holidays}
+        holidays={getHolidaysMap(this.modifyHolidays())}
         includeDates={this.props.includeDates}
         includeDateIntervals={this.props.includeDateIntervals}
         includeTimes={this.props.includeTimes}


### PR DESCRIPTION
## Issue
The `holidays` prop is not reflected even if it is updated after initial rendering, because `holidays` is managed by state, and it is set at only initial rendering.
fix #4372 

## Fixing Approach
Calculate `holidays` at every rendering instead of managing it in state

## Cons
If very large `holidays` is given, rendering cost will increase.
