### PR TITLE
fix: #4588 Allow time to be set via typing when minTime is set

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -657,7 +657,10 @@ export default class DatePicker extends React.Component {
         }
 
         // If minTime is present then set the time to minTime
-        if (this.props.showTimeSelect || this.props.showTimeSelectOnly) {
+        if (
+          !keepInput &&
+          (this.props.showTimeSelect || this.props.showTimeSelectOnly)
+        ) {
           if (minTime) {
             changedDate = setTime(changedDate, {
               hour: minTime.getHours(),

--- a/test/min_time_test.test.js
+++ b/test/min_time_test.test.js
@@ -12,6 +12,7 @@ const DatePickerWithState = (props) => {
         setSelected(date);
       }}
       showTimeSelect
+      dateFormat="MM/dd/yyyy HH:mm"
       {...props}
     />
   );
@@ -45,5 +46,19 @@ describe("Datepicker minTime", () => {
     const selectedTime = getByText("1:00 PM");
 
     expect(selectedTime.getAttribute("aria-selected")).toBe("true");
+  });
+
+  it("should select time from input instead of minimum allowable time when time is typed in", () => {
+    const minTime = new Date("2023-03-10 13:00");
+    const maxTime = new Date("2023-03-10 18:00");
+
+    const { container } = render(
+      <DatePickerWithState minTime={minTime} maxTime={maxTime} />,
+    );
+    const input = container.querySelector("input");
+    fireEvent.change(input, { target: { value: "2023-03-10 16:00" } });
+    fireEvent.focusOut(input);
+
+    expect(input.value).toEqual("03/10/2023 16:00");
   });
 });


### PR DESCRIPTION
## Description
**Linked issue**: close #4588 

**Problem**
See issue #4588 

**Changes**
Set the selected time to `minTime` only if no input to be kept is present.

## Screenshots
<!-- If applicable, add screenshots to help explain your improvements -->

## To reviewers
<!-- Additional comments for reviewers -->

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
