### PR TITLE
Add multiple months visual selection

### DIFF
--- a/docs-site/src/components/Examples/index.js
+++ b/docs-site/src/components/Examples/index.js
@@ -104,6 +104,7 @@ import CalendarStartDay from "../../examples/calendarStartDay";
 import ExternalForm from "../../examples/externalForm";
 import CalendarIcon from "../../examples/calendarIcon";
 import SelectsMultiple from "../../examples/selectsMultiple";
+import SelectsMultipleMonths from "../../examples/selectsMultipleMonths";
 import CalendarIconExternal from "../../examples/calendarIconExternal";
 import CalendarIconSvgIcon from "../../examples/calendarIconSvgIcon";
 import ToggleCalendarOnIconClick from "../../examples/toggleCalendarOnIconClick";
@@ -501,6 +502,10 @@ export default class exampleComponents extends React.Component {
     {
       title: "Select multiple dates",
       component: SelectsMultiple,
+    },
+    {
+      title: "Select multiple months",
+      component: SelectsMultipleMonths,
     },
     {
       title: "Strict parsing",

--- a/docs-site/src/examples/selectsMultipleMonths.js
+++ b/docs-site/src/examples/selectsMultipleMonths.js
@@ -1,0 +1,17 @@
+() => {
+  const [selectedDates, setSelectedDates] = useState([new Date()]);
+  const onChange = (dates) => {
+    setSelectedDates(dates);
+  };
+  return (
+    <DatePicker
+      selectedDates={selectedDates}
+      selectsMultiple
+      showMonthYearPicker
+      show
+      onChange={onChange}
+      shouldCloseOnSelect={false}
+      disabledKeyboardNavigation
+    />
+  );
+};

--- a/src/month.tsx
+++ b/src/month.tsx
@@ -403,6 +403,11 @@ export default class Month extends Component<MonthProps> {
   isSelectedMonth = (day: Date, m: number, selected: Date) =>
     getMonth(selected) === m && getYear(day) === getYear(selected);
 
+  isSelectMonthInList = (day: Date, m: number, selectedDates: Date[]) =>
+    selectedDates.some((selectedDate) =>
+      this.isSelectedMonth(day, m, selectedDate),
+    );
+
   isSelectedQuarter = (day: Date, q: number, selected: Date): boolean =>
     getQuarter(day) === q && getYear(day) === getYear(selected);
 
@@ -779,20 +784,37 @@ export default class Month extends Component<MonthProps> {
     return isDisabled;
   };
 
+  getSelection() {
+    const { selected, selectedDates, selectsMultiple } = this.props;
+
+    if (selectsMultiple) {
+      return selectedDates;
+    }
+
+    if (selected) {
+      return [selected];
+    }
+
+    return undefined;
+  }
+
   getMonthClassNames = (m: number) => {
-    const { day, startDate, endDate, selected, preSelection, monthClassName } =
+    const { day, startDate, endDate, preSelection, monthClassName } =
       this.props;
     const _monthClassName = monthClassName
       ? monthClassName(setMonth(day, m))
       : undefined;
+
+    const selection = this.getSelection();
+
     return clsx(
       "react-datepicker__month-text",
       `react-datepicker__month-${m}`,
       _monthClassName,
       {
         "react-datepicker__month-text--disabled": this.isMonthDisabled(m),
-        "react-datepicker__month-text--selected": selected
-          ? this.isSelectedMonth(day, m, selected)
+        "react-datepicker__month-text--selected": selection
+          ? this.isSelectMonthInList(day, m, selection)
           : undefined,
         "react-datepicker__month-text--keyboard-selected":
           !this.props.disabledKeyboardNavigation &&

--- a/src/test/month_test.test.tsx
+++ b/src/test/month_test.test.tsx
@@ -924,6 +924,52 @@ describe("Month", () => {
     it("should have no axe violations", () => runAxe(monthComponent));
   });
 
+  describe("if 2 months are selected in a multi selection", () => {
+    let monthComponent: HTMLElement;
+
+    beforeEach(() => {
+      monthComponent = render(
+        <Month
+          day={newDate("2015-02-01")}
+          selectedDates={[newDate("2015-02-01"), newDate("2015-03-01")]}
+          selectsMultiple
+          showMonthYearPicker
+        />,
+      ).container;
+    });
+
+    it("should return 2 selected classes in the current year", () => {
+      expect(
+        monthComponent.querySelectorAll<HTMLElement>(
+          ".react-datepicker__month-text--selected",
+        ).length,
+      ).toBe(2);
+    });
+  });
+
+  describe("if no months are selected in a multi selection", () => {
+    let monthComponent: HTMLElement;
+
+    beforeEach(() => {
+      monthComponent = render(
+        <Month
+          day={newDate("2015-02-01")}
+          selectedDates={[]}
+          selectsMultiple
+          showMonthYearPicker
+        />,
+      ).container;
+    });
+
+    it("should return 0 selected classes in the current year", () => {
+      expect(
+        monthComponent.querySelectorAll<HTMLElement>(
+          ".react-datepicker__month-text--selected",
+        ).length,
+      ).toBe(0);
+    });
+  });
+
   describe("if month is not selected", () => {
     let month: HTMLElement;
 


### PR DESCRIPTION
## Description
Currently there's a `selectsMultiple` flag that enables the pick of multiple dates, yet the selection styles for when applied together with `showMonthYearPicker` was never implemented.

**Problem**
Current behaviour upon selecting multiple months:

<img width="273" alt="Screenshot 2024-06-28 at 08 54 03" src="https://github.com/Hacker0x01/react-datepicker/assets/26875009/85f1fc08-c7e3-487e-b7f6-6a23a376a53a">


**Changes**
This is a simple change that adds the missing selected class (`react-datepicker__month-text--selected`) to the scenario of having `selectsMultiple` & `showMonthYearPicker` flags enabled

<img width="317" alt="Screenshot 2024-06-28 at 08 44 37" src="https://github.com/Hacker0x01/react-datepicker/assets/26875009/4fdde03a-0d06-4a16-a3dd-00f09195a4a5">


## Screenshots
<!-- If applicable, add screenshots to help explain your improvements -->

## To reviewers
<!-- Additional comments for reviewers -->

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
