### PR TITLE
fix: #4400 Keyboard accessibility MonthYearPicker

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -838,7 +838,10 @@ export default class DatePicker extends React.Component {
         const selectorString =
           this.props.showWeekPicker && this.props.showWeekNumbers
             ? '.react-datepicker__week-number[tabindex="0"]'
-            : '.react-datepicker__day[tabindex="0"]';
+            : this.props.showFullMonthYearPicker ||
+                this.props.showMonthYearPicker
+              ? '.react-datepicker__month-text[tabindex="0"]'
+              : '.react-datepicker__day[tabindex="0"]';
         const selectedItem =
           this.calendar.componentNode &&
           this.calendar.componentNode.querySelector(selectorString);

--- a/test/datepicker_test.test.js
+++ b/test/datepicker_test.test.js
@@ -1285,6 +1285,25 @@ describe("DatePicker", () => {
     fireEvent.keyDown(data.dateInput, getKey("ArrowDown"));
     expect(data.instance.state.open).toBe(true);
   });
+  it("should focus first month when the down arrow key is pressed", async () => {
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+    render(<DatePicker showMonthYearPicker />, {
+      container: div,
+    });
+
+    // user focuses the input field, the calendar opens
+    const dateInput = div.querySelector("input");
+    fireEvent.focus(dateInput);
+    fireEvent.keyDown(dateInput, getKey("ArrowDown"));
+
+    await waitFor(() => {
+      const selectedMonth = div.querySelector(
+        '.react-datepicker__month-text[tabindex="0"]',
+      );
+      expect(document.activeElement).toBe(selectedMonth);
+    });
+  });
   it("should not open the calendar when the left arrow key is pressed", () => {
     const data = getOnInputKeyDownStuff();
     act(() => {


### PR DESCRIPTION
## Description
**Linked issue**: #4400

**Problem**
Focus calender month when the user presses down or up arrow keys in input field. This makes Datepicker accessible when only using keyboard.

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
