### PR TITLE
containerRef div shouldnt affect styling

### DIFF
--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -1074,7 +1074,7 @@ export default class Calendar extends React.Component {
   render() {
     const Container = this.props.container || CalendarContainer;
     return (
-      <div ref={this.containerRef}>
+      <div style={{display: 'contents'}} ref={this.containerRef}>
         <Container
           className={classnames("react-datepicker", this.props.className, {
             "react-datepicker--time-only": this.props.showTimeSelectOnly,


### PR DESCRIPTION
Currently the calendar is being rendered wrapped in a div that the sole intent, as i understand, is to wrap a ref arround it.
Considering this and that there are no props to style that div, it should have the display contents property to not affect styling. In some very specific cases it can create issues, for example in the print below, there is a little gap under the calendar*

*Maybe if i used height 100% in the calendar style it would fix it, however it could introduce other issues in the way i want the style to behave.

![image](https://github.com/Hacker0x01/react-datepicker/assets/139906072/40935ad6-9c94-409c-b1c9-bdb88031d703)

With a flex parent:

![image](https://github.com/Hacker0x01/react-datepicker/assets/139906072/f68912a2-8ec1-473b-8791-4cd0f9220319)
![image](https://github.com/Hacker0x01/react-datepicker/assets/139906072/f79f46ad-fe26-4e97-9eb1-d9a3083c2732)
