### PR TITLE
Fix #4518: 🔨 Add accessibility props like role and aria-modal to the Calendar popup

### DIFF
--- a/src/calendar_container.jsx
+++ b/src/calendar_container.jsx
@@ -2,7 +2,11 @@ import PropTypes from "prop-types";
 import React from "react";
 
 export default function CalendarContainer({ className, children }) {
-  return <div className={className}>{children}</div>;
+  return (
+    <div className={className} role="dialog" aria-modal="true">
+      {children}
+    </div>
+  );
 }
 
 CalendarContainer.propTypes = {

--- a/test/calendar_test.test.js
+++ b/test/calendar_test.test.js
@@ -8,6 +8,7 @@ import Month from "../src/month";
 import Day from "../src/day";
 import ReactDOM from "react-dom";
 import TestUtils from "react-dom/test-utils";
+import { render } from "@testing-library/react";
 import YearDropdown from "../src/year_dropdown";
 import MonthDropdown from "../src/month_dropdown";
 import MonthYearDropdown from "../src/month_year_dropdown";
@@ -1797,6 +1798,17 @@ describe("Calendar", () => {
           datePicker.props.locale,
         )} ${utils.getYear(calendar.state.date)}`,
       );
+    });
+  });
+
+  describe("calendar container", () => {
+    it("should work", () => {
+      const { container } = render(<Calendar dateFormat={dateFormat} />);
+
+      const dialog = container.querySelector(".react-datepicker");
+      expect(dialog).not.toBeNull();
+      expect(dialog.getAttribute("role")).toBe("dialog");
+      expect(dialog.getAttribute("aria-modal")).toBe("true");
     });
   });
 });


### PR DESCRIPTION
Closes #4518

## Description
This PR addresses the accessibility-related issues in the calendar component by adding props like role and aria-modal to it.

[Reference Link](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepicker-dialog/#:~:text=Usage-,dialog,Indicates%20the%20dialog%20is%20modal.,-aria%2Dlabel%3D%22string)

## Changes Made
- Updated CalendarContainer component with role="dialog" and aria-modal="true" props.
- Added the corresponding test cases.
