### PR TITLE
fix: #4581 and #4560 selected and preSelection  with showWeekPicker

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -573,13 +573,6 @@ export default class DatePicker extends React.Component {
       });
     }
     if (date || !event.target.value) {
-      if (this.props.showWeekPicker) {
-        date = getStartOfWeek(
-          date,
-          this.props.locale,
-          this.props.calendarStartDay,
-        );
-      }
       this.setSelected(date, event, true);
     }
   };
@@ -592,13 +585,6 @@ export default class DatePicker extends React.Component {
     }
     if (this.props.onChangeRaw) {
       this.props.onChangeRaw(event);
-    }
-    if (this.props.showWeekPicker) {
-      date = getStartOfWeek(
-        date,
-        this.props.locale,
-        this.props.calendarStartDay,
-      );
     }
     this.setSelected(date, event, false, monthSelectedIn);
     if (this.props.showDateSelect) {
@@ -743,13 +729,6 @@ export default class DatePicker extends React.Component {
     const hasMaxDate = typeof this.props.maxDate !== "undefined";
     let isValidDateSelection = true;
     if (date) {
-      if (this.props.showWeekPicker) {
-        date = getStartOfWeek(
-          date,
-          this.props.locale,
-          this.props.calendarStartDay,
-        );
-      }
       const dateStartOfDay = startOfDay(date);
       if (hasMinDate && hasMaxDate) {
         // isDayInRange uses startOfDay internally, so not necessary to manipulate times here

--- a/src/month.jsx
+++ b/src/month.jsx
@@ -310,6 +310,22 @@ export default class Month extends React.Component {
       this.props.calendarStartDay,
     );
 
+    const selected = this.props.showWeekPicker
+      ? utils.getStartOfWeek(
+          this.props.selected,
+          this.props.locale,
+          this.props.calendarStartDay,
+        )
+      : this.props.selected;
+
+    const preSelection = this.props.showWeekPicker
+      ? utils.getStartOfWeek(
+          this.props.preSelection,
+          this.props.locale,
+          this.props.calendarStartDay,
+        )
+      : this.props.preSelection;
+
     while (true) {
       weeks.push(
         <Week
@@ -337,8 +353,8 @@ export default class Month extends React.Component {
           holidays={this.props.holidays}
           selectingDate={this.props.selectingDate}
           filterDate={this.props.filterDate}
-          preSelection={this.props.preSelection}
-          selected={this.props.selected}
+          preSelection={preSelection}
+          selected={selected}
           selectsStart={this.props.selectsStart}
           selectsEnd={this.props.selectsEnd}
           selectsRange={this.props.selectsRange}

--- a/src/week.jsx
+++ b/src/week.jsx
@@ -97,12 +97,7 @@ export default class Week extends React.Component {
       this.props.onWeekSelect(day, weekNumber, event);
     }
     if (this.props.showWeekPicker) {
-      const startOfWeek = getStartOfWeek(
-        day,
-        this.props.locale,
-        this.props.calendarStartDay,
-      );
-      this.handleDayClick(startOfWeek, event);
+      this.handleDayClick(day, event);
     }
     if (this.props.shouldCloseOnSelect) {
       this.props.setOpen(false);
@@ -117,11 +112,7 @@ export default class Week extends React.Component {
   };
 
   renderDays = () => {
-    const startOfWeek = getStartOfWeek(
-      this.props.day,
-      this.props.locale,
-      this.props.calendarStartDay,
-    );
+    const startOfWeek = this.startOfWeek();
     const days = [];
     const weekNumber = this.formatWeekNumber(startOfWeek);
     if (this.props.showWeekNumber) {

--- a/test/week_test.test.js
+++ b/test/week_test.test.js
@@ -256,8 +256,7 @@ describe("Week", () => {
       );
       const handleDayClick = jest.spyOn(instance, "handleDayClick");
       instance.handleWeekClick(day, weekNumber, event);
-      const startOfWeek = utils.getStartOfWeek(day);
-      expect(handleDayClick).toHaveBeenCalledWith(startOfWeek, event);
+      expect(handleDayClick).toHaveBeenCalledWith(day, event);
     });
 
     it("should call setOpen prop with false if shouldCloseOnSelect prop is true", () => {


### PR DESCRIPTION
## Description
**Linked issue**:  close #4581,#4560
**Problem**
See issue #4581 and #4560

**Changes**
As per comment #4581, I have made the following changes to the showWeekPicker case.
- Remove processing to correct date and preSelection to the first day of the week.
- Changed the passing of date and preSelection from Month component to Week component so that they are corrected to the first day of the week before passing them to the Month component.

For #4560, a null selected was being passed to getStartOfWeek. This time, the processing timing of getStartOfWeek has been moved to Month, so that null is no longer included.

## Screenshots
<!-- If applicable, add screenshots to help explain your improvements -->

## To reviewers
<!-- Additional comments for reviewers -->

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
