### PR TITLE
Fix #4844: 🔨 Retain the open state of the calendar popup on document visibility change

### DIFF
--- a/test/datepicker_test.test.tsx
+++ b/test/datepicker_test.test.tsx
@@ -68,9 +68,60 @@ function formatDayWithZeros(day) {
   return dayString;
 }
 
+const hideDocument = (calendarInput) => {
+  jest.spyOn(document, "visibilityState", "get").mockReturnValue("hidden");
+  fireEvent(document, new Event("visibilitychange"));
+  // Blur, To simulate the browser auto-blur the input before document hide
+  fireEvent.blur(calendarInput);
+};
+
+const showDocument = (calendarInput) => {
+  jest.spyOn(document, "visibilityState", "get").mockReturnValue("visible");
+  fireEvent(document, new Event("visibilitychange"));
+  // Focus, To simulate the browser auto-refocus of the input
+  fireEvent.focus(calendarInput);
+};
+
 describe("DatePicker", () => {
   afterEach(() => {
     jest.resetAllMocks();
+  });
+
+  it("should retain the calendar open status when the document visibility change", () => {
+    const { container } = render(<DatePicker />);
+    const input = container.querySelector("input");
+
+    if (!input) {
+      throw new Error("Input element not found");
+    }
+
+    fireEvent.click(input);
+    expect(container.querySelector(".react-datepicker")).toBeTruthy();
+
+    hideDocument(input);
+    showDocument(input);
+
+    expect(container.querySelector(".react-datepicker")).toBeTruthy();
+  });
+
+  it("should retain the calendar close status when the document visibility change", () => {
+    const { container } = render(<DatePicker />);
+    const input = container.querySelector("input");
+
+    if (!input) {
+      throw new Error("Input element not found");
+    }
+
+    fireEvent.click(input);
+    expect(container.querySelector(".react-datepicker")).toBeTruthy();
+
+    fireEvent.keyDown(input, getKey(KeyType.Escape));
+    expect(container.querySelector(".react-datepicker")).toBeFalsy();
+
+    hideDocument(input);
+    showDocument(input);
+
+    expect(container.querySelector(".react-datepicker")).toBeFalsy();
   });
 
   it("should show the calendar when focusing on the date input", () => {


### PR DESCRIPTION
Closes #4844 

## Description
Retain the open state of the calendar popup on document visibility change.

**Problem**
As mentioned in the issue description, the calendar gets auto-reopen whenever we switch the browser tab and switch back to the original tab in any of the below 2 cases

1. Switching the browser tab after we enter the date manually into the calendar input by dismissing the calendar popup
2. Switching the tab immediately after selecting any date via calendar popup (In this case, we could have blurred focus from the input, but when I inspect the code, we intentionally refocus the calendar input, upon selection of any date from the calendar popup as a fix for the issue https://github.com/Hacker0x01/react-datepicker/issues/628)

In any of the above cases the input is focused while switching the browser tab and when we switch back to the original tab, the browser refocus the calendar input, which will trigger our `handleFocus` handler in our code and we open the calendar popup regardless of it's previous open state

**Changes**
As a fix, I listened for the `visibilitychange` event and note whenever the tab gots hidden.  Whenever the input gets refocused, if it gets auto re-focused because of the browser `visibilitychange`, I used the previous open state to decide whether to re-open the calendar popup or not.  

- This fix helps us to keep the calendar open, when it was opened before the browser tab switch
- This fix also helps us to avoid re-open the calendar popup unnecessarily when it doesn't get opened before the browser tab switch

Basically the solution I suggested helps to retain the previous open state of the calendar popup whenever the browser gets re-opened.

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
