### PR TITLE
Fix #4644: Handle the visibility of the previous and the next year navigation when showQuarterYearPicker is enabled 

### DIFF
--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -36,6 +36,8 @@ import {
   yearDisabledAfter,
   yearsDisabledAfter,
   yearsDisabledBefore,
+  quarterDisabledBefore,
+  quarterDisabledAfter,
   getEffectiveMinDate,
   getEffectiveMaxDate,
   addZero,
@@ -489,6 +491,12 @@ export default class Calendar extends React.Component {
       case this.props.showYearPicker:
         allPrevDaysDisabled = yearsDisabledBefore(this.state.date, this.props);
         break;
+      case this.props.showQuarterYearPicker:
+        allPrevDaysDisabled = quarterDisabledBefore(
+          this.state.date,
+          this.props,
+        );
+        break;
       default:
         allPrevDaysDisabled = monthDisabledBefore(this.state.date, this.props);
         break;
@@ -585,6 +593,9 @@ export default class Calendar extends React.Component {
         break;
       case this.props.showYearPicker:
         allNextDaysDisabled = yearsDisabledAfter(this.state.date, this.props);
+        break;
+      case this.props.showQuarterYearPicker:
+        allNextDaysDisabled = quarterDisabledAfter(this.state.date, this.props);
         break;
       default:
         allNextDaysDisabled = monthDisabledAfter(this.state.date, this.props);

--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -34,6 +34,7 @@ import { max } from "date-fns/max";
 import { differenceInCalendarDays } from "date-fns/differenceInCalendarDays";
 import { differenceInCalendarMonths } from "date-fns/differenceInCalendarMonths";
 import { differenceInCalendarYears } from "date-fns/differenceInCalendarYears";
+import { differenceInCalendarQuarters } from "date-fns/differenceInCalendarQuarters";
 import { startOfDay } from "date-fns/startOfDay";
 import { startOfWeek } from "date-fns/startOfWeek";
 import { startOfMonth } from "date-fns/startOfMonth";
@@ -649,6 +650,36 @@ export function monthDisabledAfter(day, { maxDate, includeDates } = {}) {
     (includeDates &&
       includeDates.every(
         (includeDate) => differenceInCalendarMonths(nextMonth, includeDate) > 0,
+      )) ||
+    false
+  );
+}
+
+export function quarterDisabledBefore(day, { minDate, includeDates } = {}) {
+  const firstDayOfYear = startOfYear(day);
+  const previousQuarter = subQuarters(firstDayOfYear, 1);
+
+  return (
+    (minDate && differenceInCalendarQuarters(minDate, previousQuarter) > 0) ||
+    (includeDates &&
+      includeDates.every(
+        (includeDate) =>
+          differenceInCalendarQuarters(includeDate, previousQuarter) > 0,
+      )) ||
+    false
+  );
+}
+
+export function quarterDisabledAfter(day, { maxDate, includeDates } = {}) {
+  const lastDayOfYear = endOfYear(day);
+  const nextQuarter = addQuarters(lastDayOfYear, 1);
+
+  return (
+    (maxDate && differenceInCalendarQuarters(nextQuarter, maxDate) > 0) ||
+    (includeDates &&
+      includeDates.every(
+        (includeDate) =>
+          differenceInCalendarQuarters(nextQuarter, includeDate) > 0,
       )) ||
     false
   );

--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -655,9 +655,9 @@ export function monthDisabledAfter(day, { maxDate, includeDates } = {}) {
   );
 }
 
-export function quarterDisabledBefore(day, { minDate, includeDates } = {}) {
-  const firstDayOfYear = startOfYear(day);
-  const previousQuarter = subQuarters(firstDayOfYear, 1);
+export function quarterDisabledBefore(date, { minDate, includeDates } = {}) {
+  const firstDateOfYear = startOfYear(date);
+  const previousQuarter = subQuarters(firstDateOfYear, 1);
 
   return (
     (minDate && differenceInCalendarQuarters(minDate, previousQuarter) > 0) ||
@@ -670,9 +670,9 @@ export function quarterDisabledBefore(day, { minDate, includeDates } = {}) {
   );
 }
 
-export function quarterDisabledAfter(day, { maxDate, includeDates } = {}) {
-  const lastDayOfYear = endOfYear(day);
-  const nextQuarter = addQuarters(lastDayOfYear, 1);
+export function quarterDisabledAfter(date, { maxDate, includeDates } = {}) {
+  const lastDateOfYear = endOfYear(date);
+  const nextQuarter = addQuarters(lastDateOfYear, 1);
 
   return (
     (maxDate && differenceInCalendarQuarters(nextQuarter, maxDate) > 0) ||

--- a/test/calendar_test.test.js
+++ b/test/calendar_test.test.js
@@ -9,7 +9,7 @@ import DatePicker from "../src/index.jsx";
 import * as utils from "../src/date_utils";
 import { eo } from "date-fns/locale/eo";
 import { fi } from "date-fns/locale/fi";
-import { isSunday } from "date-fns";
+import { endOfYear, isSunday, startOfMonth } from "date-fns";
 import { getKey } from "./test_utils";
 
 // TODO Possibly rename
@@ -1821,6 +1821,27 @@ describe("Calendar", () => {
         increaseYear();
       });
       expect(utils.getYear(instance.state.date)).toBe(1994);
+    });
+
+    it("should hide the previous year navigation arrow button when the minDate falls under the currently visible year ", () => {
+      const { container } = render(
+        <Calendar showQuarterYearPicker minDate={startOfMonth(new Date())} />,
+      );
+      const previous = container.querySelector(
+        ".react-datepicker__navigation--previous",
+      );
+      expect(previous).toBeNull();
+    });
+
+    it("should hide the next year navigation arrow button when the maxDate falls under the currently visible year ", () => {
+      const { container } = render(
+        <Calendar showQuarterYearPicker maxDate={endOfYear(new Date())} />,
+      );
+
+      const next = container.querySelector(
+        ".react-datepicker__navigation--next",
+      );
+      expect(next).toBeNull();
     });
   });
 

--- a/test/date_utils_test.test.js
+++ b/test/date_utils_test.test.js
@@ -34,6 +34,8 @@ import {
   setDefaultLocale,
   yearsDisabledAfter,
   yearsDisabledBefore,
+  quarterDisabledBefore,
+  quarterDisabledAfter,
   getWeek,
   safeDateRangeFormat,
   getHolidaysMap,
@@ -662,6 +664,54 @@ describe("date_utils", () => {
       const day = newDate("2016-03-19");
       const includeDates = [newDate("2016-03-01")];
       expect(monthDisabledAfter(day, { includeDates })).toBe(true);
+    });
+  });
+
+  describe("quarterDisabledBefore", () => {
+    it("should return false by default", () => {
+      expect(quarterDisabledBefore(newDate())).toBe(false);
+    });
+
+    it("should return true if min date is in the same year", () => {
+      const day = newDate("2016-02-19");
+      const minDate = newDate("2016-03-01");
+      expect(quarterDisabledBefore(day, { minDate })).toBe(true);
+    });
+
+    it("should return false if min date is in the previous year", () => {
+      const day = newDate("2016-03-19");
+      const minDate = newDate("2015-03-29");
+      expect(quarterDisabledBefore(day, { minDate })).toBe(false);
+    });
+
+    it("should return true if previous year is before include dates", () => {
+      const day = newDate("2016-03-19");
+      const includeDates = [newDate("2016-03-01")];
+      expect(quarterDisabledBefore(day, { includeDates })).toBe(true);
+    });
+  });
+
+  describe("quarterDisabledAfter", () => {
+    it("should return false by default", () => {
+      expect(quarterDisabledAfter(newDate())).toBe(false);
+    });
+
+    it("should return true if max date is in the same year", () => {
+      const day = newDate("2016-03-19");
+      const maxDate = newDate("2016-08-31");
+      expect(quarterDisabledAfter(day, { maxDate })).toBe(true);
+    });
+
+    it("should return false if max date is in the next year", () => {
+      const day = newDate("2016-03-19");
+      const maxDate = newDate("2017-04-01");
+      expect(quarterDisabledAfter(day, { maxDate })).toBe(false);
+    });
+
+    it("should return true if next year is after include dates", () => {
+      const day = newDate("2016-03-19");
+      const includeDates = [newDate("2016-03-01")];
+      expect(quarterDisabledAfter(day, { includeDates })).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Description
**Linked issue**: #4644

**Problem**
As mentioned in the linked issue, the QuarterYearPicker has some issue with the visibility of the next and the previous arrow buttons based on the minDate and the maxDate.  That's because we are not handling the Quarter year picker separately, but handling it with the month picker logic

**Changes**
- Handled the quarter-year picker separately
- Added helpers in the `date_utils.js` to achieve the result
- Verified the change by test coverage

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
