### PR TITLE
Fix #4431: Update the excludedDate to match the year to check of the isYearDisabled

### DIFF
--- a/test/date_utils_test.test.js
+++ b/test/date_utils_test.test.js
@@ -580,7 +580,7 @@ describe("date_utils", () => {
     });
 
     it("should be disabled if in excluded dates", () => {
-      const day = newDate();
+      const day = newDate(`${year}-02-01`);
       expect(isYearDisabled(year, { excludeDates: [day] })).toBe(true);
     });
 


### PR DESCRIPTION
Closes #4431

### Summary
This PR addresses the issues in the test block `date_utils › isYearDisabled › should be disabled if in excluded dates`.  The issue was we were excluding the current date (year 2024), but expecting the last year (2023) to be excluded.  

### Changes Made
I updated the date to match the year we're expecting to exclude.