### PR TITLE
fix: #4594 fix setSelected

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -697,7 +697,9 @@ export default class DatePicker extends React.Component {
         if (noRanges) {
           onChange([changedDate, null], event);
         } else if (hasStartRange) {
-          if (isDateBefore(changedDate, startDate)) {
+          if (changedDate === null) {
+            onChange([null, null], event);
+          } else if (isDateBefore(changedDate, startDate)) {
             onChange([changedDate, null], event);
           } else {
             onChange([startDate, changedDate], event);

--- a/test/datepicker_test.test.js
+++ b/test/datepicker_test.test.js
@@ -1444,6 +1444,30 @@ describe("DatePicker", () => {
     });
     expect(cleared).toBe(true);
   });
+  it("should correctly clear date with empty input string (selectsRange)", () => {
+    let instance;
+    const onChangeSpy = jest.fn();
+
+    render(
+      <DatePicker
+        ref={(node) => {
+          instance = node;
+        }}
+        selectsRange
+        startDate={utils.newDate("2016-11-22")}
+        endDate={null}
+        onChange={onChangeSpy}
+        isClearable
+      />,
+    );
+    fireEvent.change(instance.input, {
+      target: {
+        value: "",
+      },
+    });
+
+    expect(onChangeSpy.mock.calls.at(-1)[0]).toStrictEqual([null, null]);
+  });
   it("should correctly update the input when the value prop changes", () => {
     let instance;
     const { rerender } = render(


### PR DESCRIPTION

## Description
**Linked issue**: close #4594

**Problem**
See issue #4594

**Changes**
Added null check because passing null as the first argument of isBefore causes an error.

## Screenshots
<!-- If applicable, add screenshots to help explain your improvements -->

## To reviewers
<!-- Additional comments for reviewers -->

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
