### PR TITLE
fix: #3840 Rollup config

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -17,6 +17,12 @@ const pkg = JSON.parse(
     .toString()
 );
 
+const banner = `/*!
+  ${pkg.name} v${pkg.version}
+  ${pkg.homepage}
+  Released under the ${pkg.license} License.
+*/`;
+
 // it's important to mark all subpackages of data-fns as externals
 // see https://github.com/Hacker0x01/react-datepicker/issues/1606
 // We're relying on date-fn's package.json `exports` field to
@@ -44,10 +50,12 @@ const globals = {
 };
 
 // NOTE:https://rollupjs.org/migration/#changed-defaults
+/** @type {import('rollup').OutputOptions} */
 const migrateRollup2to3OutputOptions = {
   interop: "compat",
 };
 
+/** @type {import('rollup').RollupOptions} */
 const config = {
   input: "src/index.jsx",
   output: [
@@ -56,24 +64,32 @@ const config = {
       format: "umd",
       name: "DatePicker",
       globals,
+      banner,
       ...migrateRollup2to3OutputOptions,
+      plugins: [terser()],
     },
     {
-      file: "dist/react-datepicker.js",
+      file: pkg.browser.replace(".min.js", ".js"),
       format: "umd",
+      sourcemap: "inline",
       name: "DatePicker",
       globals,
+      banner,
       ...migrateRollup2to3OutputOptions,
     },
     {
       file: pkg.main,
       format: "cjs",
+      sourcemap: "inline",
       name: "DatePicker",
+      banner,
       ...migrateRollup2to3OutputOptions,
     },
     {
       file: pkg.module,
       format: "es",
+      sourcemap: "inline",
+      banner,
       ...migrateRollup2to3OutputOptions,
     },
   ],
@@ -85,7 +101,6 @@ const config = {
     babel(),
     commonjs(),
     filesize(),
-    terser(),
   ],
   external: [
     ...Object.keys(pkg.dependencies || {}),


### PR DESCRIPTION
## Description
**Linked issue**:  close #3840

**Problem**
See issue #3840

**Changes**
- Add banner as copyright to build results
- Add inline sourcemap to output files other than .min.js
- Change compression target to min.js only

## Screenshots
<!-- If applicable, add screenshots to help explain your improvements -->

## To reviewers
In the issue, it was mentioned that it would be useful to have uncompressed code, but for debug purposes, we thought it would be better to add a source map as well, so we set it up.

In the case of cjs,ems, basically, compression is done in the production build of the module bundler on the user's side, so we do not think that compression on the library side is mandatory. (I assume the source map will also be removed at this time.)
（I am a little confused as to whether to compress just min.js or everything.）

I would be glad to hear your comments on the above two points.

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
