### PR TITLE
Implemented a one-click toggle for the custom time input bar

### DIFF
--- a/docs-site/src/examples/customTimeInput.js
+++ b/docs-site/src/examples/customTimeInput.js
@@ -1,12 +1,20 @@
 () => {
   const [startDate, setStartDate] = useState(new Date());
-  const ExampleCustomTimeInput = ({ date, value, onChange }) => (
-    <input
-      value={value}
-      onChange={(e) => onChange(e.target.value)}
-      style={{ border: "solid 1px pink" }}
-    />
-  );
+  const ExampleCustomTimeInput = ({ date, value, onChange }) => {
+    const handleInputClick = () => {
+      inputRef.current.focus();
+    };
+    const inputRef = React.createRef(); 
+    return (
+      <input
+        ref={inputRef}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onClick={handleInputClick}
+        style={{ border: "solid 1px pink" }}
+      />
+    );
+  };
   return (
     <DatePicker
       selected={startDate}

--- a/docs-site/src/examples/customTimeInput.js
+++ b/docs-site/src/examples/customTimeInput.js
@@ -4,7 +4,7 @@
     const handleInputClick = () => {
       inputRef.current.focus();
     };
-    const inputRef = React.createRef(); 
+    const inputRef = React.createRef();
     return (
       <input
         ref={inputRef}

--- a/src/calendar.tsx
+++ b/src/calendar.tsx
@@ -487,7 +487,8 @@ export default class Calendar extends Component<CalendarProps, CalendarState> {
         date: subYears(
           date,
           this.props.showYearPicker
-            ? this.props.yearItemNumber ?? Calendar.defaultProps.yearItemNumber
+            ? (this.props.yearItemNumber ??
+                Calendar.defaultProps.yearItemNumber)
             : 1,
         ),
       }),
@@ -601,7 +602,8 @@ export default class Calendar extends Component<CalendarProps, CalendarState> {
         date: addYears(
           date,
           this.props.showYearPicker
-            ? this.props.yearItemNumber ?? Calendar.defaultProps.yearItemNumber
+            ? (this.props.yearItemNumber ??
+                Calendar.defaultProps.yearItemNumber)
             : 1,
         ),
       }),

--- a/src/time.tsx
+++ b/src/time.tsx
@@ -256,7 +256,7 @@ export default class Time extends Component<TimeProps, TimeState> {
     return (
       <div
         className={`react-datepicker__time-container ${
-          this.props.todayButton ?? Time.defaultProps.todayButton
+          (this.props.todayButton ?? Time.defaultProps.todayButton)
             ? "react-datepicker__time-container--with-today-button"
             : ""
         }`}


### PR DESCRIPTION
---
name: “Fix time input focus issue”

about: The time input in the "Custom time input" example does not focus when clicked on for the first time. It requires two clicks to focus.

title: "Custom time input needs 2 clicks to focus"

labels: ""

assignees: "@martijnrusschen"
---

## Description
**Linked issue**: #4949  

**Problem**
The time input in the “Custom time input” example does not focus when clicked on for the first time. It requires two clicks to focus.

**Changes**
I have fixed the issue by ensuring that the time input is focused on the first click.

## Screenshots

![Screenshot (22)](https://github.com/Hacker0x01/react-datepicker/assets/165433038/3da42211-3333-4c97-a349-cb3acb76c420)
In the right side when we click the time input bar, I have ensured that the time input is focused on the first click.

## To reviewers
<!-- Additional comments for reviewers -->

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
