### PR TITLE
fix: enzyme to react testing library (3 test files)

### DIFF
--- a/test/month_dropdown_test.test.js
+++ b/test/month_dropdown_test.test.js
@@ -2,12 +2,12 @@ import React from "react";
 import range from "lodash/range";
 import MonthDropdown from "../src/month_dropdown.jsx";
 import MonthDropdownOptions from "../src/month_dropdown_options.jsx";
-import { mount } from "enzyme";
 import { render, fireEvent } from "@testing-library/react";
 import { getMonthInLocale, registerLocale } from "../src/date_utils";
 import { zhCN } from "date-fns/locale/zh-CN";
 import { el } from "date-fns/locale/el";
 import { ru } from "date-fns/locale/ru";
+import onClickOutside from "react-onclickoutside";
 
 describe("MonthDropdown", () => {
   let monthDropdown;
@@ -108,17 +108,20 @@ describe("MonthDropdown", () => {
 
     it("closes the dropdown if outside is clicked", () => {
       const monthNames = range(0, 12).map((M) => getMonthInLocale(M));
+      
       const onCancelSpy = jest.fn();
-      const monthDropdownOptionsInstance = mount(
-        <MonthDropdownOptions
+      const WrappedMonthDropdownOptions = onClickOutside(MonthDropdownOptions)
+      render(
+        <WrappedMonthDropdownOptions
           onCancel={onCancelSpy}
           onChange={onCancelSpy}
           month={11}
           monthNames={monthNames}
         />,
-      ).instance();
-      monthDropdownOptionsInstance.handleClickOutside();
-      expect(onCancelSpy).toHaveBeenCalledTimes(1);
+      );
+      fireEvent.mouseDown(document.body)
+      fireEvent.touchStart(document.body)
+      expect(onCancelSpy).toHaveBeenCalledTimes(2);
     });
 
     it("does not call the supplied onChange function when the same month is clicked", () => {

--- a/test/month_year_dropdown_test.test.js
+++ b/test/month_year_dropdown_test.test.js
@@ -1,7 +1,6 @@
 import React from "react";
 import MonthYearDropdown from "../src/month_year_dropdown.jsx";
 import MonthYearDropdownOptions from "../src/month_year_dropdown_options.jsx";
-import { mount } from "enzyme";
 import { render, fireEvent } from "@testing-library/react";
 import {
   newDate,
@@ -12,6 +11,7 @@ import {
   registerLocale,
 } from "../src/date_utils.js";
 import { fi } from "date-fns/locale/fi";
+import onClickOutside from "react-onclickoutside";
 
 describe("MonthYearDropdown", () => {
   let monthYearDropdown;
@@ -90,8 +90,9 @@ describe("MonthYearDropdown", () => {
       const dateFormatCalendar = "LLLL yyyy";
 
       const onCancelSpy = jest.fn();
-      const monthYearDropdownOptionsInstance = mount(
-        <MonthYearDropdownOptions
+      const WrappedMonthYearDropdownOptions = onClickOutside(MonthYearDropdownOptions)
+      render(
+        <WrappedMonthYearDropdownOptions
           onCancel={onCancelSpy}
           onChange={jest.fn()}
           dateFormat={dateFormatCalendar}
@@ -99,9 +100,10 @@ describe("MonthYearDropdown", () => {
           minDate={subMonths(date, 6)}
           maxDate={addMonths(date, 6)}
         />,
-      ).instance();
-      monthYearDropdownOptionsInstance.handleClickOutside();
-      expect(onCancelSpy).toHaveBeenCalledTimes(1);
+      );
+      fireEvent.mouseDown(document.body)
+      fireEvent.touchStart(document.body)
+      expect(onCancelSpy).toHaveBeenCalledTimes(2);
     });
 
     it("does not call the supplied onChange function when the same month year is clicked", () => {

--- a/test/year_dropdown_options_test.test.js
+++ b/test/year_dropdown_options_test.test.js
@@ -3,6 +3,7 @@ import YearDropdownOptions from "../src/year_dropdown_options.jsx";
 import { mount } from "enzyme";
 import { render, fireEvent } from "@testing-library/react";
 import * as utils from "../src/date_utils.js";
+import onClickOutside from "react-onclickoutside";
 
 describe("YearDropdownOptions", () => {
   let yearDropdown, handleChangeResult;
@@ -125,15 +126,17 @@ describe("YearDropdownOptions", () => {
   });
 
   it("calls the supplied onCancel function on handleClickOutside", () => {
-    const instance = mount(
-      <YearDropdownOptions
+    const WrappedYearDropdownOptions = onClickOutside(YearDropdownOptions)
+    render(
+      <WrappedYearDropdownOptions
         year={2015}
         onChange={mockHandleChange}
         onCancel={onCancelSpy}
-      />,
-    ).instance();
-    instance.handleClickOutside();
-    expect(onCancelSpy).toHaveBeenCalled();
+      />
+    );
+    fireEvent.mouseDown(document.body)
+    fireEvent.touchStart(document.body)
+    expect(onCancelSpy).toHaveBeenCalledTimes(2);
   });
 
   describe("selected", () => {


### PR DESCRIPTION
Some of the tests have been modified to migrate from enzime to the react testing library.

Details:.
Fixed tests to use rtl's render instead of enzime's mount where handleClickOutside is used.

Sorry if a similar modified PR has already been created.