### PR TITLE
[typescript-migration] portal.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,5 +121,6 @@
       "prettier --write",
       "git add"
     ]
-  }
+  },
+  "packageManager": "yarn@1.22.17"
 }

--- a/package.json
+++ b/package.json
@@ -121,6 +121,5 @@
       "prettier --write",
       "git add"
     ]
-  },
-  "packageManager": "yarn@1.22.17"
+  }
 }

--- a/src/portal.tsx
+++ b/src/portal.tsx
@@ -1,22 +1,24 @@
-import React from "react";
-import PropTypes from "prop-types";
+import React, { Component } from "react";
 import ReactDOM from "react-dom";
 
-export default class Portal extends React.Component {
-  static propTypes = {
-    children: PropTypes.any,
-    portalId: PropTypes.string,
-    portalHost: PropTypes.instanceOf(ShadowRoot),
-  };
+interface PortalProps {
+  children: React.ReactNode;
+  portalId: string;
+  portalHost?: ShadowRoot;
+}
 
-  constructor(props) {
+class Portal extends Component<PortalProps> {
+  private el: HTMLDivElement;
+  private portalRoot!: HTMLElement | null;
+
+  constructor(props: PortalProps) {
     super(props);
     this.el = document.createElement("div");
   }
 
   componentDidMount() {
     this.portalRoot = (this.props.portalHost || document).getElementById(
-      this.props.portalId,
+      this.props.portalId
     );
     if (!this.portalRoot) {
       this.portalRoot = document.createElement("div");
@@ -27,10 +29,14 @@ export default class Portal extends React.Component {
   }
 
   componentWillUnmount() {
-    this.portalRoot.removeChild(this.el);
+    if (this.portalRoot) {
+      this.portalRoot.removeChild(this.el);
+    }
   }
 
   render() {
     return ReactDOM.createPortal(this.props.children, this.el);
   }
 }
+
+export default Portal;

--- a/src/portal.tsx
+++ b/src/portal.tsx
@@ -28,7 +28,7 @@ class Portal extends Component<PortalProps> {
 
   componentDidMount() {
     this.portalRoot = (this.props.portalHost || document).getElementById(
-      this.props.portalId
+      this.props.portalId,
     );
     if (!this.portalRoot) {
       this.portalRoot = document.createElement("div");

--- a/src/portal.tsx
+++ b/src/portal.tsx
@@ -7,6 +7,16 @@ interface PortalProps {
   portalHost?: ShadowRoot;
 }
 
+/**
+ * `Portal` is a React component that allows you to render children into a DOM node
+ * that exists outside the DOM hierarchy of the parent component.
+ *
+ * @class
+ * @param {PortalProps} props - The properties that define the `Portal` component.
+ * @property {React.ReactNode} props.children - The children to be rendered into the `Portal`.
+ * @property {string} props.portalId - The id of the DOM node into which the `Portal` will render.
+ * @property {ShadowRoot} [props.portalHost] - The DOM node to host the `Portal`.
+ */
 class Portal extends Component<PortalProps> {
   private el: HTMLDivElement;
   private portalRoot!: HTMLElement | null;


### PR DESCRIPTION
---
name: Migrate portal.jsx
---
 
## Description
**Linked issue**: https://github.com/Hacker0x01/react-datepicker/issues/4700
 
**Changes**
`portal.jsx` was migrated to ts + added JSDocs
 
## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
