### PR TITLE
Allow for the keyboard preselection to skip excluded dates/weeks/months

### DIFF
--- a/docs-site/src/components/Examples/index.js
+++ b/docs-site/src/components/Examples/index.js
@@ -31,6 +31,7 @@ import ExcludeDates from "../../examples/excludeDates";
 import ExcludedWithMessage from "../../examples/excludeDatesWithMessage";
 import ExcludeDateIntervals from "../../examples/excludeDateIntervals";
 import ExcludeDatesMonthPicker from "../../examples/excludeDatesMonthPicker";
+import ExcludeMonths from "../../examples/excludeMonths";
 import HighlightDates from "../../examples/highlightDates";
 import HolidayDates from "../../examples/holidayDates";
 import HighlightDatesRanges from "../../examples/highlightDatesRanges";
@@ -289,6 +290,10 @@ export default class exampleComponents extends React.Component {
     {
       title: "Exclude Times",
       component: ExcludeTimes,
+    },
+    {
+      title: "Exclude months",
+      component: ExcludeMonths,
     },
     {
       title: "Filter dates",

--- a/docs-site/src/components/Examples/index.js
+++ b/docs-site/src/components/Examples/index.js
@@ -31,7 +31,7 @@ import ExcludeDates from "../../examples/excludeDates";
 import ExcludedWithMessage from "../../examples/excludeDatesWithMessage";
 import ExcludeDateIntervals from "../../examples/excludeDateIntervals";
 import ExcludeDatesMonthPicker from "../../examples/excludeDatesMonthPicker";
-import ExcludeMonths from "../../examples/excludeMonths";
+import ExcludeDatesRangeMonthPicker from "../../examples/excludeDatesRangeMonthPicker";
 import HighlightDates from "../../examples/highlightDates";
 import HolidayDates from "../../examples/holidayDates";
 import HighlightDatesRanges from "../../examples/highlightDatesRanges";
@@ -288,12 +288,12 @@ export default class exampleComponents extends React.Component {
       component: ExcludeDatesMonthPicker,
     },
     {
-      title: "Exclude Times",
-      component: ExcludeTimes,
+      title: "Exclude Months in Range Month Picker",
+      component: ExcludeDatesRangeMonthPicker,
     },
     {
-      title: "Exclude months",
-      component: ExcludeMonths,
+      title: "Exclude Times",
+      component: ExcludeTimes,
     },
     {
       title: "Filter dates",

--- a/docs-site/src/components/Examples/index.js
+++ b/docs-site/src/components/Examples/index.js
@@ -82,6 +82,7 @@ import TimeInput from "../../examples/timeInput";
 import StrictParsing from "../../examples/strictParsing";
 import MonthPicker from "../../examples/monthPicker";
 import WeekPicker from "../../examples/weekPicker";
+import ExcludeWeeks from "../../examples/excludeWeeks";
 import monthPickerFullName from "../../examples/monthPickerFullName";
 import monthPickerTwoColumns from "../../examples/monthPickerTwoColumns";
 import monthPickerFourColumns from "../../examples/monthPickerFourColumns";
@@ -544,6 +545,10 @@ export default class exampleComponents extends React.Component {
     {
       title: "Week Picker",
       component: WeekPicker,
+    },
+    {
+      title: "Exclude Weeks",
+      component: ExcludeWeeks,
     },
     {
       title: "External Form",

--- a/docs-site/src/examples/excludeDatesMonthPicker.js
+++ b/docs-site/src/examples/excludeDatesMonthPicker.js
@@ -1,13 +1,11 @@
 () => {
-  const [startDate, setStartDate] = useState(1659312000000);
+  const [startDate, setStartDate] = useState(new Date("2024-08-01"));
   return (
     <DatePicker
       selected={startDate}
       onChange={(date) => setStartDate(date)}
       dateFormat="MM/yyyy"
-      excludeDates={[
-        1661990400000, 1664582400000, 1667260800000, 1672531200000,
-      ]}
+      excludeDates={[new Date("2024-05-01"), new Date("2024-06-01")]}
       showMonthYearPicker
     />
   );

--- a/docs-site/src/examples/excludeDatesRangeMonthPicker.js
+++ b/docs-site/src/examples/excludeDatesRangeMonthPicker.js
@@ -11,11 +11,12 @@
         new Date("2024-01-01"),
         new Date("2024-11-01"),
       ]}
+      minDate={new Date("2023-06-01")}
+      maxDate={new Date("2025-02-01")}
       dateFormat="MM/yyyy"
       placeholderText="Select a month other than the disabled months"
       showMonthYearPicker
-      minDate={new Date("2023-06-01")}
-      maxDate={new Date("2025-02-01")}
+      selectsRange
     />
   );
 };

--- a/docs-site/src/examples/excludeDatesRangeMonthPicker.js
+++ b/docs-site/src/examples/excludeDatesRangeMonthPicker.js
@@ -21,8 +21,6 @@
         new Date("2024-01-01"),
         new Date("2024-11-01"),
       ]}
-      minDate={new Date("2023-06-01")}
-      maxDate={new Date("2025-02-01")}
       dateFormat="MM/yyyy"
       placeholderText="Select a month other than the disabled months"
       showMonthYearPicker

