### PR TITLE
fix: #4561 remove triangle-arrow-up/down mixin

### DIFF
--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -39,15 +39,21 @@
   // Eliminating extra space at the bottom of the container
   line-height: 0;
 
+  .react-datepicker__triangle {
+    stroke: $datepicker__border-color;
+  }
+
   &[data-placement^="bottom"] {
     .react-datepicker__triangle {
-      @extend %triangle-arrow-up;
+      fill: $datepicker__background-color;
+      color: $datepicker__background-color;
     }
   }
 
   &[data-placement^="top"] {
     .react-datepicker__triangle {
-      @extend %triangle-arrow-down;
+      fill: #fff;
+      color: #fff;
     }
   }
 }

--- a/src/stylesheets/mixins.scss
+++ b/src/stylesheets/mixins.scss
@@ -15,15 +15,3 @@
     cursor: default;
   }
 }
-
-%triangle-arrow-up {
-  fill: $datepicker__background-color;
-  color: $datepicker__background-color;
-  stroke: $datepicker__border-color;
-}
-
-%triangle-arrow-down {
-  fill: #fff;
-  color: #fff;
-  stroke: $datepicker__border-color;
-}

--- a/src/stylesheets/variables.scss
+++ b/src/stylesheets/variables.scss
@@ -17,4 +17,3 @@ $datepicker__font-family: "Helvetica Neue", helvetica, arial, sans-serif !defaul
 $datepicker__item-size: 1.7rem !default;
 $datepicker__margin: 0.4rem !default;
 $datepicker__navigation-button-size: 32px !default;
-$datepicker__triangle-size: 8px !default;


### PR DESCRIPTION
## Description
**Linked issue**: #4561

**Problem**
See issue #4561

**Changes**
Removed triangle-arrow mixin and moved style.
The fill and color were left as they are now, as it is correct that the fill and color are different for up and down.
(The colors of the contact datepicker body location are not aligned with the up and down locations.)

The inline color code issue is not addressed in this PR.

## Screenshots
<!-- If applicable, add screenshots to help explain your improvements -->

## To reviewers
<!-- Additional comments for reviewers -->

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
