### PR TITLE
feat: export CalendarContainerProps interface

### DIFF
--- a/src/calendar_container.tsx
+++ b/src/calendar_container.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-interface CalendarContainerProps extends React.PropsWithChildren {
+export interface CalendarContainerProps extends React.PropsWithChildren {
   showTimeSelectOnly?: boolean;
   showTime?: boolean;
   className?: string;


### PR DESCRIPTION
The `CalendarContainerProps` interface is now exported, allowing other modules to import and use it.

**Problem**
CalendarContainerProps wasn't exported 

**Changes**
Export the interface

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [ ] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
