### PR TITLE
Fix - Removed defaultProps from Function Components for React 18.3.

### DIFF
--- a/src/with_floating.jsx
+++ b/src/with_floating.jsx
@@ -25,22 +25,29 @@ export const popperPlacementPositions = [
 
 export default function withFloating(Component) {
   const WithFloating = (props) => {
+    const alt_props = {
+      ...props,
+      popperModifiers: props.popperModifiers || [],
+      popperProps: props.popperProps || {},
+      hidePopper:
+        typeof props.hidePopper === "boolean" ? props.hidePopper : true,
+    };
     const arrowRef = React.useRef();
     const floatingProps = useFloating({
-      open: !props.hidePopper,
+      open: !alt_props.hidePopper,
       whileElementsMounted: autoUpdate,
-      placement: props.popperPlacement,
+      placement: alt_props.popperPlacement,
       middleware: [
         flip({ padding: 15 }),
         offset(10),
         arrow({ element: arrowRef }),
-        ...props.popperModifiers,
+        ...alt_props.popperModifiers,
       ],
-      ...props.popperProps,
+      ...alt_props.popperProps,
     });
 
     return (
-      <Component {...props} popperProps={{ ...floatingProps, arrowRef }} />
+      <Component {...alt_props} popperProps={{ ...floatingProps, arrowRef }} />
     );
   };
 
@@ -49,12 +56,6 @@ export default function withFloating(Component) {
     popperModifiers: PropTypes.arrayOf(PropTypes.object),
     popperProps: PropTypes.object,
     hidePopper: PropTypes.bool,
-  };
-
-  WithFloating.defaultProps = {
-    popperModifiers: [],
-    popperProps: {},
-    hidePopper: true,
   };
 
   return WithFloating;


### PR DESCRIPTION
As of react 18.3, a warning will be displayed when using defaultProps inside a function component. Therefore, I have removed the defaultProps used in the function component.

Fix #4477