### PR TITLE
Fix keyboard keydown event handler

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -836,8 +836,9 @@ export default class DatePicker extends React.Component {
     if (this.state.open) {
       if (eventKey === "ArrowDown" || eventKey === "ArrowUp") {
         event.preventDefault();
-        const selectorString =
-          this.props.showWeekPicker && this.props.showWeekNumbers
+        const selectorString = this.props.showTimeSelectOnly
+          ? ".react-datepicker__time-list-item[tabindex='0']"
+          : this.props.showWeekPicker && this.props.showWeekNumbers
             ? '.react-datepicker__week-number[tabindex="0"]'
             : this.props.showFullMonthYearPicker ||
                 this.props.showMonthYearPicker

--- a/test/timepicker_test.test.js
+++ b/test/timepicker_test.test.js
@@ -219,6 +219,17 @@ describe("TimePicker", () => {
     expect(onKeyDownSpy).toHaveBeenCalledTimes(1);
   });
 
+  it("should call the onKeyDown handler on key arrow down", () => {
+    const onKeyDownSpy = jest.fn();
+    renderDatePicker("February 28, 2018 4:43 PM", {
+      onKeyDown: onKeyDownSpy,
+      showTimeSelectOnly: true,
+    });
+    fireEvent.focus(instance.input);
+    fireEvent.keyDown(instance.input, { key: "ArrowDown" });
+    expect(onKeyDownSpy).toHaveBeenCalledTimes(1);
+  });
+
   function setManually(string) {
     fireEvent.focus(instance.input);
     fireEvent.change(instance.input, { target: { value: string } });


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to improve this repository
title: "Keyboard fix for time picker show time select only"
labels: ""
assignees: "alvaromartinez986"
---

## Description
**Linked issue**: #4701 

**Problem**
Keyboard not working when showTimeSelectOnly is True

**Changes**
Add the selector for the time container when the prop showTimeSelectOnly is true

## Screenshots
![image](https://github.com/Hacker0x01/react-datepicker/assets/9259335/90307d4c-c807-48e9-be61-a5e7369fce39)

## To reviewers
<!-- Additional comments for reviewers -->

## Contribution checklist
- [ ] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [ ] I have added sufficient test coverage for my changes.
- [ ] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
