### PR TITLE
fix: invalid time error when selecting excluded month with keyboard

### DIFF
--- a/src/month.jsx
+++ b/src/month.jsx
@@ -455,8 +455,10 @@ export default class Month extends React.Component {
       const monthsGrid = MONTH_COLUMNS[monthColumnsLayout].grid;
       switch (eventKey) {
         case "Enter":
-          this.onMonthClick(event, month);
-          setPreSelection(selected);
+          if (!this.isMonthDisabled(month)) {
+            this.onMonthClick(event, month);
+            setPreSelection(selected);
+          }
           break;
         case "ArrowRight":
           this.handleMonthNavigation(

--- a/src/month.jsx
+++ b/src/month.jsx
@@ -52,7 +52,7 @@ function getMonthColumnsLayout(
   return MONTH_COLUMNS_LAYOUT.THREE_COLUMNS;
 }
 
-export default class Month extends React.Component {
+class Month extends React.Component {
   static propTypes = {
     ariaLabelPrefix: PropTypes.string,
     chooseDayAriaLabelPrefix: PropTypes.string,
@@ -841,3 +841,5 @@ export default class Month extends React.Component {
     );
   }
 }
+
+export default Month;

--- a/test/month_test.test.js
+++ b/test/month_test.test.js
@@ -1951,12 +1951,12 @@ describe("Month", () => {
         month: 7,
         preSelection: excludeDates[0],
         setPreSelection: () => {},
-        excludeDates: excludeDates
+        excludeDates: excludeDates,
       });
 
       fireEvent.keyDown(
         monthComponent.querySelector(".react-datepicker__month-7"),
-        getKey("Enter")
+        getKey("Enter"),
       );
 
       expect(selected).not.toBe(excludeDates[0]);

--- a/test/month_test.test.js
+++ b/test/month_test.test.js
@@ -1940,6 +1940,28 @@ describe("Month", () => {
       );
     });
 
+    it("should prevent selection of disabled month", () => {
+      const excludeDates = [utils.newDate("2015-08-01")];
+      let selected = utils.newDate("2015-07-01");
+      let day = utils.newDate("2015-08-01");
+
+      const monthComponent = renderMonth({
+        selected: selected,
+        day: day,
+        month: 7,
+        preSelection: excludeDates[0],
+        setPreSelection: () => {},
+        excludeDates: excludeDates
+      });
+
+      fireEvent.keyDown(
+        monthComponent.querySelector(".react-datepicker__month-7"),
+        getKey("Enter")
+      );
+
+      expect(selected).not.toBe(excludeDates[0]);
+    });
+
     it("should prevent navigation", () => {
       let preSelected = utils.newDate("2015-08-01");
       const setPreSelection = (param) => {


### PR DESCRIPTION
---
name: Pull Request
about: Fixes the date picker throwing an invalid time error when selecting excluded month with the keyboard
title: fix: invalid time error when selecting excluded month with keyboard
labels: ""
assignees: ""
---

## Description
**Linked issue**: #4731 

**Problem**
When an excluded month is selected with the keyboard, the month appears to not be keyboard selected, and when the arrow keys are used again, the Invalid time value error is thrown
![image](https://github.com/Hacker0x01/react-datepicker/assets/49902829/b37b9521-3ad0-4ea0-aab8-989371bf6516)

**Changes**
Added a `isMonthDisabled` check to the `onMonthKeyDown` function

## Screenshots
![image](https://github.com/Hacker0x01/react-datepicker/assets/49902829/aed371c0-3505-45e2-bc1a-ccb29bc2f6b1)

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
