### PR TITLE
fix: #4360 Cancel Event when clicked/MouseEnter on disabled months/quarters

### DIFF
--- a/src/month.jsx
+++ b/src/month.jsx
@@ -404,16 +404,23 @@ export default class Month extends React.Component {
   };
 
   onMonthClick = (e, m) => {
-    this.handleDayClick(
-      utils.getStartOfMonth(utils.setMonth(this.props.day, m)),
-      e,
-    );
+    const labelDate = utils.setMonth(this.props.day, m);
+
+    if (utils.isMonthDisabled(labelDate, this.props)) {
+      return;
+    }
+
+    this.handleDayClick(utils.getStartOfMonth(labelDate), e);
   };
 
   onMonthMouseEnter = (m) => {
-    this.handleDayMouseEnter(
-      utils.getStartOfMonth(utils.setMonth(this.props.day, m)),
-    );
+    const labelDate = utils.setMonth(this.props.day, m);
+
+    if (utils.isMonthDisabled(labelDate, this.props)) {
+      return;
+    }
+
+    this.handleDayMouseEnter(utils.getStartOfMonth(labelDate));
   };
 
   handleMonthNavigation = (newMonth, newDate) => {
@@ -488,16 +495,23 @@ export default class Month extends React.Component {
   };
 
   onQuarterClick = (e, q) => {
-    this.handleDayClick(
-      utils.getStartOfQuarter(utils.setQuarter(this.props.day, q)),
-      e,
-    );
+    const labelDate = utils.setQuarter(this.props.day, q);
+
+    if (utils.isQuarterDisabled(labelDate, this.props)) {
+      return;
+    }
+
+    this.handleDayClick(utils.getStartOfQuarter(labelDate), e);
   };
 
   onQuarterMouseEnter = (q) => {
-    this.handleDayMouseEnter(
-      utils.getStartOfQuarter(utils.setQuarter(this.props.day, q)),
-    );
+    const labelDate = utils.setQuarter(this.props.day, q);
+
+    if (utils.isQuarterDisabled(labelDate, this.props)) {
+      return;
+    }
+
+    this.handleDayMouseEnter(utils.getStartOfQuarter(labelDate));
   };
 
   handleQuarterNavigation = (newQuarter, newDate) => {

--- a/test/month_test.test.js
+++ b/test/month_test.test.js
@@ -400,12 +400,16 @@ describe("Month", () => {
   });
 
   it("should return disabled class if current date is out of bound of minDate and maxDate", () => {
+    const onDayClickSpy = jest.fn();
+    const onDayMouseEnterSpy = jest.fn();
     const { container } = render(
       <Month
         day={utils.newDate("2015-12-01")}
         minDate={utils.newDate("2016-02-01")}
         maxDate={utils.newDate()}
         showMonthYearPicker
+        onDayClick={onDayClickSpy}
+        onDayMouseEnter={onDayMouseEnterSpy}
       />,
     );
     const month = container.querySelectorAll(
@@ -414,14 +418,22 @@ describe("Month", () => {
     expect(
       month.classList.contains("react-datepicker__month-text--disabled"),
     ).toBe(true);
+    fireEvent.click(month);
+    expect(onDayClickSpy).not.toHaveBeenCalled();
+    fireEvent.mouseEnter(month);
+    expect(onDayMouseEnterSpy).not.toHaveBeenCalled();
   });
 
   it("should not return disabled class if current date is before minDate but same month", () => {
+    const onDayClickSpy = jest.fn();
+    const onDayMouseEnterSpy = jest.fn();
     const { container } = render(
       <Month
         day={utils.newDate("2015-01-01")}
         minDate={utils.newDate("2015-01-10")}
         showMonthYearPicker
+        onDayClick={onDayClickSpy}
+        onDayMouseEnter={onDayMouseEnterSpy}
       />,
     );
     const month = container.querySelectorAll(
@@ -430,14 +442,22 @@ describe("Month", () => {
     expect(
       month.classList.contains("react-datepicker__month-text--disabled"),
     ).not.toBe(true);
+    fireEvent.click(month);
+    expect(onDayClickSpy).toHaveBeenCalled();
+    fireEvent.mouseEnter(month);
+    expect(onDayMouseEnterSpy).toHaveBeenCalled();
   });
 
   it("should not return disabled class if current date is after maxDate but same month", () => {
+    const onDayClickSpy = jest.fn();
+    const onDayMouseEnterSpy = jest.fn();
     const { container } = render(
       <Month
         day={utils.newDate("2015-01-10")}
         maxDate={utils.newDate("2015-01-01")}
         showMonthYearPicker
+        onDayClick={onDayClickSpy}
+        onDayMouseEnter={onDayMouseEnterSpy}
       />,
     );
     const month = container.querySelectorAll(
@@ -446,9 +466,15 @@ describe("Month", () => {
     expect(
       month.classList.contains("react-datepicker__month-text--disabled"),
     ).not.toBe(true);
+    fireEvent.click(month);
+    expect(onDayClickSpy).toHaveBeenCalled();
+    fireEvent.mouseEnter(month);
+    expect(onDayMouseEnterSpy).toHaveBeenCalled();
   });
 
   it("should return disabled class if specified excludeDate", () => {
+    const onDayClickSpy = jest.fn();
+    const onDayMouseEnterSpy = jest.fn();
     const { container } = render(
       <Month
         day={utils.newDate("2015-01-01")}
@@ -459,6 +485,8 @@ describe("Month", () => {
           utils.newDate("2015-10-04"),
         ]}
         showMonthYearPicker
+        onDayClick={onDayClickSpy}
+        onDayMouseEnter={onDayMouseEnterSpy}
       />,
     );
     // exclude month index
@@ -471,6 +499,10 @@ describe("Month", () => {
       expect(
         month.classList.contains("react-datepicker__month-text--disabled"),
       ).toBe(true);
+      fireEvent.click(month);
+      expect(onDayClickSpy).not.toHaveBeenCalled();
+      fireEvent.mouseEnter(month);
+      expect(onDayMouseEnterSpy).not.toHaveBeenCalled();
     });
   });
 
@@ -937,12 +969,16 @@ describe("Month", () => {
   });
 
   it("should return disabled class if current date is out of bound of minDate and maxDate", () => {
+    const onDayClickSpy = jest.fn();
+    const onDayMouseEnterSpy = jest.fn();
     const { container } = render(
       <Month
         day={utils.newDate("2015-12-01")}
         minDate={utils.newDate("2016-02-01")}
         maxDate={utils.newDate()}
         showQuarterYearPicker
+        onDayClick={onDayClickSpy}
+        onDayMouseEnter={onDayMouseEnterSpy}
       />,
     );
     const quarter = container.querySelectorAll(
@@ -951,6 +987,10 @@ describe("Month", () => {
     expect(
       quarter.classList.contains("react-datepicker__quarter-text--disabled"),
     ).toBe(true);
+    fireEvent.click(quarter);
+    expect(onDayClickSpy).not.toHaveBeenCalled();
+    fireEvent.mouseEnter(quarter);
+    expect(onDayMouseEnterSpy).not.toHaveBeenCalled();
   });
 
   describe("if quarter is selected", () => {


### PR DESCRIPTION
## Description
**Linked issue**: close #4360

**Problem**
See issue #4360

**Changes**
Fix click/mouseEnter Event Handler iin months/quarters to determine if it is disabled or not.

## Screenshots
<!-- If applicable, add screenshots to help explain your improvements -->

## To reviewers
<!-- Additional comments for reviewers -->

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
