### PR TITLE
fix: Change onMouseXXX event to onPointerXXX event

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -74,18 +74,18 @@
 | `onChange`                      | `func`                         | `() {}`                    |             |
 | `onChangeRaw`                   | `func`                         |                            |             |
 | `onClickOutside`                | `func`                         | `() {}`                    |             |
-| `onDayMouseEnter`               | `func`                         |                            |             |
+| `onDayPointerEnter`             | `func`                         |                            |             |
 | `onFocus`                       | `func`                         | `() {}`                    |             |
 | `onInputClick`                  | `func`                         | `() {}`                    |             |
 | `onInputError`                  | `func`                         | `() {}`                    |             |
 | `onKeyDown`                     | `func`                         | `() {}`                    |             |
 | `onMonthChange`                 | `func`                         | `() {}`                    |             |
-| `onMonthMouseLeave`             | `func`                         |                            |             |
+| `onMonthPointerLeave`           | `func`                         |                            |             |
 | `onSelect`                      | `func`                         | `() {}`                    |             |
 | `onWeekSelect`                  | `func`                         |                            |             |
 | `onYearChange`                  | `func`                         | `() {}`                    |             |
-| `onYearMouseEnter`              | `func`                         |                            |             |
-| `onYearMouseLeave`              | `func`                         |                            |             |
+| `onYearPointerEnter`            | `func`                         |                            |             |
+| `onYearPointerLeave`            | `func`                         |                            |             |
 | `open`                          | `bool`                         |                            |             |
 | `openToDate`                    | `instanceOfDate`               |                            |             |
 | `peekNextMonth`                 | `bool`                         |                            |             |

--- a/docs/year.md
+++ b/docs/year.md
@@ -1,28 +1,28 @@
 # `year` (component)
 
-| name                          | type             | default value | description |
-| ----------------------------- | ---------------- | ------------- | ----------- |
-| `clearSelectingDate`          | `func`           |               |             |
-| `date`                        | `instanceOfDate` |               |             |
-| `disabledKeyboardNavigation`  | `bool`           |               |             |
-| `endDate`                     | `instanceOfDate` |               |             |
-| `excludeDates`                | `array`          |               |             |
-| `filterDate`                  | `func`           |               |             |
-| `handleOnKeyDown`             | `func`           |               |             |
-| `includeDates`                | `array`          |               |             |
-| `inline`                      | `bool`           |               |             |
-| `maxDate`                     | `instanceOfDate` |               |             |
-| `minDate`                     | `instanceOfDate` |               |             |
-| `onDayClick`                  | `func`           |               |             |
-| `onYearMouseEnter` (required) | `func`           |               |             |
-| `onYearMouseLeave` (required) | `func`           |               |             |
-| `preSelection`                | `instanceOfDate` |               |             |
-| `renderYearContent`           | `func`           |               |             |
-| `selected`                    | `object`         |               |             |
-| `selectingDate`               | `instanceOfDate` |               |             |
-| `selectsEnd`                  | `bool`           |               |             |
-| `selectsRange`                | `bool`           |               |             |
-| `selectsStart`                | `bool`           |               |             |
-| `setPreSelection`             | `func`           |               |             |
-| `startDate`                   | `instanceOfDate` |               |             |
-| `yearItemNumber`              | `number`         |               |             |
+| name                            | type             | default value | description |
+| ------------------------------- | ---------------- | ------------- | ----------- |
+| `clearSelectingDate`            | `func`           |               |             |
+| `date`                          | `instanceOfDate` |               |             |
+| `disabledKeyboardNavigation`    | `bool`           |               |             |
+| `endDate`                       | `instanceOfDate` |               |             |
+| `excludeDates`                  | `array`          |               |             |
+| `filterDate`                    | `func`           |               |             |
+| `handleOnKeyDown`               | `func`           |               |             |
+| `includeDates`                  | `array`          |               |             |
+| `inline`                        | `bool`           |               |             |
+| `maxDate`                       | `instanceOfDate` |               |             |
+| `minDate`                       | `instanceOfDate` |               |             |
+| `onDayClick`                    | `func`           |               |             |
+| `onYearPointerEnter` (required) | `func`           |               |             |
+| `onYearPointerLeave` (required) | `func`           |               |             |
+| `preSelection`                  | `instanceOfDate` |               |             |
+| `renderYearContent`             | `func`           |               |             |
+| `selected`                      | `object`         |               |             |
+| `selectingDate`                 | `instanceOfDate` |               |             |
+| `selectsEnd`                    | `bool`           |               |             |
+| `selectsRange`                  | `bool`           |               |             |
+| `selectsStart`                  | `bool`           |               |             |
+| `setPreSelection`               | `func`           |               |             |
+| `startDate`                     | `instanceOfDate` |               |             |
+| `yearItemNumber`                | `number`         |               |             |

