### PR TITLE
fix: #4489 Disable weekNumber highlighting when no click handler is assigned.

### DIFF
--- a/src/week_number.jsx
+++ b/src/week_number.jsx
@@ -116,10 +116,8 @@ export default class WeekNumber extends React.Component {
     const weekNumberClasses = {
       "react-datepicker__week-number": true,
       "react-datepicker__week-number--clickable": !!onClick,
-      "react-datepicker__week-number--selected": isSameDay(
-        this.props.date,
-        this.props.selected,
-      ),
+      "react-datepicker__week-number--selected":
+        !!onClick && isSameDay(this.props.date, this.props.selected),
       "react-datepicker__week-number--keyboard-selected":
         this.isKeyboardSelected(),
     };

--- a/test/week_number_test.test.js
+++ b/test/week_number_test.test.js
@@ -248,7 +248,25 @@ describe("WeekNumber", () => {
         ).toBe(true);
       });
 
-      it("should have the class 'react-datepicker__week-number--selected' if selected is current week and preselected is also current week", () => {
+      it("should have the class 'react-datepicker__week-number--selected' if selected is current week and preselected is also current week and has the onClick Props", () => {
+        const currentWeekNumber = utils.newDate("2023-10-22T13:09:53+02:00");
+        const { container } = render(
+          <WeekNumber
+            weekNumber={1}
+            date={currentWeekNumber}
+            selected={currentWeekNumber}
+            preSelection={currentWeekNumber}
+            onClick={() => {}}
+          />,
+        );
+        expect(
+          container
+            .querySelector(".react-datepicker__week-number")
+            .classList.contains("react-datepicker__week-number--selected"),
+        ).toBe(true);
+      });
+
+      it("should not have the class 'react-datepicker__week-number--selected' if selected is current week and preselected is also current week and doesn't have the onClick Props", () => {
         const currentWeekNumber = utils.newDate("2023-10-22T13:09:53+02:00");
         const { container } = render(
           <WeekNumber
@@ -262,10 +280,29 @@ describe("WeekNumber", () => {
           container
             .querySelector(".react-datepicker__week-number")
             .classList.contains("react-datepicker__week-number--selected"),
+        ).toBe(false);
+      });
+
+      it("should have the class 'react-datepicker__week-number--selected' if selected is current week and preselected is not current week and has the onClick Props", () => {
+        const currentWeekNumber = utils.newDate("2023-10-22T13:09:53+02:00");
+        const preSelection = utils.addWeeks(currentWeekNumber, 1);
+        const { container } = render(
+          <WeekNumber
+            weekNumber={1}
+            date={currentWeekNumber}
+            selected={currentWeekNumber}
+            preSelection={preSelection}
+            onClick={() => {}}
+          />,
+        );
+        expect(
+          container
+            .querySelector(".react-datepicker__week-number")
+            .classList.contains("react-datepicker__week-number--selected"),
         ).toBe(true);
       });
 
-      it("should have the class 'react-datepicker__week-number--selected' if selected is current week and preselected is not current week", () => {
+      it("should not have the class 'react-datepicker__week-number--selected' if selected is current week and preselected is not current week and doesn't have onClick Props", () => {
         const currentWeekNumber = utils.newDate("2023-10-22T13:09:53+02:00");
         const preSelection = utils.addWeeks(currentWeekNumber, 1);
         const { container } = render(
@@ -280,7 +317,7 @@ describe("WeekNumber", () => {
           container
             .querySelector(".react-datepicker__week-number")
             .classList.contains("react-datepicker__week-number--selected"),
-        ).toBe(true);
+        ).toBe(false);
       });
 
       it("should have the class 'react-datepicker__week-number--selected' if selected is not current week and preselected is current week", () => {


### PR DESCRIPTION
## Description
**Linked issue**: close #4489

**Problem**
See issue #4489

**Changes**
Disable weekNumber highlighting when no click handler is assigned.

## Screenshots
<!-- If applicable, add screenshots to help explain your improvements -->

## To reviewers
<!-- Additional comments for reviewers -->

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
