### PR TITLE
fix: popper dosen't close if swapRange prop was passed

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -602,7 +602,11 @@ export default class DatePicker extends React.Component {
 
       const { startDate, endDate } = this.props;
 
-      if (startDate && !endDate && !isDateBefore(date, startDate)) {
+      if (
+        startDate &&
+        !endDate &&
+        (this.props.swapRange || !isDateBefore(date, startDate))
+      ) {
         this.setOpen(false);
       }
     }

--- a/test/datepicker_test.test.js
+++ b/test/datepicker_test.test.js
@@ -2301,6 +2301,25 @@ describe("DatePicker", () => {
       expect(container.querySelector(".react-datepicker")).toBeNull();
     });
 
+    it("should be closed after clicking day when startDate has a value (endDate is being selected) and swapRange prop was passed", () => {
+      const startDate = new Date("2021-01-01 00:00:00");
+      const endDate = null;
+      const { container } = render(
+        <DatePicker
+          swapRange
+          selectsRange
+          startDate={startDate}
+          endDate={endDate}
+        />,
+      );
+      fireEvent.click(container.querySelector("input"));
+
+      const days = container.querySelectorAll(".react-datepicker__day");
+      const day = days[Math.floor(days.length / 2)];
+      fireEvent.click(day);
+      expect(container.querySelector(".react-datepicker")).toBeNull();
+    });
+
     it("has clear button rendered when isClearable is true and startDate has value", () => {
       const startDate = new Date("2021-01-01 00:00:00");
       const endDate = new Date("2021-01-21 00:00:00");


### PR DESCRIPTION
---
name: Fix input behavior
about: input doesn't close popper if swapRange prop passed 
---

**Problem**
After [the 6.7.0 release](https://github.com/Hacker0x01/react-datepicker/releases/tag/v6.7.0), I found that the new `swapRange` feature doesn't allow to close datepicker popper automatically when the range selected in reverse order

**Changes**
Add swapRange into the related check + a new test case

## Screenshots
The first video is before the fix


https://github.com/Hacker0x01/react-datepicker/assets/29524085/49ac07c7-106d-458c-8e79-91e4111f341a



The second one is after the fix


https://github.com/Hacker0x01/react-datepicker/assets/29524085/a0561d94-f654-480e-9c16-862b5e8a96f4



## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