--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -196,10 +196,10 @@ export default class Calendar extends React.Component {
     renderMonthContent: PropTypes.func,
     renderQuarterContent: PropTypes.func,
     renderYearContent: PropTypes.func,
-    onDayMouseEnter: PropTypes.func,
-    onMonthMouseLeave: PropTypes.func,
-    onYearMouseEnter: PropTypes.func,
-    onYearMouseLeave: PropTypes.func,
+    onDayPointerEnter: PropTypes.func,
+    onMonthPointerLeave: PropTypes.func,
+    onYearPointerEnter: PropTypes.func,
+    onYearPointerLeave: PropTypes.func,
     showPopperArrow: PropTypes.bool,
     handleOnKeyDown: PropTypes.func,
     handleOnDayKeyDown: PropTypes.func,
@@ -316,23 +316,23 @@ export default class Calendar extends React.Component {
     this.props.setPreSelection && this.props.setPreSelection(day);
   };
 
-  handleDayMouseEnter = (day) => {
+  handleDayPointerEnter = (day) => {
     this.setState({ selectingDate: day });
-    this.props.onDayMouseEnter && this.props.onDayMouseEnter(day);
+    this.props.onDayPointerEnter && this.props.onDayPointerEnter(day);
   };
 
-  handleMonthMouseLeave = () => {
+  handleMonthPointerLeave = () => {
     this.setState({ selectingDate: null });
-    this.props.onMonthMouseLeave && this.props.onMonthMouseLeave();
+    this.props.onMonthPointerLeave && this.props.onMonthPointerLeave();
   };
 
-  handleYearMouseEnter = (event, year) => {
+  handleYearPointerEnter = (event, year) => {
     this.setState({ selectingDate: setYear(newDate(), year) });
-    !!this.props.onYearMouseEnter && this.props.onYearMouseEnter(event, year);
+    !!this.props.onYearPointerEnter && this.props.onYearPointerEnter(event, year);
   };
 
-  handleYearMouseLeave = (event, year) => {
-    !!this.props.onYearMouseLeave && this.props.onYearMouseLeave(event, year);
+  handleYearPointerLeave = (event, year) => {
+    !!this.props.onYearPointerLeave && this.props.onYearPointerLeave(event, year);
   };
 
   handleYearChange = (date) => {
@@ -897,8 +897,8 @@ export default class Calendar extends React.Component {
             onDayClick={this.handleDayClick}
             handleOnKeyDown={this.props.handleOnDayKeyDown}
             handleOnMonthKeyDown={this.props.handleOnKeyDown}
-            onDayMouseEnter={this.handleDayMouseEnter}
-            onMouseLeave={this.handleMonthMouseLeave}
+            onDayPointerEnter={this.handleDayPointerEnter}
+            onPointerLeave={this.handleMonthPointerLeave}
             onWeekSelect={this.props.onWeekSelect}
             orderInDisplay={i}
             formatWeekNumber={this.props.formatWeekNumber}
@@ -972,8 +972,8 @@ export default class Calendar extends React.Component {
             clearSelectingDate={this.clearSelectingDate}
             date={this.state.date}
             {...this.props}
-            onYearMouseEnter={this.handleYearMouseEnter}
-            onYearMouseLeave={this.handleYearMouseLeave}
+            onYearPointerEnter={this.handleYearPointerEnter}
+            onYearPointerLeave={this.handleYearPointerLeave}
           />
         </div>
       );

--- a/src/day.jsx
+++ b/src/day.jsx
@@ -32,7 +32,7 @@ export default class Day extends React.Component {
     shouldFocusDayInline: PropTypes.bool,
     month: PropTypes.number,
     onClick: PropTypes.func,
-    onMouseEnter: PropTypes.func,
+    onPointerEnter: PropTypes.func,
     preSelection: PropTypes.instanceOf(Date),
     selected: PropTypes.object,
     selectingDate: PropTypes.instanceOf(Date),
@@ -77,9 +77,9 @@ export default class Day extends React.Component {
     }
   };
 
-  handleMouseEnter = (event) => {
-    if (!this.isDisabled() && this.props.onMouseEnter) {
-      this.props.onMouseEnter(event);
+  handlePointerEnter = (event) => {
+    if (!this.isDisabled() && this.props.onPointerEnter) {
+      this.props.onPointerEnter(event);
     }
   };
 
@@ -434,7 +434,7 @@ export default class Day extends React.Component {
       className={this.getClassNames(this.props.day)}
       onKeyDown={this.handleOnKeyDown}
       onClick={this.handleClick}
-      onMouseEnter={this.handleMouseEnter}
+      onPointerEnter={this.handlePointerEnter}
       tabIndex={this.getTabIndex()}
       aria-label={this.getAriaLabel()}
       role="option"

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -301,10 +301,10 @@ export default class DatePicker extends React.Component {
     renderYearContent: PropTypes.func,
     wrapperClassName: PropTypes.string,
     focusSelectedMonth: PropTypes.bool,
-    onDayMouseEnter: PropTypes.func,
-    onMonthMouseLeave: PropTypes.func,
-    onYearMouseEnter: PropTypes.func,
-    onYearMouseLeave: PropTypes.func,
+    onDayPointerEnter: PropTypes.func,
+    onMonthPointerLeave: PropTypes.func,
+    onYearPointerEnter: PropTypes.func,
+    onYearPointerLeave: PropTypes.func,
     showPopperArrow: PropTypes.bool,
     excludeScrollbar: PropTypes.bool,
     enableTabLoop: PropTypes.bool,
@@ -1120,10 +1120,10 @@ export default class DatePicker extends React.Component {
         renderMonthContent={this.props.renderMonthContent}
         renderQuarterContent={this.props.renderQuarterContent}
         renderYearContent={this.props.renderYearContent}
-        onDayMouseEnter={this.props.onDayMouseEnter}
-        onMonthMouseLeave={this.props.onMonthMouseLeave}
-        onYearMouseEnter={this.props.onYearMouseEnter}
-        onYearMouseLeave={this.props.onYearMouseLeave}
+        onDayPointerEnter={this.props.onDayPointerEnter}
+        onMonthPointerLeave={this.props.onMonthPointerLeave}
+        onYearPointerEnter={this.props.onYearPointerEnter}
+        onYearPointerLeave={this.props.onYearPointerLeave}
         selectsDisabledDaysInRange={this.props.selectsDisabledDaysInRange}
         showTimeInput={this.props.showTimeInput}
         showMonthYearPicker={this.props.showMonthYearPicker}

--- a/src/month.jsx
+++ b/src/month.jsx
@@ -86,8 +86,8 @@ export default class Month extends React.Component {
     maxDate: PropTypes.instanceOf(Date),
     minDate: PropTypes.instanceOf(Date),
     onDayClick: PropTypes.func,
-    onDayMouseEnter: PropTypes.func,
-    onMouseLeave: PropTypes.func,
+    onDayPointerEnter: PropTypes.func,
+    onPointerLeave: PropTypes.func,
     onWeekSelect: PropTypes.func,
     peekNextMonth: PropTypes.bool,
     preSelection: PropTypes.instanceOf(Date),
@@ -139,15 +139,15 @@ export default class Month extends React.Component {
     }
   };
 
-  handleDayMouseEnter = (day) => {
-    if (this.props.onDayMouseEnter) {
-      this.props.onDayMouseEnter(day);
+  handleDayPointerEnter = (day) => {
+    if (this.props.onDayPointerEnter) {
+      this.props.onDayPointerEnter(day);
     }
   };
 
-  handleMouseLeave = () => {
-    if (this.props.onMouseLeave) {
-      this.props.onMouseLeave();
+  handlePointerLeave = () => {
+    if (this.props.onPointerLeave) {
+      this.props.onPointerLeave();
     }
   };
 
@@ -311,7 +311,7 @@ export default class Month extends React.Component {
           day={currentWeekStart}
           month={utils.getMonth(this.props.day)}
           onDayClick={this.handleDayClick}
-          onDayMouseEnter={this.handleDayMouseEnter}
+          onDayPointerEnter={this.handleDayPointerEnter}
           onWeekSelect={this.props.onWeekSelect}
           formatWeekNumber={this.props.formatWeekNumber}
           locale={this.props.locale}
@@ -384,8 +384,8 @@ export default class Month extends React.Component {
     );
   };
 
-  onMonthMouseEnter = (m) => {
-    this.handleDayMouseEnter(
+  onMonthPointerEnter = (m) => {
+    this.handleDayPointerEnter(
       utils.getStartOfMonth(utils.setMonth(this.props.day, m)),
     );
   };
@@ -468,8 +468,8 @@ export default class Month extends React.Component {
     );
   };
 
-  onQuarterMouseEnter = (q) => {
-    this.handleDayMouseEnter(
+  onQuarterPointerEnter = (q) => {
+    this.handleDayPointerEnter(
       utils.getStartOfQuarter(utils.setQuarter(this.props.day, q)),
     );
   };
@@ -684,7 +684,7 @@ export default class Month extends React.Component {
 
               this.onMonthKeyDown(ev, m);
             }}
-            onMouseEnter={() => this.onMonthMouseEnter(m)}
+            onPointerEnter={() => this.onMonthPointerEnter(m)}
             tabIndex={this.getTabIndex(m)}
             className={this.getMonthClassNames(m)}
             role="option"
@@ -715,7 +715,7 @@ export default class Month extends React.Component {
             onKeyDown={(ev) => {
               this.onQuarterKeyDown(ev, q);
             }}
-            onMouseEnter={() => this.onQuarterMouseEnter(q)}
+            onPointerEnter={() => this.onQuarterPointerEnter(q)}
             className={this.getQuarterClassNames(q)}
             aria-selected={this.isSelectedQuarter(day, q, selected)}
             tabIndex={this.getQuarterTabIndex(q)}
@@ -760,7 +760,7 @@ export default class Month extends React.Component {
     return (
       <div
         className={this.getClassNames()}
-        onMouseLeave={this.handleMouseLeave}
+        onPointerLeave={this.handlePointerLeave}
         aria-label={`${ariaLabelPrefix} ${utils.formatDate(day, "yyyy-MM")}`}
         role="listbox"
       >

--- a/src/week.jsx
+++ b/src/week.jsx
@@ -44,7 +44,7 @@ export default class Week extends React.Component {
     minDate: PropTypes.instanceOf(Date),
     month: PropTypes.number,
     onDayClick: PropTypes.func,
-    onDayMouseEnter: PropTypes.func,
+    onDayPointerEnter: PropTypes.func,
     onWeekSelect: PropTypes.func,
     preSelection: PropTypes.instanceOf(Date),
     selected: PropTypes.instanceOf(Date),
@@ -77,9 +77,9 @@ export default class Week extends React.Component {
     }
   };
 
-  handleDayMouseEnter = (day) => {
-    if (this.props.onDayMouseEnter) {
-      this.props.onDayMouseEnter(day);
+  handleDayPointerEnter = (day) => {
+    if (this.props.onDayPointerEnter) {
+      this.props.onDayPointerEnter(day);
     }
   };
 
@@ -149,7 +149,7 @@ export default class Week extends React.Component {
             day={day}
             month={this.props.month}
             onClick={this.handleDayClick.bind(this, day)}
-            onMouseEnter={this.handleDayMouseEnter.bind(this, day)}
+            onPointerEnter={this.handleDayPointerEnter.bind(this, day)}
             minDate={this.props.minDate}
             maxDate={this.props.maxDate}
             excludeDates={this.props.excludeDates}

--- a/src/year.jsx
+++ b/src/year.jsx
@@ -17,8 +17,8 @@ export default class Year extends React.Component {
     inline: PropTypes.bool,
     maxDate: PropTypes.instanceOf(Date),
     minDate: PropTypes.instanceOf(Date),
-    onYearMouseEnter: PropTypes.func.isRequired,
-    onYearMouseLeave: PropTypes.func.isRequired,
+    onYearPointerEnter: PropTypes.func.isRequired,
+    onYearPointerLeave: PropTypes.func.isRequired,
     selectingDate: PropTypes.instanceOf(Date),
     renderYearContent: PropTypes.func,
     selectsEnd: PropTypes.bool,
@@ -235,7 +235,7 @@ export default class Year extends React.Component {
 
   render() {
     const yearsList = [];
-    const { date, yearItemNumber, onYearMouseEnter, onYearMouseLeave } =
+    const { date, yearItemNumber, onYearPointerEnter, onYearPointerLeave } =
       this.props;
     const { startPeriod, endPeriod } = utils.getYearsPeriod(
       date,
@@ -259,8 +259,8 @@ export default class Year extends React.Component {
           }}
           tabIndex={this.getYearTabIndex(y)}
           className={this.getYearClassNames(y)}
-          onMouseEnter={(ev) => onYearMouseEnter(ev, y)}
-          onMouseLeave={(ev) => onYearMouseLeave(ev, y)}
+          onPointerEnter={(ev) => onYearPointerEnter(ev, y)}
+          onPointerLeave={(ev) => onYearPointerLeave(ev, y)}
           key={y}
           aria-current={this.isCurrentYear(y) ? "date" : undefined}
         >
@@ -273,7 +273,7 @@ export default class Year extends React.Component {
       <div className={this.getYearContainerClassNames()}>
         <div
           className="react-datepicker__year-wrapper"
-          onMouseLeave={this.props.clearSelectingDate}
+          onPointerLeave={this.props.clearSelectingDate}
         >
           {yearsList}
         </div>

--- a/test/calendar_test.test.js
+++ b/test/calendar_test.test.js
@@ -868,7 +868,7 @@ describe("Calendar", () => {
       />,
     );
     const day = calendar.find(Day).first();
-    day.simulate("mouseenter");
+    day.simulate("pointerenter");
     const month = calendar.find(Month).first();
     expect(month.prop("selectingDate")).toBeDefined();
     expect(utils.isSameDay(month.prop("selectingDate"), day.prop("day"))).toBe(
@@ -876,7 +876,7 @@ describe("Calendar", () => {
     );
   });
 
-  it("should clear the hovered day when the mouse leaves", () => {
+  it("should clear the hovered day when the pointer leaves", () => {
     const calendar = mount(
       <Calendar
         dateFormat={dateFormat}
@@ -888,7 +888,7 @@ describe("Calendar", () => {
     calendar.setState({ selectingDate: utils.newDate() });
     const month = calendar.find(Month).first();
     expect(month.prop("selectingDate")).toBeDefined();
-    month.simulate("mouseleave");
+    month.simulate("pointerleave");
     calendar.update();
     expect(calendar.find(Month).first().prop("selectingDate")).toBeFalsy();
   });

--- a/test/datepicker_test.test.js
+++ b/test/datepicker_test.test.js
@@ -359,7 +359,7 @@ describe("DatePicker", () => {
     ).toBe(utils.formatDate(data.copyM, data.testFormat));
   });
 
-  xit("should update the preSelection state when a day is selected with mouse click", () => {
+  xit("should update the preSelection state when a day is selected with pointer click", () => {
     var data = getOnInputKeyDownStuff({
       shouldCloseOnSelect: false,
     });
@@ -2589,15 +2589,15 @@ describe("DatePicker", () => {
   });
 
   describe("Year picker", () => {
-    it("should call onYearMouseEnter and onYearMouseEnter", () => {
-      const onYearMouseEnterSpy = jest.fn();
-      const onYearMouseLeaveSpy = jest.fn();
+    it("should call onYearPointerEnter and onYearPointerEnter", () => {
+      const onYearPointerEnterSpy = jest.fn();
+      const onYearPointerLeaveSpy = jest.fn();
       const datePicker = mount(
         <DatePicker
           selected={new Date(2023, 0, 1)}
           showYearPicker
-          onYearMouseEnter={onYearMouseEnterSpy}
-          onYearMouseLeave={onYearMouseLeaveSpy}
+          onYearPointerEnter={onYearPointerEnterSpy}
+          onYearPointerLeave={onYearPointerLeaveSpy}
         />,
       );
 
@@ -2608,11 +2608,11 @@ describe("DatePicker", () => {
         ".react-datepicker__year-text--selected",
       );
 
-      selectedYear.simulate("mouseenter");
-      selectedYear.simulate("mouseleave");
+      selectedYear.simulate("pointerenter");
+      selectedYear.simulate("pointerleave");
 
-      expect(onYearMouseEnterSpy).toHaveBeenCalled();
-      expect(onYearMouseLeaveSpy).toHaveBeenCalled();
+      expect(onYearPointerEnterSpy).toHaveBeenCalled();
+      expect(onYearPointerLeaveSpy).toHaveBeenCalled();
     });
   });
 });

--- a/test/day_test.test.js
+++ b/test/day_test.test.js
@@ -914,21 +914,21 @@ describe("Day", () => {
     });
   });
 
-  describe("mouse enter", () => {
-    var onMouseEnterCalled;
+  describe("pointer enter", () => {
+    var onPointerEnterCalled;
 
-    function onMouseEnter() {
-      onMouseEnterCalled = true;
+    function onPointerEnter() {
+      onPointerEnterCalled = true;
     }
 
     beforeEach(() => {
-      onMouseEnterCalled = false;
+      onPointerEnterCalled = false;
     });
 
-    it("should call onMouseEnter if day is hovered", () => {
-      const shallowDay = renderDay(newDate(), { onMouseEnter });
-      shallowDay.find(".react-datepicker__day").simulate("mouseenter");
-      expect(onMouseEnterCalled).toBe(true);
+    it("should call onPointerEnter if day is hovered", () => {
+      const shallowDay = renderDay(newDate(), { onPointerEnter });
+      shallowDay.find(".react-datepicker__day").simulate("pointerenter");
+      expect(onPointerEnterCalled).toBe(true);
     });
   });
 

--- a/test/month_test.test.js
+++ b/test/month_test.test.js
@@ -116,33 +116,33 @@ describe("Month", () => {
     expect(utils.isSameDay(day.prop("day"), dayClicked)).toBe(true);
   });
 
-  it("should call the provided onMouseLeave function", () => {
-    let mouseLeaveCalled = false;
+  it("should call the provided onPointerLeave function", () => {
+    let pointerLeaveCalled = false;
 
-    function onMouseLeave() {
-      mouseLeaveCalled = true;
+    function onPointerLeave() {
+      pointerLeaveCalled = true;
     }
 
     const month = shallow(
-      <Month day={utils.newDate()} onMouseLeave={onMouseLeave} />,
+      <Month day={utils.newDate()} onPointerLeave={onPointerLeave} />,
     );
-    month.simulate("mouseleave");
-    expect(mouseLeaveCalled).toBe(true);
+    month.simulate("pointerleave");
+    expect(pointerLeaveCalled).toBe(true);
   });
 
-  it("should call the provided onDayMouseEnter function", () => {
-    let dayMouseEntered = null;
+  it("should call the provided onDayPointerEnter function", () => {
+    let dayPointerEntered = null;
 
-    function onDayMouseEnter(day) {
-      dayMouseEntered = day;
+    function onDayPointerEnter(day) {
+      dayPointerEntered = day;
     }
 
     const month = mount(
-      <Month day={utils.newDate()} onDayMouseEnter={onDayMouseEnter} />,
+      <Month day={utils.newDate()} onDayPointerEnter={onDayPointerEnter} />,
     );
     const day = month.find(Day).first();
-    day.simulate("mouseenter");
-    expect(utils.isSameDay(day.prop("day"), dayMouseEntered)).toBe(true);
+    day.simulate("pointerenter");
+    expect(utils.isSameDay(day.prop("day"), dayPointerEntered)).toBe(true);
   });
 
   it("should use its month order in handleDayClick", () => {

--- a/test/week_test.test.js
+++ b/test/week_test.test.js
@@ -161,20 +161,20 @@ describe("Week", () => {
     expect(weekNumberElement.prop("weekNumber")).toBe(9);
   });
 
-  it("should call the provided onDayMouseEnter function", () => {
-    let dayMouseEntered = null;
+  it("should call the provided onDayPointerEnter function", () => {
+    let dayPointerEntered = null;
 
-    function onDayMouseEnter(day) {
-      dayMouseEntered = day;
+    function onDayPointerEnter(day) {
+      dayPointerEntered = day;
     }
 
     const weekStart = utils.newDate();
     const week = shallow(
-      <Week day={weekStart} onDayMouseEnter={onDayMouseEnter} />,
+      <Week day={weekStart} onDayPointerEnter={onDayPointerEnter} />,
     );
     const day = week.find(Day).first();
-    day.simulate("mouseenter");
-    expect(day.prop("day")).toEqual(dayMouseEntered);
+    day.simulate("pointerenter");
+    expect(day.prop("day")).toEqual(dayPointerEntered);
   });
 
   describe("handleWeekClick", () => {


### PR DESCRIPTION
Thank you for allowing us to use your wonderful library.

I found a bug when using the `selectsRange` props.
When I select startDate and then select a date before that date, I get the `react-datepicker__day--in-selecting-range` style for a moment.
This occurs on touch devices and on the desktop Chrome touch device simulation.
It also seems to occur more noticeably when using `monthsShown` props and many calendars in a row.

[code sandbox](https://codesandbox.io/p/sandbox/react-datepicker-df2zky)

I think that onPointerXXX events should be used rather than onMouseXXX events to more accurately capture events on touch devices.
(By using `onPointerXXX events`, the earlier decrease no longer occurs.)

- [mdn](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events)
- [camiuse](https://caniuse.com/pointer)