### PR TITLE
feat: convert year_dropdown.jsx and year_dropdown_options.jsx into ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@testing-library/react": "^15.0.0",
     "@types/jest": "^29.5.12",
     "@types/node": "20",
+    "@types/react-onclickoutside": "^6.7.10",
     "axe-core": "^4.4.1",
     "babel-jest": "^29.6.4",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",

--- a/src/year_dropdown.tsx
+++ b/src/year_dropdown.tsx
@@ -1,31 +1,37 @@
 import React from "react";
-import PropTypes from "prop-types";
 import YearDropdownOptions from "./year_dropdown_options";
 import onClickOutside from "react-onclickoutside";
 import { getYear } from "./date_utils";
 
 const WrappedYearDropdownOptions = onClickOutside(YearDropdownOptions);
 
-export default class YearDropdown extends React.Component {
-  static propTypes = {
-    adjustDateOnChange: PropTypes.bool,
-    dropdownMode: PropTypes.oneOf(["scroll", "select"]).isRequired,
-    maxDate: PropTypes.instanceOf(Date),
-    minDate: PropTypes.instanceOf(Date),
-    onChange: PropTypes.func.isRequired,
-    scrollableYearDropdown: PropTypes.bool,
-    year: PropTypes.number.isRequired,
-    yearDropdownItemNumber: PropTypes.number,
-    date: PropTypes.instanceOf(Date),
-    onSelect: PropTypes.func,
-    setOpen: PropTypes.func,
-  };
+interface YearDropdownProps {
+  adjustDateOnChange?: boolean;
+  dropdownMode: "scroll" | "select";
+  maxDate?: Date;
+  minDate?: Date;
+  onChange: (year: number | string) => void;
+  scrollableYearDropdown?: boolean;
+  year: number;
+  yearDropdownItemNumber?: number;
+  date?: Date;
+  onSelect?: (date?: Date, event?: React.MouseEvent<HTMLDivElement>) => void;
+  setOpen?: (open?: boolean) => void;
+}
 
+interface YearDropdownState {
+  dropdownVisible: boolean;
+}
+
+export default class YearDropdown extends React.Component<
+  YearDropdownProps,
+  YearDropdownState
+> {
   state = {
     dropdownVisible: false,
   };
 
-  renderSelectOptions = () => {
+  renderSelectOptions = (): JSX.Element[] => {
     const minYear = this.props.minDate ? getYear(this.props.minDate) : 1900;
     const maxYear = this.props.maxDate ? getYear(this.props.maxDate) : 2100;
 
@@ -40,11 +46,11 @@ export default class YearDropdown extends React.Component {
     return options;
   };
 
-  onSelectChange = (e) => {
+  onSelectChange = (e: React.ChangeEvent<HTMLSelectElement>): void => {
     this.onChange(e.target.value);
   };
 
-  renderSelectMode = () => (
+  renderSelectMode = (): JSX.Element => (
     <select
       value={this.props.year}
       className="react-datepicker__year-select"
@@ -54,12 +60,14 @@ export default class YearDropdown extends React.Component {
     </select>
   );
 
-  renderReadView = (visible) => (
+  renderReadView = (visible: boolean): JSX.Element => (
     <div
       key="read"
       style={{ visibility: visible ? "visible" : "hidden" }}
       className="react-datepicker__year-read-view"
-      onClick={(event) => this.toggleDropdown(event)}
+      onClick={(event: React.MouseEvent<HTMLDivElement>): void =>
+        this.toggleDropdown(event)
+      }
     >
       <span className="react-datepicker__year-read-view--down-arrow" />
       <span className="react-datepicker__year-read-view--selected-year">
@@ -68,7 +76,7 @@ export default class YearDropdown extends React.Component {
     </div>
   );
 
-  renderDropdown = () => (
+  renderDropdown = (): JSX.Element => (
     <WrappedYearDropdownOptions
       key="dropdown"
       year={this.props.year}
@@ -81,22 +89,22 @@ export default class YearDropdown extends React.Component {
     />
   );
 
-  renderScrollMode = () => {
+  renderScrollMode = (): JSX.Element[] => {
     const { dropdownVisible } = this.state;
-    let result = [this.renderReadView(!dropdownVisible)];
+    const result = [this.renderReadView(!dropdownVisible)];
     if (dropdownVisible) {
       result.unshift(this.renderDropdown());
     }
     return result;
   };
 
-  onChange = (year) => {
+  onChange = (year: number | string): void => {
     this.toggleDropdown();
     if (year === this.props.year) return;
     this.props.onChange(year);
   };
 
-  toggleDropdown = (event) => {
+  toggleDropdown = (event?: React.MouseEvent<HTMLDivElement>): void => {
     this.setState(
       {
         dropdownVisible: !this.state.dropdownVisible,
@@ -109,24 +117,27 @@ export default class YearDropdown extends React.Component {
     );
   };
 
-  handleYearChange = (date, event) => {
+  handleYearChange = (
+    date?: Date,
+    event?: React.MouseEvent<HTMLDivElement>,
+  ): void => {
     this.onSelect(date, event);
     this.setOpen();
   };
 
-  onSelect = (date, event) => {
+  onSelect = (date?: Date, event?: React.MouseEvent<HTMLDivElement>): void => {
     if (this.props.onSelect) {
       this.props.onSelect(date, event);
     }
   };
 
-  setOpen = () => {
+  setOpen = (): void => {
     if (this.props.setOpen) {
       this.props.setOpen(true);
     }
   };
 
-  render() {
+  render(): JSX.Element {
     let renderedDropdown;
     switch (this.props.dropdownMode) {
       case "scroll":

--- a/src/year_dropdown_options.tsx
+++ b/src/year_dropdown_options.tsx
@@ -1,10 +1,14 @@
 import React, { createRef } from "react";
-import PropTypes from "prop-types";
 import { clsx } from "clsx";
 import { getYear } from "./date_utils";
 
-function generateYears(year, noOfYear, minDate, maxDate) {
-  const list = [];
+function generateYears(
+  year: number,
+  noOfYear: number,
+  minDate?: Date,
+  maxDate?: Date,
+): number[] {
+  const list: number[] = [];
   for (let i = 0; i < 2 * noOfYear + 1; i++) {
     const newYear = year + noOfYear - i;
     let isInRange = true;
@@ -25,18 +29,27 @@ function generateYears(year, noOfYear, minDate, maxDate) {
   return list;
 }
 
-export default class YearDropdownOptions extends React.Component {
-  static propTypes = {
-    minDate: PropTypes.instanceOf(Date),
-    maxDate: PropTypes.instanceOf(Date),
-    onCancel: PropTypes.func.isRequired,
-    onChange: PropTypes.func.isRequired,
-    scrollableYearDropdown: PropTypes.bool,
-    year: PropTypes.number.isRequired,
-    yearDropdownItemNumber: PropTypes.number,
-  };
+interface YearDropdownOptionsProps {
+  minDate?: Date;
+  maxDate?: Date;
+  onChange: (year: number) => void;
+  onCancel: VoidFunction;
+  scrollableYearDropdown?: boolean;
+  year: number;
+  yearDropdownItemNumber?: number;
+}
 
-  constructor(props) {
+interface YearDropdownOptionsState {
+  yearsList: number[];
+}
+
+export default class YearDropdownOptions extends React.Component<
+  YearDropdownOptionsProps,
+  YearDropdownOptionsState
+> {
+  dropdownRef: React.RefObject<HTMLDivElement>;
+
+  constructor(props: YearDropdownOptionsProps) {
     super(props);
     const { yearDropdownItemNumber, scrollableYearDropdown } = props;
     const noOfYear =
@@ -50,10 +63,10 @@ export default class YearDropdownOptions extends React.Component {
         this.props.maxDate,
       ),
     };
-    this.dropdownRef = createRef();
+    this.dropdownRef = createRef<HTMLDivElement>();
   }
 
-  componentDidMount() {
+  componentDidMount(): void {
     const dropdownCurrent = this.dropdownRef.current;
 
     if (dropdownCurrent) {
@@ -65,14 +78,16 @@ export default class YearDropdownOptions extends React.Component {
         ? dropdownCurrentChildren.find((childEl) => childEl.ariaSelected)
         : null;
 
-      dropdownCurrent.scrollTop = selectedYearOptionEl
-        ? selectedYearOptionEl.offsetTop +
-          (selectedYearOptionEl.clientHeight - dropdownCurrent.clientHeight) / 2
-        : (dropdownCurrent.scrollHeight - dropdownCurrent.clientHeight) / 2;
+      dropdownCurrent.scrollTop =
+        selectedYearOptionEl && selectedYearOptionEl instanceof HTMLElement
+          ? selectedYearOptionEl.offsetTop +
+            (selectedYearOptionEl.clientHeight - dropdownCurrent.clientHeight) /
+              2
+          : (dropdownCurrent.scrollHeight - dropdownCurrent.clientHeight) / 2;
     }
   }
 
-  renderOptions = () => {
+  renderOptions = (): JSX.Element[] => {
     const selectedYear = this.props.year;
     const options = this.state.yearsList.map((year) => (
       <div
@@ -124,15 +139,15 @@ export default class YearDropdownOptions extends React.Component {
     return options;
   };
 
-  onChange = (year) => {
+  onChange = (year: number): void => {
     this.props.onChange(year);
   };
 
-  handleClickOutside = () => {
+  handleClickOutside = (): void => {
     this.props.onCancel();
   };
 
-  shiftYears = (amount) => {
+  shiftYears = (amount: number): void => {
     const years = this.state.yearsList.map(function (year) {
       return year + amount;
     });
@@ -142,11 +157,11 @@ export default class YearDropdownOptions extends React.Component {
     });
   };
 
-  incrementYears = () => {
+  incrementYears = (): void => {
     return this.shiftYears(1);
   };
 
-  decrementYears = () => {
+  decrementYears = (): void => {
     return this.shiftYears(-1);
   };
 

--- a/test/month_year_dropdown_test.test.js
+++ b/test/month_year_dropdown_test.test.js
@@ -1,6 +1,6 @@
 import React from "react";
-import MonthYearDropdown from "../src/month_year_dropdown.jsx";
-import MonthYearDropdownOptions from "../src/month_year_dropdown_options.jsx";
+import MonthYearDropdown from "../src/month_year_dropdown";
+import MonthYearDropdownOptions from "../src/month_year_dropdown_options";
 import { render, fireEvent } from "@testing-library/react";
 import {
   newDate,

--- a/test/year_dropdown_options_test.test.js
+++ b/test/year_dropdown_options_test.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-import YearDropdownOptions from "../src/year_dropdown_options.jsx";
+import YearDropdownOptions from "../src/year_dropdown_options";
 import { render, fireEvent } from "@testing-library/react";
 import * as utils from "../src/date_utils.ts";
 import onClickOutside from "react-onclickoutside";

--- a/test/year_dropdown_test.test.js
+++ b/test/year_dropdown_test.test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import range from "lodash/range";
-import YearDropdown from "../src/year_dropdown.jsx";
+import YearDropdown from "../src/year_dropdown";
 import { render, fireEvent } from "@testing-library/react";
 import { newDate } from "../src/date_utils.ts";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1999,6 +1999,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-onclickoutside@^6.7.10":
+  version "6.7.10"
+  resolved "https://registry.yarnpkg.com/@types/react-onclickoutside/-/react-onclickoutside-6.7.10.tgz#aeaf56aac4b67185a69038d22c55bd0726f13123"
+  integrity sha512-Do2eOuqlJ9amXAuQO5gbhp5MAPnzZ7cknmYqX4U44tX22eAAnHgQKjp3SaNhSAuUHBTANWEqn1N+nWd3ea8FyQ==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*":
   version "18.2.21"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.21.tgz#774c37fd01b522d0b91aed04811b58e4e0514ed9"
@@ -6670,16 +6677,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -6782,14 +6780,7 @@ string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.2.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -7454,16 +7445,7 @@ widest-line@^3.1.0:
   dependencies:
     string-width "^4.0.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
## name: Migrate year_dropdown.jsx and year_dropdown_options.jsx
## Description
**Linked issue**: #4700

**Changes** `year_dropdown.jsx and year_dropdown_options.jsx` was migrated to ts and test

## Contribution checklist
* [x]  I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
* [x]  I have added sufficient test coverage for my changes.
* [x]  I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.

