### PR TITLE
Fix #4514: 🐛 Retain the Time Input focus on change of the time input value

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -814,7 +814,7 @@ export default class DatePicker extends Component<
     });
 
     this.props.onChange(changedDate);
-    if (this.props.shouldCloseOnSelect) {
+    if (this.props.shouldCloseOnSelect && !this.props.showTimeInput) {
       this.sendFocusBackToInput();
       this.setOpen(false);
     }

--- a/test/time_input_test.test.js
+++ b/test/time_input_test.test.js
@@ -33,6 +33,22 @@ describe("timeInput", () => {
     expect(input.value).toEqual("13:00");
   });
 
+  it("should retain the focus on onChange event", () => {
+    const onChangeSpy = jest.fn();
+    const { container } = render(
+      <DatePicker showTimeInput onChange={onChangeSpy} />,
+    );
+    const input = container.querySelector("input");
+
+    input.focus();
+    expect(document.activeElement).toBe(input);
+
+    fireEvent.change(input, { target: { value: "13:00" } });
+
+    expect(input.value).toEqual("13:00");
+    expect(document.activeElement).toBe(input);
+  });
+
   it("should trigger onChange event and set the value as last valid timeString if empty string is passed as time input value", () => {
     const { container } = render(
       <InputTimeComponent timeString="13:00" onChange={() => {}} />,


### PR DESCRIPTION
Closes #4514

## Description
As mentioned in the linked issue, the input field is loosing it's focus whenever we try to edit the value using keyboard.  As a result of it, it doesn't create a better User experience.  After this change, user can able to change the value of the time input without loosing it's focus inbetween.

**Changes**
- Restrict the auto-focus reset to the input box when the time input is enabled (as we're also not closing the calendar popup when the time input is enabled)
- Added a test case to validate the change

## Screenshots
![image](https://github.com/Hacker0x01/react-datepicker/assets/145029139/70fb7023-0216-4449-8937-da19d2ea208c)

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
