### PR TITLE
♻️ Refactor date picker header to use semantic <h2> element

### DIFF
--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -687,9 +687,9 @@ export default class Calendar extends React.Component {
       classes.push("react-datepicker__current-month--hasMonthYearDropdown");
     }
     return (
-      <div className={classes.join(" ")}>
+      <h2 className={classes.join(" ")}>
         {formatDate(date, this.props.dateFormat, this.props.locale)}
-      </div>
+      </h2>
     );
   };
 

--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -100,6 +100,11 @@
   font-size: $datepicker__font-size * 1.18;
 }
 
+h2.react-datepicker__current-month {
+  padding: 0;
+  margin: 0;
+}
+
 .react-datepicker-time__header {
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/test/calendar_test.test.js
+++ b/test/calendar_test.test.js
@@ -155,6 +155,12 @@ describe("Calendar", () => {
     expect(utils.isSameDay(instance.date, oneMonthFromOpenToDate));
   });
 
+  it("should render month and year as a header of datepicker by default", () => {
+    const { calendar } = getCalendar();
+    const header = calendar.querySelector("h2.react-datepicker__current-month");
+    expect(header).not.toBeNull();
+  });
+
   it("should not show the year dropdown menu by default", () => {
     const { calendar } = getCalendar();
     const yearReadView = calendar.querySelectorAll(


### PR DESCRIPTION
## Description
**Linked issue**: #4703

This PR updates the date picker header from a <div> to a semantic <h2> element for improved accessibility. 

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
