### PR TITLE
Fix #4483: Enable onKeyDown handler for the month picker view and the year picker view

### DIFF
--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -894,6 +894,7 @@ export default class Calendar extends React.Component {
             monthClassName={this.props.monthClassName}
             onDayClick={this.handleDayClick}
             handleOnKeyDown={this.props.handleOnDayKeyDown}
+            handleOnMonthKeyDown={this.props.handleOnKeyDown}
             onDayMouseEnter={this.handleDayMouseEnter}
             onMouseLeave={this.handleMonthMouseLeave}
             onWeekSelect={this.props.onWeekSelect}

--- a/src/month.jsx
+++ b/src/month.jsx
@@ -113,6 +113,7 @@ export default class Month extends React.Component {
     showQuarterYearPicker: PropTypes.bool,
     showWeekPicker: PropTypes.bool,
     handleOnKeyDown: PropTypes.func,
+    handleOnMonthKeyDown: PropTypes.func,
     isInputFocused: PropTypes.bool,
     weekAriaLabelPrefix: PropTypes.string,
     containerRef: PropTypes.oneOfType([
@@ -400,6 +401,7 @@ export default class Month extends React.Component {
       showTwoColumnMonthYearPicker,
       showFourColumnMonthYearPicker,
       setPreSelection,
+      handleOnMonthKeyDown,
     } = this.props;
     const eventKey = event.key;
     if (eventKey !== "Tab") {
@@ -451,6 +453,8 @@ export default class Month extends React.Component {
           break;
       }
     }
+
+    handleOnMonthKeyDown && handleOnMonthKeyDown(event);
   };
 
   onQuarterClick = (e, q) => {

--- a/src/year.jsx
+++ b/src/year.jsx
@@ -29,6 +29,7 @@ export default class Year extends React.Component {
     includeDates: PropTypes.array,
     filterDate: PropTypes.func,
     yearItemNumber: PropTypes.number,
+    handleOnKeyDown: PropTypes.func,
   };
 
   constructor(props) {
@@ -157,6 +158,8 @@ export default class Year extends React.Component {
 
   onYearKeyDown = (e, y) => {
     const { key } = e;
+    const { handleOnKeyDown } = this.props;
+
     if (!this.props.disabledKeyboardNavigation) {
       switch (key) {
         case "Enter":
@@ -177,6 +180,8 @@ export default class Year extends React.Component {
           break;
       }
     }
+
+    handleOnKeyDown && handleOnKeyDown(e);
   };
 
   getYearClassNames = (y) => {

--- a/test/month_test.test.js
+++ b/test/month_test.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-import ReactDOM from "react-dom";
+import { render, fireEvent } from "@testing-library/react";
 import Month from "../src/month";
 import Day from "../src/day";
 import DatePicker from "../src";
@@ -941,7 +941,7 @@ describe("Month", () => {
     it("should call onKeyDown handler on any key press", () => {
       const onKeyDownSpy = jest.fn();
 
-      const datePicker = TestUtils.renderIntoDocument(
+      const { container } = render(
         <DatePicker
           selected={new Date()}
           dateFormat="MM/yyyy"
@@ -949,15 +949,16 @@ describe("Month", () => {
           onKeyDown={onKeyDownSpy}
         />,
       );
-      TestUtils.Simulate.focus(ReactDOM.findDOMNode(datePicker.input));
 
-      const month = TestUtils.findRenderedDOMComponentWithClass(
-        datePicker,
-        "react-datepicker__month-0",
-      );
-      TestUtils.Simulate.keyDown(month, {
+      const dateInput = container.querySelector("input");
+      fireEvent.focus(dateInput);
+
+      const month = container.querySelector(".react-datepicker__month-0");
+
+      fireEvent.keyDown(month, {
         key: "ArrowDown",
       });
+
       expect(onKeyDownSpy).toHaveBeenCalledTimes(1);
     });
   });

--- a/test/month_test.test.js
+++ b/test/month_test.test.js
@@ -1,6 +1,8 @@
 import React from "react";
+import ReactDOM from "react-dom";
 import Month from "../src/month";
 import Day from "../src/day";
+import DatePicker from "../src";
 import range from "lodash/range";
 import { mount, shallow } from "enzyme";
 import * as utils from "../src/date_utils";
@@ -934,6 +936,29 @@ describe("Month", () => {
             .hasClass("react-datepicker__quarter-text--keyboard-selected"),
         ).toBe(false);
       });
+    });
+
+    it("should call onKeyDown handler on any key press", () => {
+      const onKeyDownSpy = jest.fn();
+
+      const datePicker = TestUtils.renderIntoDocument(
+        <DatePicker
+          selected={new Date()}
+          dateFormat="MM/yyyy"
+          showMonthYearPicker
+          onKeyDown={onKeyDownSpy}
+        />,
+      );
+      TestUtils.Simulate.focus(ReactDOM.findDOMNode(datePicker.input));
+
+      const month = TestUtils.findRenderedDOMComponentWithClass(
+        datePicker,
+        "react-datepicker__month-0",
+      );
+      TestUtils.Simulate.keyDown(month, {
+        key: "ArrowDown",
+      });
+      expect(onKeyDownSpy).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/test/year_picker_test.test.js
+++ b/test/year_picker_test.test.js
@@ -597,6 +597,32 @@ describe("YearPicker", () => {
       TestUtils.Simulate.keyDown(target, { key: "Enter", code: 13, which: 13 });
       expect(utils.getYear(selectedDay)).toBe(2021);
     });
+    it("should call onKeyDown handler on any key press", () => {
+      const onKeyDownSpy = jest.fn();
+
+      const datePicker = TestUtils.renderIntoDocument(
+        <DatePicker
+          selected={new Date()}
+          showYearPicker
+          dateFormat="yyyy"
+          onKeyDown={onKeyDownSpy}
+        />,
+      );
+      TestUtils.Simulate.focus(ReactDOM.findDOMNode(datePicker.input));
+
+      const yearPicker = TestUtils.findRenderedDOMComponentWithClass(
+        datePicker,
+        "react-datepicker__year-wrapper",
+      );
+
+      const year = yearPicker.children[0];
+      TestUtils.Simulate.keyDown(year, {
+        key: "ArrowDown",
+      });
+
+      expect(onKeyDownSpy).toHaveBeenCalledTimes(1);
+    });
+
     it("should disable keyboard navigation", () => {
       const yearPicker = getPicker("2021-01-01", {
         disabledKeyboardNavigation: true,

--- a/test/year_picker_test.test.js
+++ b/test/year_picker_test.test.js
@@ -4,6 +4,7 @@ import DatePicker from "../src/index.jsx";
 import Year from "../src/year.jsx";
 import TestUtils from "react-dom/test-utils";
 import ReactDOM from "react-dom";
+import { render, fireEvent } from "@testing-library/react";
 import * as utils from "../src/date_utils.js";
 import Calendar from "../src/calendar.jsx";
 import { getKey } from "./test_utils.js";
@@ -602,7 +603,7 @@ describe("YearPicker", () => {
     it("should call onKeyDown handler on any key press", () => {
       const onKeyDownSpy = jest.fn();
 
-      const datePicker = TestUtils.renderIntoDocument(
+      const { container } = render(
         <DatePicker
           selected={new Date()}
           showYearPicker
@@ -610,15 +611,13 @@ describe("YearPicker", () => {
           onKeyDown={onKeyDownSpy}
         />,
       );
-      TestUtils.Simulate.focus(ReactDOM.findDOMNode(datePicker.input));
 
-      const yearPicker = TestUtils.findRenderedDOMComponentWithClass(
-        datePicker,
-        "react-datepicker__year-wrapper",
-      );
+      const dateInput = container.querySelector("input");
+      fireEvent.focus(dateInput);
 
-      const year = yearPicker.children[0];
-      TestUtils.Simulate.keyDown(year, {
+      const year = container.querySelector(".react-datepicker__year-text");
+
+      fireEvent.keyDown(year, {
         key: "ArrowDown",
       });
 


### PR DESCRIPTION
Closes #4483

**Description**
This PR addresses the missing event handling to handle the key-press event for the month picker and the year picker.  For the Year Picker component, I added `onKeyDown` and mapped it to the corresponding prop.  However, the MonthPicker (`month.jsx`) is already receiving `onKeyDown` event, but that was mapped to the handler `handleOnDayKeyDown` which is the handler specifically we're using on `day.jsx`.  In `month.jsx` we're not directly using it, but passing that to the `Week` component.  Hence for the month.jsx alone, I didn't change any of its current behavior, and I added a new prop named `handleOnMonthKeyDown` which is linked to the `onKeyDown` event handler we pass from the DatePicker component.  So users can still use `onKeyDown` itself for any datepicker view (day/month/year), but internally `month.jsx` alone is handling it via `handleOnMonthKeyDown`.


**Changes Made**
- Updated Year picker and Month picker to handle the `onKeyDown` event.
- Updated the corresponding test cases.