### PR TITLE
add JSDoc (same files)

### DIFF
--- a/src/month_dropdown_options.jsx
+++ b/src/month_dropdown_options.jsx
@@ -1,6 +1,19 @@
+//@ts-check
 import React from "react";
 import PropTypes from "prop-types";
 
+/**
+ * @typedef {Object} Props
+ * @property {number} month
+ * @property {VoidFunction} onCancel
+ * @property {(month:number) => void} onChange
+ * @property {string[]} monthNames
+ */
+
+/**
+ * @class
+ * @extends {React.Component<Props, {}>}
+ */
 export default class MonthDropdownOptions extends React.Component {
   static propTypes = {
     onCancel: PropTypes.func.isRequired,
@@ -9,8 +22,15 @@ export default class MonthDropdownOptions extends React.Component {
     monthNames: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
   };
 
+  /**
+   * @param {number} i
+   * @returns {boolean}
+   */
   isSelectedMonth = (i) => this.props.month === i;
 
+  /**
+   * @returns {React.ReactNode[]}
+   */
   renderOptions = () => {
     return this.props.monthNames.map((month, i) => (
       <div
@@ -33,10 +53,21 @@ export default class MonthDropdownOptions extends React.Component {
     ));
   };
 
+  /**
+   *
+   * @param {number} month
+   * @returns {void}
+   */
   onChange = (month) => this.props.onChange(month);
 
+  /**
+   * @returns {void}
+   */
   handleClickOutside = () => this.props.onCancel();
 
+  /**
+   * @returns {React.ReactElement}
+   */
   render() {
     return (
       <div className="react-datepicker__month-dropdown">

--- a/src/year_dropdown_options.jsx
+++ b/src/year_dropdown_options.jsx
@@ -1,8 +1,16 @@
+//@ts-check
 import React, { createRef } from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
 import { getYear } from "./date_utils";
 
+/**
+ * @param {number} year
+ * @param {number} noOfYear
+ * @param {Date|undefined} minDate
+ * @param {Date|undefined} maxDate
+ * @returns {number[]}
+ */
 function generateYears(year, noOfYear, minDate, maxDate) {
   const list = [];
   for (let i = 0; i < 2 * noOfYear + 1; i++) {
@@ -25,6 +33,26 @@ function generateYears(year, noOfYear, minDate, maxDate) {
   return list;
 }
 
+/**
+ * @typedef {Object} Props
+ * @property {Date|undefined} minDate
+ * @property {Date|undefined} maxDate
+ * @property {VoidFunction} onCancel
+ * @property {(year:number) => void} onChange
+ * @property {boolean|undefined} scrollableYearDropdown
+ * @property {number} year
+ * @property {number|undefined} yearDropdownItemNumber
+ */
+
+/**
+ * @typedef {Object} State
+ * @property {number[]} yearsList
+ */
+
+/**
+ * @class
+ * @extends {React.Component<Props, State>}
+ */
 export default class YearDropdownOptions extends React.Component {
   static propTypes = {
     minDate: PropTypes.instanceOf(Date),
@@ -36,6 +64,10 @@ export default class YearDropdownOptions extends React.Component {
     yearDropdownItemNumber: PropTypes.number,
   };
 
+  /**
+   * @constructor
+   * @param {Props}  props
+   */
   constructor(props) {
     super(props);
     const { yearDropdownItemNumber, scrollableYearDropdown } = props;
@@ -50,9 +82,13 @@ export default class YearDropdownOptions extends React.Component {
         this.props.maxDate,
       ),
     };
+    /** @type {React.RefObject<HTMLDivElement>} */
     this.dropdownRef = createRef();
   }
 
+  /**
+   * @returns {void}
+   */
   componentDidMount() {
     const dropdownCurrent = this.dropdownRef.current;
 
@@ -72,6 +108,9 @@ export default class YearDropdownOptions extends React.Component {
     }
   }
 
+  /**
+   * @returns {React.ReactNode[]}
+   */
   renderOptions = () => {
     const selectedYear = this.props.year;
     const options = this.state.yearsList.map((year) => (
@@ -124,14 +163,25 @@ export default class YearDropdownOptions extends React.Component {
     return options;
   };
 
+  /**
+   * @param {number} year
+   * @returns {void}
+   */
   onChange = (year) => {
     this.props.onChange(year);
   };
 
+  /**
+   * @returns {void}
+   */
   handleClickOutside = () => {
     this.props.onCancel();
   };
 
+  /**
+   * @param {number} amount
+   * @returns {void}
+   */
   shiftYears = (amount) => {
     const years = this.state.yearsList.map(function (year) {
       return year + amount;
@@ -142,14 +192,23 @@ export default class YearDropdownOptions extends React.Component {
     });
   };
 
+  /**
+   * @returns {void}
+   */
   incrementYears = () => {
     return this.shiftYears(1);
   };
 
+  /**
+   * @returns {void}
+   */
   decrementYears = () => {
     return this.shiftYears(-1);
   };
 
+  /**
+   * @returns {React.ReactElement}
+   */
   render() {
     let dropdownClass = classNames({
       "react-datepicker__year-dropdown": true,


### PR DESCRIPTION
## Description
**Linked issue**: #(issue number) 

**Problem**
Type completion does not work with jsx, and with huge Component, the type of Porps and State (null or undefined) cannot be guessed, which is not a good prospect.
By adding JSDoc correctly, type completion will work at least on VSCode, which we believe will improve development efficiency and reduce the incidence of defects due to omissions of empty checks.

**Changes**
We have included JSDoc in two files as a sample.
I would like to hear your opinion on whether it is worth expanding to other files.

If all files are to be replaced with ts/tsx, it is better to start with JSDoc, which is easier to install, because of the large impact of rollup setting changes, etc.

## Screenshots
<!-- If applicable, add screenshots to help explain your improvements -->

## To reviewers
<!-- Additional comments for reviewers -->

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
