### PR TITLE
feat: run prettier check in ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Install dependencies
         run: yarn install
 
+      - name: Check Code Formatter
+        run: yarn prettier:check
+
       - name: Lint
         run: yarn lint
 

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "sass-lint": "stylelint 'src/stylesheets/*.scss'",
     "lint": "yarn run eslint && yarn run sass-lint",
     "prettier": "prettier --write '**/*.{js,jsx}'",
+    "prettier:check": "prettier --check '**/*.{js,jsx}'",
     "start": "yarn --cwd docs-site install && yarn --cwd docs-site start",
     "test": "NODE_ENV=test jest",
     "test:ci": "NODE_ENV=test jest --ci --coverage",


### PR DESCRIPTION
Since the prettier execution affects the Codecov Report, we thought it should be enforced by CI.

-- Background --
I did not run prettier on #4553.
When I ran prettier on another PR, a line break occurred and Codecov Report's CI was NG, so I needed to add a test.
https://github.com/Hacker0x01/react-datepicker/pull/4574/commits/dec832a628176f5f513113f8fb6082ed10f650de

This case was not a problem because it was code I created myself, but I don't think well if it was code created by someone else.