### PR TITLE
fix: Add aria-label to read the day of the week instead of the shorthand 

### DIFF
--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -444,6 +444,7 @@ export default class Calendar extends React.Component {
         return (
           <div
             key={offset}
+            aria-label={formatDate(day, "EEEE", this.props.locale)}
             className={clsx("react-datepicker__day-name", weekDayClassName)}
           >
             {weekDayName}

--- a/test/calendar_test.test.js
+++ b/test/calendar_test.test.js
@@ -1882,6 +1882,37 @@ describe("Calendar", () => {
     });
   });
 
+  it("should add the aria-label correctly to day names", () => {
+    const expectedAriaLabels = [
+      "Sunday",
+      "Monday",
+      "Tuesday",
+      "Wednesday",
+      "Thursday",
+      "Friday",
+      "Saturday",
+    ];
+
+    const { container } = render(
+      <Calendar
+        dateFormat={DATE_FORMAT}
+        onSelect={() => {}}
+        onClickOutside={() => {}}
+      />,
+    );
+
+    const header = container.querySelector(".react-datepicker__header");
+    const dayNameElements = header.querySelectorAll(
+      ".react-datepicker__day-name",
+    );
+
+    dayNameElements.forEach((element, index) => {
+      expect(element.getAttribute("aria-label")).toBe(
+        expectedAriaLabels[index],
+      );
+    });
+  });
+
   it("should have a next-button with the provided aria-label for year", () => {
     const ariaLabel = "A label in my native language for next year";
     const { container } = render(


### PR DESCRIPTION
## Description
**Linked issue**: #3185

**Problem**
<!-- The problems this PR aims to solve -->
When using a screenreader it reads the days in the header as "Mo", "Tu"... etc. instead of the more understandable full name  See the linked issue for a more detailed description

**Changes**
<!-- Changes you have made to address the issue -->
This PR adds aria-labels to the header dates so that the screenreader now reads days with full name e.g. "Monday" instead of "Mo"

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
