### PR TITLE
fix:enhance-code-syntax

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -695,7 +695,7 @@ export default class DatePicker extends React.Component {
       }
       const dateStartOfDay = startOfDay(date);
       if (hasMinDate && hasMaxDate) {
-        // isDayinRange uses startOfDay internally, so not necessary to manipulate times here
+        // isDayInRange uses startOfDay internally, so not necessary to manipulate times here
         isValidDateSelection = isDayInRange(
           date,
           this.props.minDate,

--- a/test/datepicker_test.test.js
+++ b/test/datepicker_test.test.js
@@ -997,7 +997,7 @@ describe("DatePicker", () => {
       utils.formatDate(data.datePicker.state.preSelection, data.testFormat),
     ).toBe(utils.formatDate(data.copyM, data.testFormat));
   });
-  it("should call onMonthchange when keyboard navigation moves preSelection to different month", () => {
+  it("should call onMonthChange when keyboard navigation moves preSelection to different month", () => {
     var onMonthChangeSpy = jest.fn();
     var opts = { onMonthChange: onMonthChangeSpy };
     var data = getOnInputKeyDownStuff(opts);
@@ -1335,13 +1335,13 @@ describe("DatePicker", () => {
     );
   });
 
-  it("should autofocus the input given the autoFocus prop", () => {
+  it("should autoFocus the input given the autoFocus prop", () => {
     var div = document.createElement("div");
     document.body.appendChild(div);
     ReactDOM.render(<DatePicker autoFocus />, div);
     expect(div.querySelector("input")).toBe(document.activeElement);
   });
-  it("should autofocus the input when calling the setFocus method", () => {
+  it("should autoFocus the input when calling the setFocus method", () => {
     var div = document.createElement("div");
     document.body.appendChild(div);
     var datePicker = ReactDOM.render(<DatePicker />, div);


### PR DESCRIPTION
This merge request includes two enhancements in syntax:

1. onMonthChange and autoFocus have been used in the correct camelCase format throughout the project, except in the test file for react-datepicker. All other test titles follow this convention.

2. isDayInRange has a similar issue in the comment within the index.js file.