### PR TITLE
Add support for seconds in date_utils

### DIFF
--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -620,16 +620,20 @@ export function isTimeInDisabledRange(time, { minTime, maxTime }) {
   if (!minTime || !maxTime) {
     throw new Error("Both minTime and maxTime props required");
   }
-  const base = newDate();
-  const baseTime = setHours(setMinutes(base, getMinutes(time)), getHours(time));
-  const min = setHours(
-    setMinutes(base, getMinutes(minTime)),
-    getHours(minTime),
-  );
-  const max = setHours(
-    setMinutes(base, getMinutes(maxTime)),
-    getHours(maxTime),
-  );
+  let baseTime = newDate();
+  baseTime = setHours(baseTime, getHours(time));
+  baseTime = setMinutes(baseTime, getMinutes(time));
+  baseTime = setSeconds(baseTime, getSeconds(time));
+
+  let min = newDate();
+  min = setHours(min, getHours(minTime));
+  min = setMinutes(min, getMinutes(minTime));
+  min = setSeconds(min, getSeconds(minTime));
+
+  let max = newDate();
+  max = setHours(max, getHours(maxTime));
+  max = setMinutes(max, getMinutes(maxTime));
+  max = setSeconds(max, getSeconds(maxTime));
 
   let valid;
   try {

--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -599,7 +599,8 @@ export function isTimeInList(time, times) {
   return times.some(
     (listTime) =>
       getHours(listTime) === getHours(time) &&
-      getMinutes(listTime) === getMinutes(time),
+      getMinutes(listTime) === getMinutes(time) &&
+      getSeconds(listTime) === getSeconds(time),
   );
 }
 

--- a/test/date_utils_test.test.js
+++ b/test/date_utils_test.test.js
@@ -49,7 +49,7 @@ import { setHours } from "date-fns/setHours";
 import { addQuarters } from "date-fns/addQuarters";
 import { ptBR } from "date-fns/locale/pt-BR";
 import { registerLocale } from "../src/date_utils";
-import { addYears } from "date-fns";
+import { addYears, setSeconds } from "date-fns";
 
 registerLocale("pt-BR", ptBR);
 
@@ -888,9 +888,12 @@ describe("date_utils", () => {
   describe("isTimeInDisabledRange", () => {
     it("should tell if time is in disabled range", () => {
       const date = newDate("2016-03-15");
-      const time = setHours(setMinutes(date, 30), 1);
-      const minTime = setHours(setMinutes(date, 30), 0);
-      const maxTime = setHours(setMinutes(date, 30), 5);
+      let time = setHours(date, 1);
+      time = setMinutes(time, 30);
+      time = setSeconds(time, 30); // 2016-03-15 01:30:30
+
+      const minTime = setHours(setMinutes(date, 30), 0); //2016-03-15 00:30:00
+      const maxTime = setHours(setMinutes(setSeconds(date, 35), 30), 1); //2016-03-15 01:30:35
       expect(isTimeInDisabledRange(time, { minTime, maxTime })).toBe(false);
     });
 

--- a/test/include_times_test.test.js
+++ b/test/include_times_test.test.js
@@ -67,23 +67,11 @@ describe("TimeComponent", () => {
       />,
     );
 
-    const allTimeItems = timeComponent.querySelectorAll(
-      ".react-datepicker__time-list-item",
-    );
-
-    // 01:00:30 and 00:00:30 should be correctly visible in the time list
-    expect(Array.from(allTimeItems).map((node) => node.textContent)).toContain(
-      "01:00:30",
-    );
-    expect(Array.from(allTimeItems).map((node) => node.textContent)).toContain(
-      "00:00:30",
-    );
-
     const disabledTimeItems = timeComponent.querySelectorAll(
       ".react-datepicker__time-list-item--disabled",
     );
 
-    // 01:00:00 and 00:00:00 should be correctly disabled
+    // 01:00:00 and 00:00:00 should be correctly disabled because they are not included
     expect(
       Array.from(disabledTimeItems).map((node) => node.textContent),
     ).toContain("01:00:00");

--- a/test/include_times_test.test.js
+++ b/test/include_times_test.test.js
@@ -67,10 +67,23 @@ describe("TimeComponent", () => {
       />,
     );
 
+    const allTimeItems = timeComponent.querySelectorAll(
+      ".react-datepicker__time-list-item",
+    );
+
+    // 01:00:30 and 00:00:30 should be correctly visible in the time list
+    expect(Array.from(allTimeItems).map((node) => node.textContent)).toContain(
+      "01:00:30",
+    );
+    expect(Array.from(allTimeItems).map((node) => node.textContent)).toContain(
+      "00:00:30",
+    );
+
     const disabledTimeItems = timeComponent.querySelectorAll(
       ".react-datepicker__time-list-item--disabled",
     );
 
+    // 01:00:00 and 00:00:00 should be correctly disabled
     expect(
       Array.from(disabledTimeItems).map((node) => node.textContent),
     ).toContain("01:00:00");

--- a/test/include_times_test.test.js
+++ b/test/include_times_test.test.js
@@ -55,7 +55,7 @@ describe("TimeComponent", () => {
     expect(enabledTimeItemsHasNoAriaDisabled).toBe(true);
   });
 
-  it.only("should factor in seconds", () => {
+  it("should factor in seconds", () => {
     const includeHoursMinutesSeconds = [
       utils.addHours(utils.addSeconds(today, 30), 1), //01:00:30
       utils.addSeconds(today, 30), //00:00:30

--- a/test/include_times_test.test.js
+++ b/test/include_times_test.test.js
@@ -54,4 +54,28 @@ describe("TimeComponent", () => {
     });
     expect(enabledTimeItemsHasNoAriaDisabled).toBe(true);
   });
+
+  it.only("should factor in seconds", () => {
+    const includeHoursMinutesSeconds = [
+      utils.addHours(utils.addSeconds(today, 30), 1), //01:00:30
+      utils.addSeconds(today, 30), //00:00:30
+    ];
+    const { container: timeComponent } = render(
+      <TimeComponent
+        format="HH:mm:ss"
+        includeTimes={includeHoursMinutesSeconds}
+      />,
+    );
+
+    const disabledTimeItems = timeComponent.querySelectorAll(
+      ".react-datepicker__time-list-item--disabled",
+    );
+
+    expect(
+      Array.from(disabledTimeItems).map((node) => node.textContent),
+    ).toContain("01:00:00");
+    expect(
+      Array.from(disabledTimeItems).map((node) => node.textContent),
+    ).toContain("00:00:00");
+  });
 });


### PR DESCRIPTION
**Problem**
missed out support for seconds in functions in `date_utils.js`

**Changes**
added second support 

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