--- a/docs-site/src/examples/excludeDatesRangeMonthPicker.js
+++ b/docs-site/src/examples/excludeDatesRangeMonthPicker.js
@@ -1,10 +1,20 @@
 () => {
-  const defaultDate = new Date("2024-08-01");
-  const [startDate, setStartDate] = useState(defaultDate);
+  const defaultStartDate = new Date("2024-08-01");
+  const defaultEndDate = new Date("2024-10-01");
+  const [startDate, setStartDate] = useState(defaultStartDate);
+  const [endDate, setEndDate] = useState(defaultEndDate);
+
+  const handleChange = ([newStartDate, newEndDate]) => {
+    setStartDate(newStartDate);
+    setEndDate(newEndDate);
+  };
+
   return (
     <DatePicker
       selected={startDate}
-      onChange={(date) => setStartDate(date)}
+      startDate={startDate}
+      endDate={endDate}
+      onChange={handleChange}
       excludeDates={[
         new Date("2024-05-01"),
         new Date("2024-02-01"),

--- a/docs-site/src/examples/excludeMonths.js
+++ b/docs-site/src/examples/excludeMonths.js
@@ -1,21 +1,15 @@
 () => {
-  const defaultDate = new Date("2024-08-01");
-  const [startDate, setStartDate] = useState(defaultDate);
+  const [startDate, setStartDate] = useState(new Date());
   return (
     <DatePicker
       selected={startDate}
       onChange={(date) => setStartDate(date)}
       excludeDates={[
-        new Date("2024-05-01"),
-        new Date("2024-02-01"),
-        new Date("2024-01-01"),
-        new Date("2024-11-01")
+        subMonths(new Date(), 2),
       ]}
       dateFormat="MM/yyyy"
       placeholderText="Select a month other than the disabled months"
       showMonthYearPicker
-      minDate={new Date("2023-06-01")}
-      maxDate={new Date("2025-02-01")}
     />
   );
 };

--- a/docs-site/src/examples/excludeMonths.js
+++ b/docs-site/src/examples/excludeMonths.js
@@ -1,17 +1,18 @@
 () => {
-  const defaultDate = new Date("2024-05-01");
+  const defaultDate = new Date("2024-08-01");
   const [startDate, setStartDate] = useState(defaultDate);
   return (
     <DatePicker
       selected={startDate}
       onChange={(date) => setStartDate(date)}
       excludeDates={[
-        subMonths(defaultDate, 1),
-        subMonths(defaultDate, 3),
-        addMonths(defaultDate, 6),
+        new Date("2024-05-01"),
+        new Date("2024-02-01"),
+        new Date("2024-01-01"),
+        new Date("2024-11-01")
       ]}
       dateFormat="MM/yyyy"
-      placeholderText="Select a month other than this month or last last month"
+      placeholderText="Select a month other than the disabled months"
       showMonthYearPicker
       minDate={new Date("2023-06-01")}
       maxDate={new Date("2025-02-01")}

--- a/docs-site/src/examples/excludeMonths.js
+++ b/docs-site/src/examples/excludeMonths.js
@@ -1,15 +1,21 @@
 () => {
-  const [startDate, setStartDate] = useState(new Date());
+  const defaultDate = new Date("2024-08-01");
+  const [startDate, setStartDate] = useState(defaultDate);
   return (
     <DatePicker
       selected={startDate}
       onChange={(date) => setStartDate(date)}
       excludeDates={[
-        subMonths(new Date(), 2),
+        new Date("2024-05-01"),
+        new Date("2024-02-01"),
+        new Date("2024-01-01"),
+        new Date("2024-11-01"),
       ]}
       dateFormat="MM/yyyy"
       placeholderText="Select a month other than the disabled months"
       showMonthYearPicker
+      minDate={new Date("2023-06-01")}
+      maxDate={new Date("2025-02-01")}
     />
   );
 };

--- a/docs-site/src/examples/excludeMonths.js
+++ b/docs-site/src/examples/excludeMonths.js
@@ -1,0 +1,20 @@
+() => {
+  const defaultDate = new Date("2024-05-01");
+  const [startDate, setStartDate] = useState(defaultDate);
+  return (
+    <DatePicker
+      selected={startDate}
+      onChange={(date) => setStartDate(date)}
+      excludeDates={[
+        subMonths(defaultDate, 1),
+        subMonths(defaultDate, 3),
+        addMonths(defaultDate, 6),
+      ]}
+      dateFormat="MM/yyyy"
+      placeholderText="Select a month other than this month or last last month"
+      showMonthYearPicker
+      minDate={new Date("2023-06-01")}
+      maxDate={new Date("2025-02-01")}
+    />
+  );
+};

--- a/docs-site/src/examples/excludeWeeks.js
+++ b/docs-site/src/examples/excludeWeeks.js
@@ -1,0 +1,17 @@
+() => {
+  const [startDate, setStartDate] = useState(new Date("2021/02/22"));
+  return (
+    <DatePicker
+      selected={startDate}
+      onChange={(date) => setStartDate(date)}
+      dateFormat="I/R"
+      locale="en-GB"
+      excludeDateIntervals={[
+        { start: "2021/02/08", end: "2021/02/14" },
+        { start: "2021/01/18", end: "2021/01/24" },
+      ]}
+      showWeekNumbers
+      showWeekPicker
+    />
+  );
+};

--- a/src/date_utils.ts
+++ b/src/date_utils.ts
@@ -69,6 +69,21 @@ interface LocaleObj
 
 export type Locale = string | LocaleObj;
 
+export enum KeyType {
+  ArrowUp = "ArrowUp",
+  ArrowDown = "ArrowDown",
+  ArrowLeft = "ArrowLeft",
+  ArrowRight = "ArrowRight",
+  PageUp = "PageUp",
+  PageDown = "PageDown",
+  Home = "Home",
+  End = "End",
+  Enter = "Enter",
+  Space = " ",
+  Tab = "Tab",
+  Escape = "Escape",
+}
+
 function getLocaleScope() {
   // Use this cast to avoid messing with users globalThis (like window) and the rest of keys in the globalThis object we don't care about
   const scope = (typeof window !== "undefined"
@@ -1537,6 +1552,5 @@ export function isDateBefore(date: Date, dateToCompare: Date): boolean {
 export function isSpaceKeyDown(
   event: React.KeyboardEvent<HTMLDivElement>,
 ): boolean {
-  const SPACE_KEY = " ";
-  return event.key === SPACE_KEY;
+  return event.key === KeyType.Space;
 }

--- a/src/date_utils.ts
+++ b/src/date_utils.ts
@@ -888,12 +888,16 @@ export function isMonthInRange(
  */
 export function isMonthYearDisabled(
   date: Date,
-  props: Pick<
+  {
+    minDate,
+    maxDate,
+    excludeDates,
+    includeDates,
+  }: Pick<
     DateFilterOptions,
     "minDate" | "maxDate" | "excludeDates" | "includeDates"
   > = {},
 ): boolean {
-  const { minDate, maxDate, excludeDates, includeDates } = props;
   return (
     isOutOfBounds(date, { minDate, maxDate }) ||
     (excludeDates &&

--- a/src/date_utils.ts
+++ b/src/date_utils.ts
@@ -881,6 +881,34 @@ export function isMonthInRange(
   return false;
 }
 
+/**
+ * To check if a date's month and year are disabled/excluded
+ * @param date Date to check
+ * @returns {boolean} true if month and year are disabled/excluded, false otherwise
+ */
+export function isMonthYearDisabled(
+  date: Date,
+  props: Pick<
+    DateFilterOptions,
+    "minDate" | "maxDate" | "excludeDates" | "includeDates"
+  > = {},
+): boolean {
+  const { minDate, maxDate, excludeDates, includeDates } = props;
+  return (
+    isOutOfBounds(date, { minDate, maxDate }) ||
+    (excludeDates &&
+      excludeDates.some((excludedDate) =>
+        isSameMonth(
+          excludedDate instanceof Date ? excludedDate : excludedDate.date,
+          date,
+        ),
+      )) ||
+    (includeDates &&
+      !includeDates.some((includedDate) => isSameMonth(includedDate, date))) ||
+    false
+  );
+}
+
 export function isQuarterDisabled(
   quarter: Date,
   {

--- a/src/day.tsx
+++ b/src/day.tsx
@@ -20,6 +20,7 @@ import {
   type DateNumberType,
   type Locale,
   type HolidaysMap,
+  KeyType,
 } from "./date_utils";
 
 interface DayProps
@@ -167,7 +168,7 @@ export default class Day extends Component<DayProps> {
 
   handleOnKeyDown: React.KeyboardEventHandler<HTMLDivElement> = (event) => {
     const eventKey = event.key;
-    if (eventKey === " ") {
+    if (eventKey === KeyType.Space) {
       event.preventDefault();
       event.key = "Enter";
     }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -991,6 +991,8 @@ export default class DatePicker extends Component<
         if (eventKey === "PageDown" || eventKey === "End") {
           return getNewDate("ArrowLeft", newSelection);
         }
+
+        return getNewDate(eventKey, newSelection);
       }
       return newSelection;
     };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -975,12 +975,16 @@ export default class DatePicker extends Component<
 
       // if minDate exists and the new selection is before the min date, return
       if (minDate && newSelection < minDate) {
-        newSelection = minDate;
+        return isDayDisabled(minDate, this.props)
+          ? getNewDate("ArrowRight", minDate)
+          : minDate;
       }
 
       // if maxDate exists and the new selection is after the max date, return
       if (maxDate && newSelection > maxDate) {
-        newSelection = maxDate;
+        return isDayDisabled(maxDate, this.props)
+          ? getNewDate("ArrowLeft", maxDate)
+          : maxDate;
       }
 
       if (isDayDisabled(newSelection, this.props)) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -922,9 +922,19 @@ export default class DatePicker extends Component<
 
   // keyDown events passed down to day.jsx
   onDayKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-    const { minDate, maxDate } = this.props;
+    const {
+      minDate,
+      maxDate,
+      disabledKeyboardNavigation,
+      showWeekPicker,
+      shouldCloseOnSelect,
+      locale,
+      calendarStartDay,
+      adjustDateOnChange,
+      inline,
+    } = this.props;
     this.props.onKeyDown?.(event);
-    if (this.props.disabledKeyboardNavigation) return;
+    if (disabledKeyboardNavigation) return;
     const eventKey = event.key;
     const isShiftKeyActive = event.shiftKey;
 
@@ -934,14 +944,10 @@ export default class DatePicker extends Component<
 
       switch (eventKey) {
         case "ArrowRight":
-          newSelection = this.props.showWeekPicker
-            ? addWeeks(date, 1)
-            : addDays(date, 1);
+          newSelection = showWeekPicker ? addWeeks(date, 1) : addDays(date, 1);
           break;
         case "ArrowLeft":
-          newSelection = this.props.showWeekPicker
-            ? subWeeks(date, 1)
-            : subDays(date, 1);
+          newSelection = showWeekPicker ? subWeeks(date, 1) : subDays(date, 1);
           break;
         case "ArrowUp":
           newSelection = subWeeks(date, 1);
@@ -960,11 +966,7 @@ export default class DatePicker extends Component<
             : addMonths(date, 1);
           break;
         case "Home":
-          newSelection = getStartOfWeek(
-            date,
-            this.props.locale,
-            this.props.calendarStartDay,
-          );
+          newSelection = getStartOfWeek(date, locale, calendarStartDay);
           break;
         case "End":
           newSelection = getEndOfWeek(date);
@@ -996,7 +998,7 @@ export default class DatePicker extends Component<
     if (eventKey === "Enter") {
       event.preventDefault();
       this.handleSelect(copy, event);
-      !this.props.shouldCloseOnSelect && this.setPreSelection(copy);
+      !shouldCloseOnSelect && this.setPreSelection(copy);
       return;
     } else if (eventKey === "Escape") {
       event.preventDefault();
@@ -1032,12 +1034,12 @@ export default class DatePicker extends Component<
     }
     event.preventDefault();
     this.setState({ lastPreSelectChange: PRESELECT_CHANGE_VIA_NAVIGATE });
-    if (this.props.adjustDateOnChange) {
+    if (adjustDateOnChange) {
       this.setSelected(newSelection);
     }
     this.setPreSelection(newSelection);
     // need to figure out whether month has changed to focus day in inline version
-    if (this.props.inline) {
+    if (inline) {
       const prevMonth = getMonth(copy);
       const newMonth = getMonth(newSelection);
       const prevYear = getYear(copy);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -975,12 +975,12 @@ export default class DatePicker extends Component<
 
       // if minDate exists and the new selection is before the min date, return
       if (minDate && newSelection < minDate) {
-        return getNewDate("ArrowRight", newSelection);
+        newSelection = minDate;
       }
 
       // if maxDate exists and the new selection is after the max date, return
       if (maxDate && newSelection > maxDate) {
-        return getNewDate("ArrowLeft", newSelection);
+        newSelection = maxDate;
       }
 
       if (isDayDisabled(newSelection, this.props)) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -981,11 +981,17 @@ export default class DatePicker extends Component<
     };
 
     const getNewDate = (eventKey: KeyType, date: Date): Date => {
+      const MAX_ITERATIONS = 40;
       let eventKeyCopy = eventKey;
       let validDateFound = false;
+      let iterations = 0;
       let newSelection = calculateNewDate(eventKey, date);
 
       while (!validDateFound) {
+        if (iterations >= MAX_ITERATIONS) {
+          newSelection = date;
+          break;
+        }
         // if minDate exists and the new selection is before the min date, get the nearest date that isn't disabled
         if (minDate && newSelection < minDate) {
           eventKeyCopy = KeyType.ArrowRight;
@@ -1022,6 +1028,7 @@ export default class DatePicker extends Component<
         } else {
           validDateFound = true;
         }
+        iterations++;
       }
 
       return newSelection;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -990,9 +990,8 @@ export default class DatePicker extends Component<
           eventKey === "PageDown" ||
           eventKey === "Home"
         ) {
-          eventKey = "ArrowRight";
+          return getNewDate("ArrowRight", newSelection);
         }
-        return getNewDate(eventKey, newSelection);
       }
       return newSelection;
     };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1016,7 +1016,7 @@ export default class DatePicker extends Component<
       return;
     }
 
-    let newSelection;
+    let newSelection = null;
     switch (eventKey) {
       case "ArrowLeft":
       case "ArrowRight":
@@ -1027,9 +1027,6 @@ export default class DatePicker extends Component<
       case "Home":
       case "End":
         newSelection = getNewDate(eventKey, copy);
-        break;
-      default:
-        newSelection = null;
         break;
     }
     if (!newSelection) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -53,6 +53,7 @@ import {
   getEndOfDay,
   type HighlightDate,
   type HolidayItem,
+  KeyType,
 } from "./date_utils";
 import PopperComponent from "./popper_component";
 import Portal from "./portal";
@@ -845,9 +846,9 @@ export default class DatePicker extends Component<
       !this.props.preventOpenOnFocus
     ) {
       if (
-        eventKey === "ArrowDown" ||
-        eventKey === "ArrowUp" ||
-        eventKey === "Enter"
+        eventKey === KeyType.ArrowDown ||
+        eventKey === KeyType.ArrowUp ||
+        eventKey === KeyType.Enter
       ) {
         this.onInputClick();
       }
@@ -856,7 +857,7 @@ export default class DatePicker extends Component<
 
     // if calendar is open, these keys will focus the selected item
     if (this.state.open) {
-      if (eventKey === "ArrowDown" || eventKey === "ArrowUp") {
+      if (eventKey === KeyType.ArrowDown || eventKey === KeyType.ArrowUp) {
         event.preventDefault();
         const selectorString = this.props.showTimeSelectOnly
           ? ".react-datepicker__time-list-item[tabindex='0']"
@@ -935,7 +936,7 @@ export default class DatePicker extends Component<
     } = this.props;
     this.props.onKeyDown?.(event);
     if (disabledKeyboardNavigation) return;
-    const eventKey = event.key;
+    const eventKey = event.key as KeyType;
     const isShiftKeyActive = event.shiftKey;
 
     const copy = newDate(this.state.preSelection);
@@ -943,32 +944,32 @@ export default class DatePicker extends Component<
       let newSelection = date;
 
       switch (eventKey) {
-        case "ArrowRight":
+        case KeyType.ArrowRight:
           newSelection = showWeekPicker ? addWeeks(date, 1) : addDays(date, 1);
           break;
-        case "ArrowLeft":
+        case KeyType.ArrowLeft:
           newSelection = showWeekPicker ? subWeeks(date, 1) : subDays(date, 1);
           break;
-        case "ArrowUp":
+        case KeyType.ArrowUp:
           newSelection = subWeeks(date, 1);
           break;
-        case "ArrowDown":
+        case KeyType.ArrowDown:
           newSelection = addWeeks(date, 1);
           break;
-        case "PageUp":
+        case KeyType.PageUp:
           newSelection = isShiftKeyActive
             ? subYears(date, 1)
             : subMonths(date, 1);
           break;
-        case "PageDown":
+        case KeyType.PageDown:
           newSelection = isShiftKeyActive
             ? addYears(date, 1)
             : addMonths(date, 1);
           break;
-        case "Home":
+        case KeyType.Home:
           newSelection = getStartOfWeek(date, locale, calendarStartDay);
           break;
-        case "End":
+        case KeyType.End:
           newSelection = getEndOfWeek(date);
           break;
       }
@@ -976,24 +977,24 @@ export default class DatePicker extends Component<
       // if minDate exists and the new selection is before the min date, return
       if (minDate && newSelection < minDate) {
         return isDayDisabled(minDate, this.props)
-          ? getNewDate("ArrowRight", minDate)
+          ? getNewDate(KeyType.ArrowRight, minDate)
           : minDate;
       }
 
       // if maxDate exists and the new selection is after the max date, return
       if (maxDate && newSelection > maxDate) {
         return isDayDisabled(maxDate, this.props)
-          ? getNewDate("ArrowLeft", maxDate)
+          ? getNewDate(KeyType.ArrowLeft, maxDate)
           : maxDate;
       }
 
       if (isDayDisabled(newSelection, this.props)) {
-        if (eventKey === "PageUp" || eventKey === "Home") {
-          return getNewDate("ArrowRight", newSelection);
+        if (eventKey === KeyType.PageUp || eventKey === KeyType.Home) {
+          return getNewDate(KeyType.ArrowRight, newSelection);
         }
 
-        if (eventKey === "PageDown" || eventKey === "End") {
-          return getNewDate("ArrowLeft", newSelection);
+        if (eventKey === KeyType.PageDown || eventKey === KeyType.End) {
+          return getNewDate(KeyType.ArrowLeft, newSelection);
         }
 
         return getNewDate(eventKey, newSelection);
@@ -1001,12 +1002,12 @@ export default class DatePicker extends Component<
       return newSelection;
     };
 
-    if (eventKey === "Enter") {
+    if (eventKey === KeyType.Enter) {
       event.preventDefault();
       this.handleSelect(copy, event);
       !shouldCloseOnSelect && this.setPreSelection(copy);
       return;
-    } else if (eventKey === "Escape") {
+    } else if (eventKey === KeyType.Escape) {
       event.preventDefault();
 
       this.setOpen(false);
@@ -1018,14 +1019,14 @@ export default class DatePicker extends Component<
 
     let newSelection = null;
     switch (eventKey) {
-      case "ArrowLeft":
-      case "ArrowRight":
-      case "ArrowUp":
-      case "ArrowDown":
-      case "PageUp":
-      case "PageDown":
-      case "Home":
-      case "End":
+      case KeyType.ArrowLeft:
+      case KeyType.ArrowRight:
+      case KeyType.ArrowUp:
+      case KeyType.ArrowDown:
+      case KeyType.PageUp:
+      case KeyType.PageDown:
+      case KeyType.Home:
+      case KeyType.End:
         newSelection = getNewDate(eventKey, copy);
         break;
     }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -985,12 +985,12 @@ export default class DatePicker extends Component<
       }
 
       if (isDayDisabled(newSelection, this.props)) {
-        if (
-          eventKey === "PageUp" ||
-          eventKey === "PageDown" ||
-          eventKey === "Home"
-        ) {
+        if (eventKey === "PageUp" || eventKey === "Home") {
           return getNewDate("ArrowRight", newSelection);
+        }
+
+        if (eventKey === "PageDown" || eventKey === "End") {
+          return getNewDate("ArrowLeft", newSelection);
         }
       }
       return newSelection;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -924,16 +924,13 @@ export default class DatePicker extends Component<
   onDayKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     const { minDate, maxDate } = this.props;
     this.props.onKeyDown?.(event);
+    if (this.props.disabledKeyboardNavigation) return;
     const eventKey = event.key;
     const isShiftKeyActive = event.shiftKey;
 
     const copy = newDate(this.state.preSelection);
     const getNewDate = (eventKey: string, date: Date): Date => {
       let newSelection = date;
-
-      if (eventKey === "Enter") {
-        return newSelection;
-      }
 
       switch (eventKey) {
         case "ArrowRight":
@@ -1000,6 +997,7 @@ export default class DatePicker extends Component<
       event.preventDefault();
       this.handleSelect(copy, event);
       !this.props.shouldCloseOnSelect && this.setPreSelection(copy);
+      return;
     } else if (eventKey === "Escape") {
       event.preventDefault();
 
@@ -1007,49 +1005,50 @@ export default class DatePicker extends Component<
       if (!this.inputOk()) {
         this.props.onInputError?.({ code: 1, msg: INPUT_ERR_1 });
       }
-    } else if (!this.props.disabledKeyboardNavigation) {
-      let newSelection;
-      switch (eventKey) {
-        case "ArrowLeft":
-        case "ArrowRight":
-        case "ArrowUp":
-        case "ArrowDown":
-        case "PageUp":
-        case "PageDown":
-        case "Home":
-        case "End":
-          newSelection = getNewDate(eventKey, copy);
-          break;
-        default:
-          newSelection = null;
-          break;
-      }
-      if (!newSelection) {
-        if (this.props.onInputError) {
-          this.props.onInputError({ code: 1, msg: INPUT_ERR_1 });
-        }
-        return;
-      }
-      event.preventDefault();
-      this.setState({ lastPreSelectChange: PRESELECT_CHANGE_VIA_NAVIGATE });
-      if (this.props.adjustDateOnChange) {
-        this.setSelected(newSelection);
-      }
-      this.setPreSelection(newSelection);
-      // need to figure out whether month has changed to focus day in inline version
-      if (this.props.inline) {
-        const prevMonth = getMonth(copy);
-        const newMonth = getMonth(newSelection);
-        const prevYear = getYear(copy);
-        const newYear = getYear(newSelection);
+      return;
+    }
 
-        if (prevMonth !== newMonth || prevYear !== newYear) {
-          // month has changed
-          this.setState({ shouldFocusDayInline: true });
-        } else {
-          // month hasn't changed
-          this.setState({ shouldFocusDayInline: false });
-        }
+    let newSelection;
+    switch (eventKey) {
+      case "ArrowLeft":
+      case "ArrowRight":
+      case "ArrowUp":
+      case "ArrowDown":
+      case "PageUp":
+      case "PageDown":
+      case "Home":
+      case "End":
+        newSelection = getNewDate(eventKey, copy);
+        break;
+      default:
+        newSelection = null;
+        break;
+    }
+    if (!newSelection) {
+      if (this.props.onInputError) {
+        this.props.onInputError({ code: 1, msg: INPUT_ERR_1 });
+      }
+      return;
+    }
+    event.preventDefault();
+    this.setState({ lastPreSelectChange: PRESELECT_CHANGE_VIA_NAVIGATE });
+    if (this.props.adjustDateOnChange) {
+      this.setSelected(newSelection);
+    }
+    this.setPreSelection(newSelection);
+    // need to figure out whether month has changed to focus day in inline version
+    if (this.props.inline) {
+      const prevMonth = getMonth(copy);
+      const newMonth = getMonth(newSelection);
+      const prevYear = getYear(copy);
+      const newYear = getYear(newSelection);
+
+      if (prevMonth !== newMonth || prevYear !== newYear) {
+        // month has changed
+        this.setState({ shouldFocusDayInline: true });
+      } else {
+        // month hasn't changed
+        this.setState({ shouldFocusDayInline: false });
       }
     }
   };

--- a/src/month.tsx
+++ b/src/month.tsx
@@ -2,6 +2,7 @@ import { clsx } from "clsx";
 import React, { Component, createRef } from "react";
 
 import {
+  KeyType,
   addDays,
   addMonths,
   addQuarters,
@@ -517,7 +518,7 @@ export default class Month extends Component<MonthProps> {
 
   triggerKeyboardNavigation = (
     event: React.KeyboardEvent<HTMLDivElement>,
-    eventKey: string,
+    eventKey: KeyType,
     month: number,
   ) => {
     const {
@@ -541,35 +542,35 @@ export default class Month extends Component<MonthProps> {
     const monthsGrid = MONTH_COLUMNS[monthColumnsLayout]?.grid;
 
     const getNewDateAndMonth = (
-      eventKey: string,
+      eventKey: KeyType,
       selectedDate: Date,
       month: number,
     ): { newDate: Date; newMonth: number } => {
       let newDate = selectedDate;
       let newMonth = month;
 
-      if (eventKey === "Enter") {
+      if (eventKey === KeyType.Enter) {
         return { newDate, newMonth };
       }
 
       switch (eventKey) {
-        case "ArrowRight":
+        case KeyType.ArrowRight:
           newDate = addMonths(selectedDate, MONTH_NAVIGATION_HORIZONTAL_OFFSET);
           newMonth =
             month === 11 ? 0 : month + MONTH_NAVIGATION_HORIZONTAL_OFFSET;
           break;
-        case "ArrowLeft":
+        case KeyType.ArrowLeft:
           newDate = subMonths(selectedDate, MONTH_NAVIGATION_HORIZONTAL_OFFSET);
           newMonth =
             month === 0 ? 11 : month - MONTH_NAVIGATION_HORIZONTAL_OFFSET;
           break;
-        case "ArrowUp":
+        case KeyType.ArrowUp:
           newDate = subMonths(selectedDate, verticalOffset);
           newMonth = monthsGrid?.[0]?.includes(month)
             ? month + 12 - verticalOffset
             : month - verticalOffset;
           break;
-        case "ArrowDown":
+        case KeyType.ArrowDown:
           newDate = addMonths(selectedDate, verticalOffset);
           newMonth = monthsGrid?.[monthsGrid.length - 1]?.includes(month)
             ? month - 12 + verticalOffset
@@ -579,12 +580,12 @@ export default class Month extends Component<MonthProps> {
 
       // if minDate exists and the new month is before the minimum month, return
       if (minDate && newDate < minDate) {
-        return getNewDateAndMonth("ArrowRight", newDate, newMonth);
+        return getNewDateAndMonth(KeyType.ArrowRight, newDate, newMonth);
       }
 
       // if maxDate exists and the new month is after the maximum month, return
       if (maxDate && newDate > maxDate) {
-        return getNewDateAndMonth("ArrowLeft", newDate, newMonth);
+        return getNewDateAndMonth(KeyType.ArrowLeft, newDate, newMonth);
       }
 
       if (isMonthYearDisabled(newDate, this.props)) {
@@ -601,16 +602,16 @@ export default class Month extends Component<MonthProps> {
     );
 
     switch (eventKey) {
-      case "Enter":
+      case KeyType.Enter:
         if (!this.isMonthDisabled(month)) {
           this.onMonthClick(event, month);
           setPreSelection?.(selected);
         }
         break;
-      case "ArrowRight":
-      case "ArrowLeft":
-      case "ArrowUp":
-      case "ArrowDown":
+      case KeyType.ArrowRight:
+      case KeyType.ArrowLeft:
+      case KeyType.ArrowUp:
+      case KeyType.ArrowDown:
         this.handleMonthNavigation(newMonth, newDate);
         break;
     }
@@ -625,8 +626,8 @@ export default class Month extends Component<MonthProps> {
     month: number,
   ) => {
     const { disabledKeyboardNavigation, handleOnMonthKeyDown } = this.props;
-    const eventKey = event.key;
-    if (eventKey !== "Tab") {
+    const eventKey = event.key as KeyType;
+    if (eventKey !== KeyType.Tab) {
       // preventDefault on tab event blocks focus change
       event.preventDefault();
     }
@@ -677,11 +678,11 @@ export default class Month extends Component<MonthProps> {
     const eventKey = event.key;
     if (!this.props.disabledKeyboardNavigation) {
       switch (eventKey) {
-        case "Enter":
+        case KeyType.Enter:
           this.onQuarterClick(event, quarter);
           this.props.setPreSelection?.(this.props.selected);
           break;
-        case "ArrowRight":
+        case KeyType.ArrowRight:
           if (!this.props.preSelection) {
             break;
           }
@@ -690,7 +691,7 @@ export default class Month extends Component<MonthProps> {
             addQuarters(this.props.preSelection, 1),
           );
           break;
-        case "ArrowLeft":
+        case KeyType.ArrowLeft:
           if (!this.props.preSelection) {
             break;
           }

--- a/src/month.tsx
+++ b/src/month.tsx
@@ -20,6 +20,7 @@ import {
   isDayExcluded,
   isMonthDisabled,
   isMonthInRange,
+  isMonthYearDisabled,
   isQuarterDisabled,
   isQuarterInRange,
   isSameMonth,
@@ -586,7 +587,7 @@ export default class Month extends Component<MonthProps> {
         return getNewDateAndMonth("ArrowLeft", newDate, newMonth);
       }
 
-      if (this.isMonthDisabled(newDate.getMonth())) {
+      if (isMonthYearDisabled(newDate, this.props)) {
         return getNewDateAndMonth(eventKey, newDate, newMonth);
       }
 

--- a/src/month.tsx
+++ b/src/month.tsx
@@ -629,7 +629,7 @@ export default class Month extends Component<MonthProps> {
       // preventDefault on tab event blocks focus change
       event.preventDefault();
     }
-    if (!disabledKeyboardNavigation) {
+    if (!disabledKeyboardNavigation && preSelection) {
       const monthColumnsLayout = getMonthColumnsLayout(
         showFourColumnMonthYearPicker,
         showTwoColumnMonthYearPicker,

--- a/src/month.tsx
+++ b/src/month.tsx
@@ -589,8 +589,10 @@ export default class Month extends Component<MonthProps> {
       selectedDate: Date,
       month: number,
     ): { newCalculatedDate: Date; newCalculatedMonth: number } => {
+      const MAX_ITERATIONS = 40;
       let eventKeyCopy = eventKey;
       let validDateFound = false;
+      let iterations = 0;
       let { newCalculatedDate, newCalculatedMonth } = calculateNewDateAndMonth(
         eventKeyCopy,
         selectedDate,
@@ -598,6 +600,11 @@ export default class Month extends Component<MonthProps> {
       );
 
       while (!validDateFound) {
+        if (iterations >= MAX_ITERATIONS) {
+          newCalculatedDate = selectedDate;
+          newCalculatedMonth = month;
+          break;
+        }
         // if minDate exists and the new month is before the minimum month, it will try to find the next available month after
         if (minDate && newCalculatedDate < minDate) {
           eventKeyCopy = KeyType.ArrowRight;
@@ -633,6 +640,7 @@ export default class Month extends Component<MonthProps> {
         } else {
           validDateFound = true;
         }
+        iterations++;
       }
 
       return { newCalculatedDate, newCalculatedMonth };

--- a/src/month.tsx
+++ b/src/month.tsx
@@ -586,7 +586,7 @@ export default class Month extends Component<MonthProps> {
         return getNewDateAndMonth("ArrowLeft", newDate, newMonth);
       }
 
-      if (this.isDisabled(newDate) || this.isExcluded(newDate)) {
+      if (this.isMonthDisabled(newDate.getMonth())) {
         return getNewDateAndMonth(eventKey, newDate, newMonth);
       }
 

--- a/src/month.tsx
+++ b/src/month.tsx
@@ -518,17 +518,17 @@ export default class Month extends Component<MonthProps> {
     event: React.KeyboardEvent<HTMLDivElement>,
     eventKey: string,
     month: number,
-    preSelection: Date | undefined,
   ) => {
-    if (!preSelection) return;
     const {
       selected,
+      preSelection,
       setPreSelection,
       minDate,
       maxDate,
       showFourColumnMonthYearPicker,
       showTwoColumnMonthYearPicker,
     } = this.props;
+    if (!preSelection) return;
 
     const monthColumnsLayout = getMonthColumnsLayout(
       showFourColumnMonthYearPicker,
@@ -599,16 +599,6 @@ export default class Month extends Component<MonthProps> {
       month,
     );
 
-    // if minDate exists and the new month is before the minimum month, return
-    if (minDate && newDate < minDate) {
-      return;
-    }
-
-    // if maxDate exists and the new month is after the maximum month, return
-    if (maxDate && newDate > maxDate) {
-      return;
-    }
-
     switch (eventKey) {
       case "Enter":
         if (!this.isMonthDisabled(month)) {
@@ -633,15 +623,14 @@ export default class Month extends Component<MonthProps> {
     event: React.KeyboardEvent<HTMLDivElement>,
     month: number,
   ) => {
-    const { disabledKeyboardNavigation, handleOnMonthKeyDown, preSelection } =
-      this.props;
+    const { disabledKeyboardNavigation, handleOnMonthKeyDown } = this.props;
     const eventKey = event.key;
     if (eventKey !== "Tab") {
       // preventDefault on tab event blocks focus change
       event.preventDefault();
     }
-    if (!disabledKeyboardNavigation && preSelection) {
-      this.triggerKeyboardNavigation(event, eventKey, month, preSelection);
+    if (!disabledKeyboardNavigation) {
+      this.triggerKeyboardNavigation(event, eventKey, month);
     }
 
     handleOnMonthKeyDown && handleOnMonthKeyDown(event);

--- a/src/month.tsx
+++ b/src/month.tsx
@@ -593,7 +593,6 @@ export default class Month extends Component<MonthProps> {
       return { newDate, newMonth };
     };
 
-    console.log(eventKey);
     const { newDate, newMonth } = getNewDateAndMonth(
       eventKey,
       preSelection,

--- a/src/month.tsx
+++ b/src/month.tsx
@@ -547,6 +547,10 @@ export default class Month extends Component<MonthProps> {
       let newDate = selectedDate;
       let newMonth = month;
 
+      if (eventKey === "Enter") {
+        return { newDate, newMonth };
+      }
+
       switch (eventKey) {
         case "ArrowRight":
           newDate = addMonths(selectedDate, MONTH_NAVIGATION_HORIZONTAL_OFFSET);
@@ -574,12 +578,12 @@ export default class Month extends Component<MonthProps> {
 
       // if minDate exists and the new month is before the minimum month, return
       if (minDate && newDate < minDate) {
-        return { newDate, newMonth };
+        return getNewDateAndMonth("ArrowRight", newDate, newMonth);
       }
 
       // if maxDate exists and the new month is after the maximum month, return
       if (maxDate && newDate > maxDate) {
-        return { newDate, newMonth };
+        return getNewDateAndMonth("ArrowLeft", newDate, newMonth);
       }
 
       if (this.isDisabled(newDate) || this.isExcluded(newDate)) {
@@ -589,6 +593,7 @@ export default class Month extends Component<MonthProps> {
       return { newDate, newMonth };
     };
 
+    console.log(eventKey);
     const { newDate, newMonth } = getNewDateAndMonth(
       eventKey,
       preSelection,

--- a/src/month.tsx
+++ b/src/month.tsx
@@ -559,22 +559,20 @@ export default class Month extends Component<MonthProps> {
       return obj[eventKey] as Date;
     };
 
-    if (minDate) {
-      if (
-        getNewPreSelection(eventKey, preSelection) <
-        getNewPreSelection(eventKey, minDate)
-      ) {
-        return;
-      }
+    // if minDate exists and the new month is before the minimum month, return
+    if (minDate && (
+      getNewPreSelection(eventKey, preSelection) <
+      getNewPreSelection(eventKey, minDate)
+    )) {
+      return;
     }
 
-    if (maxDate) {
-      if (
-        getNewPreSelection(eventKey, preSelection) >
-        getNewPreSelection(eventKey, maxDate)
-      ) {
-        return;
-      }
+    // if maxDate exists and the new month is after the maximum month, return
+    if (maxDate && (
+      getNewPreSelection(eventKey, preSelection) >
+      getNewPreSelection(eventKey, maxDate)
+    )) {
+      return;
     }
 
     if (

--- a/src/time.tsx
+++ b/src/time.tsx
@@ -15,6 +15,7 @@ import {
   getSeconds,
   type Locale,
   type TimeFilterOptions,
+  KeyType,
 } from "./date_utils";
 
 interface TimeProps
@@ -152,13 +153,13 @@ export default class Time extends Component<TimeProps, TimeState> {
     event: React.KeyboardEvent<HTMLLIElement>,
     time: Date,
   ): void => {
-    if (event.key === " ") {
+    if (event.key === KeyType.Space) {
       event.preventDefault();
-      event.key = "Enter";
+      event.key = KeyType.Enter;
     }
 
     if (
-      (event.key === "ArrowUp" || event.key === "ArrowLeft") &&
+      (event.key === KeyType.ArrowUp || event.key === KeyType.ArrowLeft) &&
       event.target instanceof HTMLElement &&
       event.target.previousSibling
     ) {
@@ -167,7 +168,7 @@ export default class Time extends Component<TimeProps, TimeState> {
         event.target.previousSibling.focus();
     }
     if (
-      (event.key === "ArrowDown" || event.key === "ArrowRight") &&
+      (event.key === KeyType.ArrowDown || event.key === KeyType.ArrowRight) &&
       event.target instanceof HTMLElement &&
       event.target.nextSibling
     ) {
@@ -176,7 +177,7 @@ export default class Time extends Component<TimeProps, TimeState> {
         event.target.nextSibling.focus();
     }
 
-    if (event.key === "Enter") {
+    if (event.key === KeyType.Enter) {
       this.handleClick(time);
     }
     this.props.handleOnKeyDown?.(event);

--- a/src/week_number.tsx
+++ b/src/week_number.tsx
@@ -1,7 +1,7 @@
 import { clsx } from "clsx";
 import React, { Component, createRef } from "react";
 
-import { isSameDay } from "./date_utils";
+import { KeyType, isSameDay } from "./date_utils";
 
 interface WeekNumberProps {
   weekNumber: number;
@@ -45,7 +45,7 @@ export default class WeekNumber extends Component<WeekNumberProps> {
 
   handleOnKeyDown = (event: React.KeyboardEvent<HTMLDivElement>): void => {
     const eventKey = event.key;
-    if (eventKey === " ") {
+    if (eventKey === KeyType.Space) {
       event.preventDefault();
       event.key = "Enter";
     }

--- a/src/year.tsx
+++ b/src/year.tsx
@@ -17,6 +17,7 @@ import {
   newDate,
   setYear,
   subYears,
+  KeyType,
 } from "./date_utils";
 
 const VERTICAL_NAVIGATION_OFFSET = 3;
@@ -254,14 +255,14 @@ export default class Year extends Component<YearProps> {
 
     if (!this.props.disabledKeyboardNavigation) {
       switch (key) {
-        case "Enter":
+        case KeyType.Enter:
           if (this.props.selected == null) {
             break;
           }
           this.onYearClick(event, y);
           this.props.setPreSelection?.(this.props.selected);
           break;
-        case "ArrowRight":
+        case KeyType.ArrowRight:
           if (this.props.preSelection == null) {
             break;
           }
@@ -270,7 +271,7 @@ export default class Year extends Component<YearProps> {
             addYears(this.props.preSelection, 1),
           );
           break;
-        case "ArrowLeft":
+        case KeyType.ArrowLeft:
           if (this.props.preSelection == null) {
             break;
           }
@@ -279,7 +280,7 @@ export default class Year extends Component<YearProps> {
             subYears(this.props.preSelection, 1),
           );
           break;
-        case "ArrowUp": {
+        case KeyType.ArrowUp: {
           if (
             date === undefined ||
             yearItemNumber === undefined ||
@@ -309,7 +310,7 @@ export default class Year extends Component<YearProps> {
           );
           break;
         }
-        case "ArrowDown": {
+        case KeyType.ArrowDown: {
           if (
             date === undefined ||
             yearItemNumber === undefined ||

--- a/test/date_utils_test.test.ts
+++ b/test/date_utils_test.test.ts
@@ -1392,9 +1392,9 @@ describe("date_utils", () => {
       ).toBe(false);
     });
 
-    it("should return false if props are empty", () => {
+    it("should return false by default", () => {
       const date = new Date(new Date(2023, 3, 1));
-      expect(isMonthYearDisabled(date, {})).toBe(false);
+      expect(isMonthYearDisabled(date)).toBe(false);
     });
   });
 });

--- a/test/date_utils_test.test.ts
+++ b/test/date_utils_test.test.ts
@@ -1392,6 +1392,13 @@ describe("date_utils", () => {
       ).toBe(false);
     });
 
+    it("should return false if two dates have the same month but different years", () => {
+      const date = new Date(2021, 5, 1);
+      expect(
+        isMonthYearDisabled(date, { excludeDates: [new Date(2023, 5, 1)] }),
+      ).toBe(false);
+    });
+
     it("should return false by default", () => {
       const date = new Date(new Date(2023, 3, 1));
       expect(isMonthYearDisabled(date)).toBe(false);

--- a/test/date_utils_test.test.ts
+++ b/test/date_utils_test.test.ts
@@ -50,6 +50,7 @@ import {
   isDateBefore,
   getMidnightDate,
   registerLocale,
+  isMonthYearDisabled,
 } from "../src/date_utils";
 
 registerLocale("pt-BR", ptBR);
@@ -1354,6 +1355,46 @@ describe("date_utils", () => {
 
         isDateBefore(invalidDate, validDate);
       }).toThrow();
+    });
+  });
+
+  describe("isMonthYearDisabled", () => {
+    const props = {
+      minDate: new Date(2023, 2, 1),
+      maxDate: new Date(2023, 11, 31),
+      excludeDates: [new Date(2023, 5, 1)],
+    };
+
+    it("should return true if month is disabled", () => {
+      const date = new Date(new Date(2023, 5, 1));
+      expect(isMonthYearDisabled(date, props)).toBe(true);
+    });
+
+    it("should return true if month is before the min date", () => {
+      const date = new Date(new Date(2023, 1, 1));
+      expect(isMonthYearDisabled(date, props)).toBe(true);
+    });
+
+    it("should return true if month is after the max date", () => {
+      const date = new Date(new Date(2024, 1, 1));
+      expect(isMonthYearDisabled(date, props)).toBe(true);
+    });
+
+    it("should return false if month is not disabled", () => {
+      const date = new Date(new Date(2023, 3, 1));
+      expect(isMonthYearDisabled(date, props)).toBe(false);
+    });
+
+    it("should return false if month is in include dates", () => {
+      const date = new Date(2024, 2, 1);
+      expect(
+        isMonthYearDisabled(date, { includeDates: [new Date(2024, 2, 1)] }),
+      ).toBe(false);
+    });
+
+    it("should return false if props are empty", () => {
+      const date = new Date(new Date(2023, 3, 1));
+      expect(isMonthYearDisabled(date, {})).toBe(false);
     });
   });
 });

--- a/test/datepicker_test.test.js
+++ b/test/datepicker_test.test.js
@@ -1257,7 +1257,7 @@ describe("DatePicker", () => {
     fireEvent.keyDown(getSelectedDayNode(data.instance), getKey("PageUp"));
     expect(
       utils.formatDate(data.instance.state.preSelection, data.testFormat),
-    ).toBe(utils.formatDate(new Date("2024-05-03"), data.testFormat));
+    ).toBe(utils.formatDate(date, data.testFormat));
   });
 
   it("using keyboard, should not navigate to excluded date when excluded date and maxDate are the same (edge case)", () => {
@@ -1273,7 +1273,24 @@ describe("DatePicker", () => {
     fireEvent.keyDown(getSelectedDayNode(data.instance), getKey("PageDown"));
     expect(
       utils.formatDate(data.instance.state.preSelection, data.testFormat),
-    ).toBe(utils.formatDate(new Date("2024-05-03"), data.testFormat));
+    ).toBe(utils.formatDate(date, data.testFormat));
+  });
+
+  it("using keyboard, should not navigate to any date when there are no dates enabled (edge case)", () => {
+    const date = new Date("2024-05-03");
+    const data = getOnInputKeyDownStuff({
+      minDate: date,
+      maxDate: date,
+      excludeDates: [date],
+      selected: date,
+      preSelection: date,
+    });
+
+    fireEvent.keyDown(data.dateInput, getKey("ArrowDown"));
+    fireEvent.keyDown(getSelectedDayNode(data.instance), getKey("PageDown"));
+    expect(
+      utils.formatDate(data.instance.state.preSelection, data.testFormat),
+    ).toBe(utils.formatDate(date, data.testFormat));
   });
 
   it("should call onMonthChange when keyboard navigation moves preSelection to different month", () => {

--- a/test/datepicker_test.test.js
+++ b/test/datepicker_test.test.js
@@ -1244,6 +1244,38 @@ describe("DatePicker", () => {
     ).toBe(utils.formatDate(new Date("2024-05-10"), data.testFormat));
   });
 
+  it("using keyboard, should not navigate to excluded date when excluded date and minDate are the same (edge case)", () => {
+    const date = new Date("2024-05-03");
+    const data = getOnInputKeyDownStuff({
+      minDate: new Date("2024-05-02"),
+      excludeDates: [new Date("2024-05-02")],
+      selected: date,
+      preSelection: date,
+    });
+
+    fireEvent.keyDown(data.dateInput, getKey("ArrowDown"));
+    fireEvent.keyDown(getSelectedDayNode(data.instance), getKey("PageUp"));
+    expect(
+      utils.formatDate(data.instance.state.preSelection, data.testFormat),
+    ).toBe(utils.formatDate(new Date("2024-05-03"), data.testFormat));
+  });
+
+  it("using keyboard, should not navigate to excluded date when excluded date and maxDate are the same (edge case)", () => {
+    const date = new Date("2024-05-03");
+    const data = getOnInputKeyDownStuff({
+      maxDate: new Date("2024-05-04"),
+      excludeDates: [new Date("2024-05-04")],
+      selected: date,
+      preSelection: date,
+    });
+
+    fireEvent.keyDown(data.dateInput, getKey("ArrowDown"));
+    fireEvent.keyDown(getSelectedDayNode(data.instance), getKey("PageDown"));
+    expect(
+      utils.formatDate(data.instance.state.preSelection, data.testFormat),
+    ).toBe(utils.formatDate(new Date("2024-05-03"), data.testFormat));
+  });
+
   it("should call onMonthChange when keyboard navigation moves preSelection to different month", () => {
     const onMonthChangeSpy = jest.fn();
     const opts = { onMonthChange: onMonthChangeSpy };

--- a/test/datepicker_test.test.js
+++ b/test/datepicker_test.test.js
@@ -3292,4 +3292,188 @@ describe("DatePicker", () => {
       expect(onYearMouseLeaveSpy).toHaveBeenCalled();
     });
   });
+
+  describe("Week picker", () => {
+    describe("Keyboard navigation", () => {
+      it("should navigate to the previous week when pressing ArrowUp", () => {
+        const date = new Date("2021-02-08");
+        const data = getOnInputKeyDownStuff({
+          showWeekPicker: true,
+          selected: date,
+          preSelection: date,
+        });
+
+        fireEvent.keyDown(data.dateInput, getKey("ArrowDown"));
+        fireEvent.keyDown(getSelectedDayNode(data.instance), getKey("ArrowUp"));
+        expect(
+          utils.formatDate(data.instance.state.preSelection, data.testFormat),
+        ).toBe(utils.formatDate(new Date("2021-02-01"), data.testFormat));
+      });
+      it("should navigate to the previous week when pressing ArrowLeft", () => {
+        const date = new Date("2021-02-08");
+        const data = getOnInputKeyDownStuff({
+          showWeekPicker: true,
+          selected: date,
+          preSelection: date,
+        });
+
+        fireEvent.keyDown(data.dateInput, getKey("ArrowDown"));
+        fireEvent.keyDown(
+          getSelectedDayNode(data.instance),
+          getKey("ArrowLeft"),
+        );
+        expect(
+          utils.formatDate(data.instance.state.preSelection, data.testFormat),
+        ).toBe(utils.formatDate(new Date("2021-02-01"), data.testFormat));
+      });
+      it("should navigate to the next week when pressing ArrowDown", () => {
+        const date = new Date("2021-02-08");
+        const data = getOnInputKeyDownStuff({
+          showWeekPicker: true,
+          selected: date,
+          preSelection: date,
+        });
+
+        fireEvent.keyDown(data.dateInput, getKey("ArrowDown"));
+        fireEvent.keyDown(
+          getSelectedDayNode(data.instance),
+          getKey("ArrowDown"),
+        );
+        expect(
+          utils.formatDate(data.instance.state.preSelection, data.testFormat),
+        ).toBe(utils.formatDate(new Date("2021-02-15"), data.testFormat));
+      });
+      it("should navigate to the next week when pressing ArrowRight", () => {
+        const date = new Date("2021-02-08");
+        const data = getOnInputKeyDownStuff({
+          showWeekPicker: true,
+          selected: date,
+          preSelection: date,
+        });
+
+        fireEvent.keyDown(data.dateInput, getKey("ArrowDown"));
+        fireEvent.keyDown(
+          getSelectedDayNode(data.instance),
+          getKey("ArrowRight"),
+        );
+        expect(
+          utils.formatDate(data.instance.state.preSelection, data.testFormat),
+        ).toBe(utils.formatDate(new Date("2021-02-15"), data.testFormat));
+      });
+      it("should skip excluded week when pressing ArrowUp", () => {
+        const date = new Date("2021-02-08");
+        const data = getOnInputKeyDownStuff({
+          showWeekPicker: true,
+          selected: date,
+          preSelection: date,
+          excludeDateIntervals: [
+            { start: new Date("2021-02-01"), end: new Date("2021-02-07") },
+          ],
+        });
+
+        fireEvent.keyDown(data.dateInput, getKey("ArrowDown"));
+        fireEvent.keyDown(getSelectedDayNode(data.instance), getKey("ArrowUp"));
+        expect(
+          utils.formatDate(data.instance.state.preSelection, data.testFormat),
+        ).toBe(utils.formatDate(new Date("2021-01-25"), data.testFormat));
+      });
+      it("should skip excluded week when pressing ArrowLeft", () => {
+        const date = new Date("2021-02-08");
+        const data = getOnInputKeyDownStuff({
+          showWeekPicker: true,
+          selected: date,
+          preSelection: date,
+          excludeDateIntervals: [
+            { start: new Date("2021-02-01"), end: new Date("2021-02-07") },
+          ],
+        });
+
+        fireEvent.keyDown(data.dateInput, getKey("ArrowDown"));
+        fireEvent.keyDown(
+          getSelectedDayNode(data.instance),
+          getKey("ArrowLeft"),
+        );
+        expect(
+          utils.formatDate(data.instance.state.preSelection, data.testFormat),
+        ).toBe(utils.formatDate(new Date("2021-01-25"), data.testFormat));
+      });
+      it("should skip excluded week when pressing ArrowDown", () => {
+        const date = new Date("2021-02-08");
+        const data = getOnInputKeyDownStuff({
+          showWeekPicker: true,
+          selected: date,
+          preSelection: date,
+          excludeDateIntervals: [
+            { start: new Date("2021-02-15"), end: new Date("2021-02-21") },
+          ],
+        });
+
+        fireEvent.keyDown(data.dateInput, getKey("ArrowDown"));
+        fireEvent.keyDown(
+          getSelectedDayNode(data.instance),
+          getKey("ArrowDown"),
+        );
+        expect(
+          utils.formatDate(data.instance.state.preSelection, data.testFormat),
+        ).toBe(utils.formatDate(new Date("2021-02-22"), data.testFormat));
+      });
+      it("should skip excluded week when pressing ArrowRight", () => {
+        const date = new Date("2021-02-08");
+        const data = getOnInputKeyDownStuff({
+          showWeekPicker: true,
+          selected: date,
+          preSelection: date,
+          excludeDateIntervals: [
+            { start: new Date("2021-02-15"), end: new Date("2021-02-21") },
+          ],
+        });
+
+        fireEvent.keyDown(data.dateInput, getKey("ArrowDown"));
+        fireEvent.keyDown(
+          getSelectedDayNode(data.instance),
+          getKey("ArrowRight"),
+        );
+        expect(
+          utils.formatDate(data.instance.state.preSelection, data.testFormat),
+        ).toBe(utils.formatDate(new Date("2021-02-22"), data.testFormat));
+      });
+      it("should move to the next available week after pressing PageUp to a disabled date", () => {
+        const date = new Date("2021-02-08");
+        const data = getOnInputKeyDownStuff({
+          showWeekPicker: true,
+          selected: date,
+          preSelection: date,
+          excludeDateIntervals: [
+            { start: new Date("2021-01-04"), end: new Date("2021-01-10") },
+          ],
+        });
+
+        fireEvent.keyDown(data.dateInput, getKey("ArrowDown"));
+        fireEvent.keyDown(getSelectedDayNode(data.instance), getKey("PageUp"));
+        expect(
+          utils.formatDate(data.instance.state.preSelection, data.testFormat),
+        ).toBe(utils.formatDate(new Date("2021-01-15"), data.testFormat));
+      });
+      it("should move to the previous available week after pressing PageDown to a disabled date", () => {
+        const date = new Date("2021-02-08");
+        const data = getOnInputKeyDownStuff({
+          showWeekPicker: true,
+          selected: date,
+          preSelection: date,
+          excludeDateIntervals: [
+            { start: new Date("2021-03-08"), end: new Date("2021-03-14") },
+          ],
+        });
+
+        fireEvent.keyDown(data.dateInput, getKey("ArrowDown"));
+        fireEvent.keyDown(
+          getSelectedDayNode(data.instance),
+          getKey("PageDown"),
+        );
+        expect(
+          utils.formatDate(data.instance.state.preSelection, data.testFormat),
+        ).toBe(utils.formatDate(new Date("2021-03-01"), data.testFormat));
+      });
+    });
+  });
 });

--- a/test/datepicker_test.test.js
+++ b/test/datepicker_test.test.js
@@ -1056,7 +1056,67 @@ describe("DatePicker", () => {
   });
 
   // excluded stuff
-  it("using keyboard, should not navigate to dates before minDate", () => {
+  it("should skip over excluded date when ArrowRight is pressed", () => {
+    const date = new Date("2024-05-01");
+    const data = getOnInputKeyDownStuff({
+      excludeDates: [new Date("2024-05-02")],
+      selected: date,
+      preSelection: date,
+    });
+
+    fireEvent.keyDown(data.dateInput, getKey("ArrowDown"));
+    fireEvent.keyDown(getSelectedDayNode(data.instance), getKey("ArrowRight"));
+    expect(
+      utils.formatDate(data.instance.state.preSelection, data.testFormat),
+    ).toBe(utils.formatDate(new Date("2024-05-03"), data.testFormat));
+  });
+
+  it("should skip over excluded date when ArrowLeft is pressed", () => {
+    const date = new Date("2024-05-01");
+    const data = getOnInputKeyDownStuff({
+      excludeDates: [new Date("2024-04-30")],
+      selected: date,
+      preSelection: date,
+    });
+
+    fireEvent.keyDown(data.dateInput, getKey("ArrowDown"));
+    fireEvent.keyDown(getSelectedDayNode(data.instance), getKey("ArrowLeft"));
+    expect(
+      utils.formatDate(data.instance.state.preSelection, data.testFormat),
+    ).toBe(utils.formatDate(new Date("2024-04-29"), data.testFormat));
+  });
+
+  it("should skip over excluded date when ArrowUp is pressed", () => {
+    const date = new Date("2024-05-22");
+    const data = getOnInputKeyDownStuff({
+      excludeDates: [new Date("2024-05-15")],
+      selected: date,
+      preSelection: date,
+    });
+
+    fireEvent.keyDown(data.dateInput, getKey("ArrowDown"));
+    fireEvent.keyDown(getSelectedDayNode(data.instance), getKey("ArrowUp"));
+    expect(
+      utils.formatDate(data.instance.state.preSelection, data.testFormat),
+    ).toBe(utils.formatDate(new Date("2024-05-08"), data.testFormat));
+  });
+
+  it("should skip over excluded date when ArrowDown is pressed", () => {
+    const date = new Date("2024-05-08");
+    const data = getOnInputKeyDownStuff({
+      excludeDates: [new Date("2024-05-15")],
+      selected: date,
+      preSelection: date,
+    });
+
+    fireEvent.keyDown(data.dateInput, getKey("ArrowDown"));
+    fireEvent.keyDown(getSelectedDayNode(data.instance), getKey("ArrowDown"));
+    expect(
+      utils.formatDate(data.instance.state.preSelection, data.testFormat),
+    ).toBe(utils.formatDate(new Date("2024-05-22"), data.testFormat));
+  });
+
+  it("using keyboard, should not navigate to dates before minDate with ArrowLeft", () => {
     const date = new Date("2024-05-01");
     const data = getOnInputKeyDownStuff({
       minDate: date,
@@ -1071,7 +1131,7 @@ describe("DatePicker", () => {
     ).toBe(utils.formatDate(date, data.testFormat));
   });
 
-  it("using keyboard, should not navigate to dates after maxDate", () => {
+  it("using keyboard, should not navigate to dates after maxDate with ArrowRight", () => {
     const date = new Date("2024-05-01");
     const data = getOnInputKeyDownStuff({
       maxDate: date,
@@ -1084,6 +1144,104 @@ describe("DatePicker", () => {
     expect(
       utils.formatDate(data.instance.state.preSelection, data.testFormat),
     ).toBe(utils.formatDate(date, data.testFormat));
+  });
+
+  it("using keyboard, should not navigate to dates before minDate with PageUp and Home", () => {
+    const date = new Date("2024-05-01");
+    const data = getOnInputKeyDownStuff({
+      minDate: date,
+      selected: date,
+      preSelection: date,
+    });
+
+    fireEvent.keyDown(data.dateInput, getKey("ArrowDown"));
+    fireEvent.keyDown(getSelectedDayNode(data.instance), getKey("PageUp"));
+    expect(
+      utils.formatDate(data.instance.state.preSelection, data.testFormat),
+    ).toBe(utils.formatDate(date, data.testFormat));
+    fireEvent.keyDown(getSelectedDayNode(data.instance), getKey("Home"));
+    expect(
+      utils.formatDate(data.instance.state.preSelection, data.testFormat),
+    ).toBe(utils.formatDate(date, data.testFormat));
+  });
+
+  it("using keyboard, with PageUp pressed, should navigate to the date after the excluded date", () => {
+    const date = new Date("2024-05-01");
+    const data = getOnInputKeyDownStuff({
+      excludeDates: [new Date("2024-04-01")],
+      selected: date,
+      preSelection: date,
+    });
+
+    fireEvent.keyDown(data.dateInput, getKey("ArrowDown"));
+    fireEvent.keyDown(getSelectedDayNode(data.instance), getKey("PageUp"));
+    expect(
+      utils.formatDate(data.instance.state.preSelection, data.testFormat),
+    ).toBe(utils.formatDate(new Date("2024-04-02"), data.testFormat));
+  });
+
+  it("using keyboard, with Home pressed, should navigate to the date after the excluded date", () => {
+    const date = new Date("2024-05-11");
+    const data = getOnInputKeyDownStuff({
+      excludeDates: [new Date("2024-05-05")],
+      selected: date,
+      preSelection: date,
+    });
+
+    fireEvent.keyDown(data.dateInput, getKey("ArrowDown"));
+    fireEvent.keyDown(getSelectedDayNode(data.instance), getKey("Home"));
+    expect(
+      utils.formatDate(data.instance.state.preSelection, data.testFormat),
+    ).toBe(utils.formatDate(new Date("2024-05-06"), data.testFormat));
+  });
+
+  it("using keyboard, should not navigate to dates after maxDate with PageDown and End", () => {
+    const date = new Date("2024-05-01");
+    const data = getOnInputKeyDownStuff({
+      maxDate: date,
+      selected: date,
+      preSelection: date,
+    });
+
+    fireEvent.keyDown(data.dateInput, getKey("ArrowDown"));
+    fireEvent.keyDown(getSelectedDayNode(data.instance), getKey("PageDown"));
+    expect(
+      utils.formatDate(data.instance.state.preSelection, data.testFormat),
+    ).toBe(utils.formatDate(date, data.testFormat));
+    fireEvent.keyDown(getSelectedDayNode(data.instance), getKey("End"));
+    expect(
+      utils.formatDate(data.instance.state.preSelection, data.testFormat),
+    ).toBe(utils.formatDate(date, data.testFormat));
+  });
+
+  it("using keyboard, with PageDown pressed, should navigate to the date before the excluded date", () => {
+    const date = new Date("2024-05-01");
+    const data = getOnInputKeyDownStuff({
+      excludeDates: [new Date("2024-06-01")],
+      selected: date,
+      preSelection: date,
+    });
+
+    fireEvent.keyDown(data.dateInput, getKey("ArrowDown"));
+    fireEvent.keyDown(getSelectedDayNode(data.instance), getKey("PageDown"));
+    expect(
+      utils.formatDate(data.instance.state.preSelection, data.testFormat),
+    ).toBe(utils.formatDate(new Date("2024-05-31"), data.testFormat));
+  });
+
+  it("using keyboard, with End pressed, should navigate to the date before the excluded date", () => {
+    const date = new Date("2024-05-05");
+    const data = getOnInputKeyDownStuff({
+      excludeDates: [new Date("2024-05-11")],
+      selected: date,
+      preSelection: date,
+    });
+
+    fireEvent.keyDown(data.dateInput, getKey("ArrowDown"));
+    fireEvent.keyDown(getSelectedDayNode(data.instance), getKey("End"));
+    expect(
+      utils.formatDate(data.instance.state.preSelection, data.testFormat),
+    ).toBe(utils.formatDate(new Date("2024-05-10"), data.testFormat));
   });
 
   it("should call onMonthChange when keyboard navigation moves preSelection to different month", () => {

--- a/test/datepicker_test.test.js
+++ b/test/datepicker_test.test.js
@@ -1054,6 +1054,38 @@ describe("DatePicker", () => {
       utils.formatDate(data.instance.state.preSelection, data.testFormat),
     ).toBe(utils.formatDate(data.copyM, data.testFormat));
   });
+
+  // excluded stuff
+  it("using keyboard, should not navigate to dates before minDate", () => {
+    const date = new Date("2024-05-01");
+    const data = getOnInputKeyDownStuff({
+      minDate: date,
+      selected: date,
+      preSelection: date,
+    });
+
+    fireEvent.keyDown(data.dateInput, getKey("ArrowDown"));
+    fireEvent.keyDown(getSelectedDayNode(data.instance), getKey("ArrowLeft"));
+    expect(
+      utils.formatDate(data.instance.state.preSelection, data.testFormat),
+    ).toBe(utils.formatDate(date, data.testFormat));
+  });
+
+  it("using keyboard, should not navigate to dates after maxDate", () => {
+    const date = new Date("2024-05-01");
+    const data = getOnInputKeyDownStuff({
+      maxDate: date,
+      selected: date,
+      preSelection: date,
+    });
+
+    fireEvent.keyDown(data.dateInput, getKey("ArrowDown"));
+    fireEvent.keyDown(getSelectedDayNode(data.instance), getKey("ArrowRight"));
+    expect(
+      utils.formatDate(data.instance.state.preSelection, data.testFormat),
+    ).toBe(utils.formatDate(date, data.testFormat));
+  });
+
   it("should call onMonthChange when keyboard navigation moves preSelection to different month", () => {
     const onMonthChangeSpy = jest.fn();
     const opts = { onMonthChange: onMonthChangeSpy };

--- a/test/month_test.test.js
+++ b/test/month_test.test.js
@@ -2034,6 +2034,120 @@ describe("Month", () => {
         `Can't select this January 2015`,
       );
     });
+
+    it("should skip over excluded date from all 4 directions", () => {
+      const excludeDates = [utils.newDate("2015-08-01")];
+      let preSelected = false;
+      const setPreSelection = (param) => {
+        preSelected = param;
+      };
+
+      const monthComponent = renderMonth({
+        selected: utils.newDate("2015-07-01"),
+        day: utils.newDate("2015-07-01"),
+        setPreSelection: setPreSelection,
+        preSelection: utils.newDate("2015-08-01"),
+        minDate: utils.newDate("2015-03-01"),
+        maxDate: utils.newDate("2015-12-01"),
+        excludeDates,
+      });
+
+      fireEvent.keyDown(
+        monthComponent.querySelector(".react-datepicker__month-7"),
+        getKey("ArrowRight"),
+      );
+
+      expect(preSelected.toString()).toBe(
+        utils.newDate("2015-09-01").toString(),
+      );
+
+      fireEvent.keyDown(
+        monthComponent.querySelector(".react-datepicker__month-9"),
+        getKey("ArrowLeft"),
+      );
+
+      expect(preSelected.toString()).toBe(
+        utils.newDate("2015-07-01").toString(),
+      );
+
+      fireEvent.keyDown(
+        monthComponent.querySelector(".react-datepicker__month-7"),
+        getKey("ArrowUp"),
+      );
+
+      fireEvent.keyDown(
+        monthComponent.querySelector(".react-datepicker__month-4"),
+        getKey("ArrowRight"),
+      );
+
+      fireEvent.keyDown(
+        monthComponent.querySelector(".react-datepicker__month-5"),
+        getKey("ArrowDown"),
+      );
+
+      expect(preSelected.toString()).toBe(
+        utils.newDate("2015-11-01").toString(),
+      );
+
+      fireEvent.keyDown(
+        monthComponent.querySelector(".react-datepicker__month-11"),
+        getKey("ArrowUp"),
+      );
+
+      expect(preSelected.toString()).toBe(
+        utils.newDate("2015-05-01").toString(),
+      );
+    });
+
+    it("should prevent navigation when cursor is next to minimum date and the left arrow is pressed", () => {
+      let preSelected = utils.newDate("2015-04-01");
+      const setPreSelection = (param) => {
+        preSelected = param;
+      };
+
+      const monthComponent = renderMonth({
+        selected: utils.newDate("2015-03-01"),
+        day: utils.newDate("2015-03-01"),
+        setPreSelection: setPreSelection,
+        preSelection: preSelected,
+        minDate: utils.newDate("2015-03-01"),
+        maxDate: utils.newDate("2015-08-01"),
+      });
+
+      fireEvent.keyDown(
+        monthComponent.querySelector(".react-datepicker__month-3"),
+        getKey("ArrowLeft"),
+      );
+
+      expect(preSelected.toString()).toBe(
+        utils.newDate("2015-03-01").toString(),
+      );
+    });
+
+    it("should prevent navigation when cursor is next to maximum date and right arrow is pressed", () => {
+      let preSelected = utils.newDate("2015-08-01");
+      const setPreSelection = (param) => {
+        preSelected = param;
+      };
+
+      const monthComponent = renderMonth({
+        selected: utils.newDate("2015-08-01"),
+        day: utils.newDate("2015-08-01"),
+        setPreSelection: setPreSelection,
+        preSelection: preSelected,
+        minDate: utils.newDate("2015-03-01"),
+        maxDate: utils.newDate("2015-08-01"),
+      });
+
+      fireEvent.keyDown(
+        monthComponent.querySelector(".react-datepicker__month-8"),
+        getKey("ArrowRight"),
+      );
+
+      expect(preSelected.toString()).toBe(
+        utils.newDate("2015-08-01").toString(),
+      );
+    });
   });
 
   describe("if keyboard navigation is disabled", () => {

--- a/test/month_test.test.js
+++ b/test/month_test.test.js
@@ -1180,6 +1180,33 @@ describe("Month", () => {
     const renderQuarters = (props) =>
       render(<Month showQuarterYearPicker {...props} />).container;
 
+    it("should select Q2 when pressing Enter", () => {
+      let preSelected = false;
+      const setPreSelection = (param) => {
+        preSelected = param;
+      };
+
+      const quartersComponent = renderQuarters({
+        selected: utils.newDate("2015-04-01"),
+        day: utils.newDate("2015-04-01"),
+        setPreSelection: setPreSelection,
+        preSelection: utils.newDate("2015-04-01"),
+      });
+      fireEvent.keyDown(
+        quartersComponent.querySelector(".react-datepicker__quarter-2"),
+        getKey("Tab"),
+      );
+
+      fireEvent.keyDown(
+        quartersComponent.querySelector(".react-datepicker__quarter-2"),
+        getKey("Enter"),
+      );
+
+      expect(preSelected.toString()).toBe(
+        utils.newDate("2015-04-01").toString(),
+      );
+    });
+
     it("should trigger setPreSelection and set Q3 as pre-selected on arrowRight", () => {
       let preSelected = false;
       const setPreSelection = (param) => {

--- a/test/month_test.test.js
+++ b/test/month_test.test.js
@@ -2035,87 +2035,128 @@ describe("Month", () => {
       );
     });
 
-    it("should skip over excluded date from all 4 directions", () => {
-      const excludeDates = [utils.newDate("2015-08-01")];
-      let preSelected = false;
-      const setPreSelection = (param) => {
-        preSelected = param;
-      };
+    describe("skip over excluded dates", () => {
+      it("should skip over excluded date when pressed arrow right", () => {
+        const excludeDates = [utils.newDate("2015-08-01")];
+        let preSelected = false;
+        const setPreSelection = (param) => {
+          preSelected = param;
+        };
+        const selected = utils.newDate("2015-07-01");
 
-      const monthComponent = renderMonth({
-        selected: utils.newDate("2015-07-01"),
-        day: utils.newDate("2015-07-01"),
-        setPreSelection: setPreSelection,
-        preSelection: utils.newDate("2015-08-01"),
-        minDate: utils.newDate("2015-03-01"),
-        maxDate: utils.newDate("2015-12-01"),
-        excludeDates,
+        const monthComponent = renderMonth({
+          selected,
+          day: selected,
+          setPreSelection,
+          preSelection: selected,
+          excludeDates,
+        });
+
+        fireEvent.keyDown(
+          monthComponent.querySelector(".react-datepicker__month-6"),
+          getKey("ArrowRight"),
+        );
+
+        expect(preSelected.toString()).toBe(
+          utils.newDate("2015-09-01").toString(),
+        );
       });
 
-      fireEvent.keyDown(
-        monthComponent.querySelector(".react-datepicker__month-7"),
-        getKey("ArrowRight"),
-      );
+      it("should skip over excluded date when pressed arrow left", () => {
+        const excludeDates = [utils.newDate("2015-08-01")];
+        let preSelected = false;
+        const setPreSelection = (param) => {
+          preSelected = param;
+        };
+        const selected = utils.newDate("2015-09-01");
 
-      expect(preSelected.toString()).toBe(
-        utils.newDate("2015-09-01").toString(),
-      );
+        const monthComponent = renderMonth({
+          selected,
+          day: selected,
+          setPreSelection,
+          preSelection: selected,
+          excludeDates,
+        });
 
-      fireEvent.keyDown(
-        monthComponent.querySelector(".react-datepicker__month-9"),
-        getKey("ArrowLeft"),
-      );
+        fireEvent.keyDown(
+          monthComponent.querySelector(".react-datepicker__month-8"),
+          getKey("ArrowLeft"),
+        );
 
-      expect(preSelected.toString()).toBe(
-        utils.newDate("2015-07-01").toString(),
-      );
+        expect(preSelected.toString()).toBe(
+          utils.newDate("2015-07-01").toString(),
+        );
+      });
 
-      fireEvent.keyDown(
-        monthComponent.querySelector(".react-datepicker__month-7"),
-        getKey("ArrowUp"),
-      );
+      it("should skip over excluded date when pressed arrow up", () => {
+        const excludeDates = [utils.newDate("2015-08-01")];
+        let preSelected = false;
+        const setPreSelection = (param) => {
+          preSelected = param;
+        };
+        const selected = utils.newDate("2015-11-01");
 
-      fireEvent.keyDown(
-        monthComponent.querySelector(".react-datepicker__month-4"),
-        getKey("ArrowRight"),
-      );
+        const monthComponent = renderMonth({
+          selected,
+          day: selected,
+          setPreSelection,
+          preSelection: selected,
+          excludeDates,
+        });
 
-      fireEvent.keyDown(
-        monthComponent.querySelector(".react-datepicker__month-5"),
-        getKey("ArrowDown"),
-      );
+        fireEvent.keyDown(
+          monthComponent.querySelector(".react-datepicker__month-10"),
+          getKey("ArrowUp"),
+        );
 
-      expect(preSelected.toString()).toBe(
-        utils.newDate("2015-11-01").toString(),
-      );
+        expect(preSelected.toString()).toBe(
+          utils.newDate("2015-05-01").toString(),
+        );
+      });
 
-      fireEvent.keyDown(
-        monthComponent.querySelector(".react-datepicker__month-11"),
-        getKey("ArrowUp"),
-      );
+      it("should skip over excluded date when pressed arrow down", () => {
+        const excludeDates = [utils.newDate("2015-08-01")];
+        let preSelected = false;
+        const setPreSelection = (param) => {
+          preSelected = param;
+        };
+        const selected = utils.newDate("2015-05-01");
 
-      expect(preSelected.toString()).toBe(
-        utils.newDate("2015-05-01").toString(),
-      );
+        const monthComponent = renderMonth({
+          selected,
+          day: selected,
+          setPreSelection,
+          preSelection: selected,
+          excludeDates,
+        });
+
+        fireEvent.keyDown(
+          monthComponent.querySelector(".react-datepicker__month-4"),
+          getKey("ArrowDown"),
+        );
+
+        expect(preSelected.toString()).toBe(
+          utils.newDate("2015-11-01").toString(),
+        );
+      });
     });
 
     it("should prevent navigation when cursor is next to minimum date and the left arrow is pressed", () => {
-      let preSelected = utils.newDate("2015-04-01");
+      let preSelected = utils.newDate("2015-03-01");
       const setPreSelection = (param) => {
         preSelected = param;
       };
 
       const monthComponent = renderMonth({
-        selected: utils.newDate("2015-03-01"),
+        selected: preSelected,
         day: utils.newDate("2015-03-01"),
         setPreSelection: setPreSelection,
         preSelection: preSelected,
         minDate: utils.newDate("2015-03-01"),
-        maxDate: utils.newDate("2015-08-01"),
       });
 
       fireEvent.keyDown(
-        monthComponent.querySelector(".react-datepicker__month-3"),
+        monthComponent.querySelector(".react-datepicker__month-2"),
         getKey("ArrowLeft"),
       );
 

--- a/test/month_test.test.js
+++ b/test/month_test.test.js
@@ -1176,7 +1176,7 @@ describe("Month", () => {
     });
   });
 
-  describe("Keyboard navigation", () => {
+  describe("Quarters keyboard navigation", () => {
     const renderQuarters = (props) =>
       render(<Month showQuarterYearPicker {...props} />).container;
 
@@ -2164,6 +2164,33 @@ describe("Month", () => {
 
         expect(preSelected.toString()).toBe(
           utils.newDate("2015-11-01").toString(),
+        );
+      });
+
+      it("should not navigate to any date when all dates are disabled (edge case)", () => {
+        const date = utils.newDate("2015-05-01");
+        let preSelected = false;
+        const setPreSelection = (param) => {
+          preSelected = param;
+        };
+
+        const monthComponent = renderMonth({
+          selected: date,
+          day: date,
+          setPreSelection,
+          preSelection: date,
+          minDate: date,
+          maxDate: date,
+          excludeDates: [date],
+        });
+
+        fireEvent.keyDown(
+          monthComponent.querySelector(".react-datepicker__month-4"),
+          getKey("ArrowDown"),
+        );
+
+        expect(preSelected.toString()).toBe(
+          utils.newDate("2015-05-01").toString(),
         );
       });
     });


### PR DESCRIPTION
---
name: Allow for skipping of excluded dates/weeks/months
about: Create a pull request to improve this repository
title: Allow for skipping of excluded dates/weeks/months
labels: ""
assignees: ""
---

## Description
**Linked issue**: #4731 

**Problem**
Currently, the date picker only stops when the user is about to navigate to an excluded month, which, if let's say there are multiple disabled dates side by side spanning the whole row, the user is unable to navigate to the months after it. This only happens on the month picker.

![image](https://github.com/Hacker0x01/react-datepicker/assets/49902829/ab8f2657-4187-4a05-ad0c-d4813cff8785)

**Changes**
I have made recursive functions in the keydown functionality of the month and day calendar to get a new day/month if the date is disabled/excluded. Even though this is only a month picker thing, I have changed the behavior of the day calendar as well to make it consistent.

## Screenshots

**Day**

https://github.com/Hacker0x01/react-datepicker/assets/49902829/5637ad57-2773-4d69-ba58-a9714167bfed

**Week**

https://github.com/Hacker0x01/react-datepicker/assets/49902829/ccae4796-7db5-4292-b552-52cc5c74cb72

**Month**

https://github.com/Hacker0x01/react-datepicker/assets/49902829/54e07d27-1298-4562-a337-f03ab33c6675

## To reviewers
If this behavior should be made optional, please let me know

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
