### PR TITLE
Remove usages of react-onclickoutside to support React 19

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@types/eslint": "^8.56.10",
     "@types/jest": "^29.5.12",
     "@types/node": "20",
-    "@types/react-onclickoutside": "^6.7.10",
     "@typescript-eslint/eslint-plugin": "^7.9.0",
     "@typescript-eslint/parser": "^7.9.0",
     "axe-core": "^4.4.1",
@@ -83,8 +82,7 @@
     "@floating-ui/react": "^0.26.2",
     "clsx": "^2.1.0",
     "date-fns": "^3.3.1",
-    "prop-types": "^15.7.2",
-    "react-onclickoutside": "^6.13.0"
+    "prop-types": "^15.7.2"
   },
   "scripts": {
     "eslint": "eslint --ext .js,.jsx,.ts,.tsx ./src",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -46,7 +46,6 @@ const dateFnsSubpackages = Object.keys(dateFnsPackageJson.exports)
 const globals = {
   react: "React",
   "prop-types": "PropTypes",
-  "react-onclickoutside": "onClickOutside",
 };
 
 // NOTE:https://rollupjs.org/migration/#changed-defaults

--- a/src/@types/react-onclickoutside/index.d.ts
+++ b/src/@types/react-onclickoutside/index.d.ts
@@ -1,8 +1,0 @@
-import type { findDOMNode } from "react-dom";
-
-declare module "react-onclickoutside" {
-  // eslint-disable-next-line unused-imports/no-unused-vars
-  interface WrapperInstance<P, C> {
-    componentNode: ReturnType<typeof findDOMNode>;
-  }
-}

--- a/src/calendar.tsx
+++ b/src/calendar.tsx
@@ -2,6 +2,7 @@ import { clsx } from "clsx";
 import React, { Component, createRef } from "react";
 
 import CalendarContainer from "./calendar_container";
+import { ClickOutsideWrapper } from "./click_outside_wrapper";
 import {
   newDate,
   setMonth,
@@ -48,6 +49,7 @@ import Time from "./time";
 import Year from "./year";
 import YearDropdown from "./year_dropdown";
 
+import type { ClickOutsideHandler } from "./click_outside_wrapper";
 import type { Day } from "date-fns/types";
 
 interface YearDropdownProps
@@ -154,7 +156,8 @@ type CalendarProps = React.PropsWithChildren &
     onDayMouseEnter?: (date: Date) => void;
     onMonthMouseLeave?: VoidFunction;
     weekLabel?: string;
-    onClickOutside: React.MouseEventHandler<HTMLElement>;
+    onClickOutside: ClickOutsideHandler;
+    outsideClickIgnoreClass?: string;
     previousMonthButtonLabel?: React.ReactNode;
     previousYearButtonLabel?: string;
     previousMonthAriaLabel?: string;
@@ -279,7 +282,7 @@ export default class Calendar extends Component<CalendarProps, CalendarState> {
 
   assignMonthContainer: void | undefined;
 
-  handleClickOutside = (event: React.MouseEvent<HTMLElement>): void => {
+  handleClickOutside = (event: MouseEvent): void => {
     this.props.onClickOutside(event);
   };
 
@@ -1082,7 +1085,12 @@ export default class Calendar extends Component<CalendarProps, CalendarState> {
   render(): JSX.Element {
     const Container = this.props.container || CalendarContainer;
     return (
-      <div style={{ display: "contents" }} ref={this.containerRef}>
+      <ClickOutsideWrapper
+        onClickOutside={this.handleClickOutside}
+        style={{ display: "contents" }}
+        containerRef={this.containerRef}
+        ignoreClass={this.props.outsideClickIgnoreClass}
+      >
         <Container
           className={clsx("react-datepicker", this.props.className, {
             "react-datepicker--time-only": this.props.showTimeSelectOnly,
@@ -1100,7 +1108,7 @@ export default class Calendar extends Component<CalendarProps, CalendarState> {
           {this.renderInputTimeSection()}
           {this.renderChildren()}
         </Container>
-      </div>
+      </ClickOutsideWrapper>
     );
   }
 }

--- a/src/click_outside_wrapper.tsx
+++ b/src/click_outside_wrapper.tsx
@@ -1,0 +1,69 @@
+import React, { useCallback, useEffect, useRef } from "react";
+
+export type ClickOutsideHandler = (event: MouseEvent) => void;
+
+interface ClickOutsideWrapperProps {
+  onClickOutside: ClickOutsideHandler;
+  className?: string;
+  children: React.ReactNode;
+  containerRef?: React.MutableRefObject<HTMLDivElement | null>;
+  style?: React.CSSProperties;
+  ignoreClass?: string;
+}
+
+const useDetectClickOutside = (
+  onClickOutside: ClickOutsideHandler,
+  ignoreClass?: string,
+) => {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const onClickOutsideRef = useRef(onClickOutside);
+  onClickOutsideRef.current = onClickOutside;
+  const handleClickOutside = useCallback(
+    (event: MouseEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        if (
+          !(
+            ignoreClass &&
+            event.target instanceof HTMLElement &&
+            event.target.classList.contains(ignoreClass)
+          )
+        ) {
+          onClickOutsideRef.current?.(event);
+        }
+      }
+    },
+    [ignoreClass],
+  );
+  useEffect(() => {
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [handleClickOutside]);
+  return ref;
+};
+
+export const ClickOutsideWrapper: React.FC<ClickOutsideWrapperProps> = ({
+  children,
+  onClickOutside,
+  className,
+  containerRef,
+  style,
+  ignoreClass,
+}) => {
+  const detectRef = useDetectClickOutside(onClickOutside, ignoreClass);
+  return (
+    <div
+      className={className}
+      style={style}
+      ref={(node: HTMLDivElement | null) => {
+        detectRef.current = node;
+        if (containerRef) {
+          containerRef.current = node;
+        }
+      }}
+    >
+      {children}
+    </div>
+  );
+};

--- a/src/month_dropdown.tsx
+++ b/src/month_dropdown.tsx
@@ -1,5 +1,4 @@
 import React, { Component } from "react";
-import onClickOutside from "react-onclickoutside";
 
 import {
   getMonthShortInLocale,
@@ -10,8 +9,6 @@ import MonthDropdownOptions from "./month_dropdown_options";
 
 interface MonthDropdownOptionsProps
   extends React.ComponentPropsWithoutRef<typeof MonthDropdownOptions> {}
-
-const WrappedMonthDropdownOptions = onClickOutside(MonthDropdownOptions);
 
 interface MonthDropdownProps
   extends Omit<
@@ -70,7 +67,7 @@ export default class MonthDropdown extends Component<
   );
 
   renderDropdown = (monthNames: string[]): JSX.Element => (
-    <WrappedMonthDropdownOptions
+    <MonthDropdownOptions
       key="dropdown"
       {...this.props}
       monthNames={monthNames}

--- a/src/month_dropdown_options.tsx
+++ b/src/month_dropdown_options.tsx
@@ -1,5 +1,7 @@
 import React, { Component } from "react";
 
+import { ClickOutsideWrapper } from "./click_outside_wrapper";
+
 interface MonthDropdownOptionsProps {
   onCancel: VoidFunction;
   onChange: (month: number) => void;
@@ -40,9 +42,12 @@ export default class MonthDropdownOptions extends Component<MonthDropdownOptions
 
   render(): JSX.Element {
     return (
-      <div className="react-datepicker__month-dropdown">
+      <ClickOutsideWrapper
+        className="react-datepicker__month-dropdown"
+        onClickOutside={this.handleClickOutside}
+      >
         {this.renderOptions()}
-      </div>
+      </ClickOutsideWrapper>
     );
   }
 }

--- a/src/month_year_dropdown.tsx
+++ b/src/month_year_dropdown.tsx
@@ -1,5 +1,4 @@
 import React, { Component } from "react";
-import onClickOutside from "react-onclickoutside";
 
 import {
   addMonths,
@@ -16,10 +15,6 @@ import MonthYearDropdownOptions from "./month_year_dropdown_options";
 
 interface MonthYearDropdownOptionsProps
   extends React.ComponentPropsWithoutRef<typeof MonthYearDropdownOptions> {}
-
-const WrappedMonthYearDropdownOptions = onClickOutside(
-  MonthYearDropdownOptions,
-);
 
 interface MonthYearDropdownProps
   extends Omit<MonthYearDropdownOptionsProps, "onChange" | "onCancel"> {
@@ -96,7 +91,7 @@ export default class MonthYearDropdown extends Component<
   };
 
   renderDropdown = (): JSX.Element => (
-    <WrappedMonthYearDropdownOptions
+    <MonthYearDropdownOptions
       key="dropdown"
       {...this.props}
       onChange={this.onChange}

--- a/src/month_year_dropdown_options.tsx
+++ b/src/month_year_dropdown_options.tsx
@@ -1,6 +1,7 @@
 import { clsx } from "clsx";
 import React, { Component } from "react";
 
+import { ClickOutsideWrapper } from "./click_outside_wrapper";
 import {
   addMonths,
   formatDate,
@@ -103,6 +104,13 @@ export default class MonthYearDropdownOptions extends Component<
         this.props.scrollableMonthYearDropdown,
     });
 
-    return <div className={dropdownClass}>{this.renderOptions()}</div>;
+    return (
+      <ClickOutsideWrapper
+        className={dropdownClass}
+        onClickOutside={this.handleClickOutside}
+      >
+        {this.renderOptions()}
+      </ClickOutsideWrapper>
+    );
   }
 }

--- a/src/test/calendar_test.test.tsx
+++ b/src/test/calendar_test.test.tsx
@@ -2051,9 +2051,7 @@ describe("Calendar", () => {
     it("calls onClickOutside prop when handles click outside", () => {
       const { instance } = renderCalendar();
       act(() => {
-        instance.handleClickOutside(
-          "__event__" as unknown as React.MouseEvent<HTMLElement>,
-        );
+        instance.handleClickOutside("__event__" as unknown as MouseEvent);
       });
 
       expect(clickOutsideSpy).toHaveBeenCalledWith("__event__");
@@ -2185,7 +2183,7 @@ describe("Calendar", () => {
       expect(instance!.input).not.toBeFalsy();
       const dateInput = instance!.input!;
       fireEvent.focus(dateInput);
-      const calendar = instance!.calendar?.getInstance().containerRef.current;
+      const calendar = instance!.calendar?.containerRef.current;
       const navigation = calendar?.querySelector(
         ".react-datepicker__navigation--next",
       );
@@ -2213,7 +2211,7 @@ describe("Calendar", () => {
       expect(instance!.input).not.toBeFalsy();
       const dateInput = instance!.input!;
       fireEvent.focus(dateInput);
-      const calendar = instance!.calendar?.getInstance().containerRef.current;
+      const calendar = instance!.calendar?.containerRef.current;
       expect(calendar).not.toBeFalsy();
       const navigation = calendar!.querySelector(
         ".react-datepicker__navigation--previous",
@@ -2385,7 +2383,7 @@ describe("Calendar", () => {
       fireEvent.focus(dateInput);
 
       expect((instance as DatePicker | null)?.calendar).not.toBeFalsy();
-      const calendar = instance!.calendar!.getInstance().containerRef.current;
+      const calendar = instance!.calendar!.containerRef.current;
       const yearDropdown = calendar?.querySelector(
         ".react-datepicker__year-read-view",
       );
@@ -2406,9 +2404,9 @@ describe("Calendar", () => {
         expect((instance as DatePicker | null)?.calendar).not.toBeFalsy();
         expect(ariaLiveMessage).toBe(
           `${getMonthInLocale(
-            getMonth(instance!.calendar!.getInstance().state.date),
+            getMonth(instance!.calendar!.state.date),
             instance!.props.locale,
-          )} ${getYear(instance!.calendar!.getInstance().state.date)}`,
+          )} ${getYear(instance!.calendar!.state.date)}`,
         );
       });
     });

--- a/src/test/datepicker_test.test.tsx
+++ b/src/test/datepicker_test.test.tsx
@@ -524,9 +524,9 @@ describe("DatePicker", () => {
     expect(anyOtherDay).toBeTruthy();
     fireEvent.click(anyOtherDay!); // will update the preSelection to next or previous day
 
-    const todayBtn = instance!.calendar
-      ?.getInstance()
-      .containerRef.current?.querySelector(".react-datepicker__today-button");
+    const todayBtn = instance!.calendar?.containerRef.current?.querySelector(
+      ".react-datepicker__today-button",
+    );
     expect(anyOtherDay).toBeTruthy();
     fireEvent.click(todayBtn!); // will update the preSelection
 
@@ -1014,9 +1014,9 @@ describe("DatePicker", () => {
     ).not.toBeNull();
     expect(instance!.calendar).toBeDefined();
 
-    const header = instance!.calendar
-      ?.getInstance()
-      .containerRef.current?.querySelector(".react-datepicker__current-month");
+    const header = instance!.calendar?.containerRef.current?.querySelector(
+      ".react-datepicker__current-month",
+    );
 
     expect(header).toBeTruthy();
     fireEvent.click(header!);
@@ -2289,7 +2289,7 @@ describe("DatePicker", () => {
     act(() => {
       instance!.handleCalendarClickOutside({
         preventDefault: jest.fn(),
-      } as unknown as React.MouseEvent<HTMLElement, MouseEvent>);
+      } as unknown as MouseEvent);
     });
     expect(openSpy).toHaveBeenCalledWith(false);
   });
@@ -3295,11 +3295,9 @@ describe("DatePicker", () => {
       expect(instance!.input).toBeTruthy();
       fireEvent.click(instance!.input!);
       const headers =
-        instance!.calendar
-          ?.getInstance()
-          .containerRef.current?.querySelectorAll(
-            ".react-datepicker__header",
-          ) ?? [];
+        instance!.calendar?.containerRef.current?.querySelectorAll(
+          ".react-datepicker__header",
+        ) ?? [];
       expect(headers).toHaveLength(2);
       expect(headers[0]!.textContent).toBe("2023");
       expect(headers[1]!.textContent).toBe("2024");
@@ -3318,11 +3316,9 @@ describe("DatePicker", () => {
       expect(instance!.input).toBeTruthy();
       fireEvent.click(instance!.input!);
       const headersMore =
-        instance!.calendar
-          ?.getInstance()
-          .containerRef.current?.querySelectorAll(
-            ".react-datepicker__header",
-          ) ?? [];
+        instance!.calendar?.containerRef.current?.querySelectorAll(
+          ".react-datepicker__header",
+        ) ?? [];
       expect(headersMore).toHaveLength(4);
       expect(headersMore[0]!.textContent).toBe("2023");
       expect(headersMore[1]!.textContent).toBe("2024");
@@ -3351,11 +3347,9 @@ describe("DatePicker", () => {
       expect(instance!.input).toBeTruthy();
       fireEvent.click(instance!.input!);
       const headers =
-        instance!.calendar
-          ?.getInstance()
-          .containerRef.current?.querySelectorAll(
-            ".react-datepicker__header",
-          ) ?? [];
+        instance!.calendar?.containerRef.current?.querySelectorAll(
+          ".react-datepicker__header",
+        ) ?? [];
       expect(headers).toHaveLength(2);
       expect(headers[0]!.textContent).toBe("2023");
       expect(headers[1]!.textContent).toBe("2024");
@@ -3374,11 +3368,9 @@ describe("DatePicker", () => {
       expect(instance!.input).toBeTruthy();
       fireEvent.click(instance!.input!);
       const headersMore =
-        instance!.calendar
-          ?.getInstance()
-          .containerRef.current?.querySelectorAll(
-            ".react-datepicker__header",
-          ) ?? [];
+        instance!.calendar?.containerRef.current?.querySelectorAll(
+          ".react-datepicker__header",
+        ) ?? [];
       expect(headersMore).toHaveLength(4);
       expect(headersMore[0]!.textContent).toBe("2023");
       expect(headersMore[1]!.textContent).toBe("2024");

--- a/src/test/datepicker_test.test.tsx
+++ b/src/test/datepicker_test.test.tsx
@@ -2293,6 +2293,38 @@ describe("DatePicker", () => {
     });
     expect(openSpy).toHaveBeenCalledWith(false);
   });
+
+  it("should close date picker on outside click", () => {
+    const onClickOutsideSpy = jest.fn();
+    const { container } = render(
+      <div>
+        <span className="testText">test text</span>
+        <DatePicker onClickOutside={onClickOutsideSpy} />
+      </div>,
+    );
+    expect(container.querySelector(".react-datepicker")).toBeNull();
+    fireEvent.focus(container.querySelector("input") ?? new HTMLElement());
+    expect(container.querySelector(".react-datepicker")).not.toBeNull();
+    fireEvent.mouseDown(
+      container.querySelector(".testText") ?? new HTMLElement(),
+    );
+    expect(container.querySelector(".react-datepicker")).toBeNull();
+    expect(onClickOutsideSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not close date picker on input click", () => {
+    const onClickOutsideSpy = jest.fn();
+    const { container } = render(
+      <DatePicker onClickOutside={onClickOutsideSpy} />,
+    );
+    expect(container.querySelector(".react-datepicker")).toBeNull();
+    fireEvent.focus(container.querySelector("input") ?? new HTMLElement());
+    expect(container.querySelector(".react-datepicker")).not.toBeNull();
+    fireEvent.mouseDown(container.querySelector("input") ?? new HTMLElement());
+    expect(container.querySelector(".react-datepicker")).not.toBeNull();
+    expect(onClickOutsideSpy).not.toHaveBeenCalled();
+  });
+
   it("should default to the currently selected date", () => {
     let instance: DatePicker | null = null;
     render(

--- a/src/test/min_time_test.test.tsx
+++ b/src/test/min_time_test.test.tsx
@@ -5,11 +5,15 @@ import DatePicker from "../index";
 
 import type { DatePickerProps } from "../index";
 
+// see https://github.com/microsoft/TypeScript/issues/31501
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type OmitUnion<T, K extends keyof any> = T extends any ? Omit<T, K> : never;
+
 const DatePickerWithState = (
   props: Partial<
     Pick<DatePickerProps, "open" | "selected" | "showTimeSelect" | "dateFormat">
   > &
-    Omit<
+    OmitUnion<
       DatePickerProps,
       | "open"
       | "selected"

--- a/src/test/month_dropdown_test.test.tsx
+++ b/src/test/month_dropdown_test.test.tsx
@@ -3,7 +3,6 @@ import { el } from "date-fns/locale/el";
 import { ru } from "date-fns/locale/ru";
 import { zhCN } from "date-fns/locale/zh-CN";
 import React from "react";
-import onClickOutside from "react-onclickoutside";
 
 import { getMonthInLocale, registerLocale } from "../date_utils";
 import MonthDropdown from "../month_dropdown";
@@ -124,9 +123,8 @@ describe("MonthDropdown", () => {
       const monthNames = range(0, 12).map((M) => getMonthInLocale(M));
 
       const onCancelSpy = jest.fn();
-      const WrappedMonthDropdownOptions = onClickOutside(MonthDropdownOptions);
       render(
-        <WrappedMonthDropdownOptions
+        <MonthDropdownOptions
           onCancel={onCancelSpy}
           onChange={onCancelSpy}
           month={11}
@@ -135,7 +133,7 @@ describe("MonthDropdown", () => {
       );
       fireEvent.mouseDown(document.body);
       fireEvent.touchStart(document.body);
-      expect(onCancelSpy).toHaveBeenCalledTimes(2);
+      expect(onCancelSpy).toHaveBeenCalledTimes(1);
     });
 
     it("does not call the supplied onChange function when the same month is clicked", () => {

--- a/src/test/month_year_dropdown_test.test.tsx
+++ b/src/test/month_year_dropdown_test.test.tsx
@@ -1,7 +1,6 @@
 import { render, fireEvent } from "@testing-library/react";
 import { fi } from "date-fns/locale/fi";
 import React from "react";
-import onClickOutside from "react-onclickoutside";
 
 import {
   newDate,
@@ -116,11 +115,8 @@ describe("MonthYearDropdown", () => {
       const dateFormatCalendar = "LLLL yyyy";
 
       const onCancelSpy = jest.fn();
-      const WrappedMonthYearDropdownOptions = onClickOutside(
-        MonthYearDropdownOptions,
-      );
       render(
-        <WrappedMonthYearDropdownOptions
+        <MonthYearDropdownOptions
           onCancel={onCancelSpy}
           onChange={jest.fn()}
           dateFormat={dateFormatCalendar}
@@ -131,7 +127,7 @@ describe("MonthYearDropdown", () => {
       );
       fireEvent.mouseDown(document.body);
       fireEvent.touchStart(document.body);
-      expect(onCancelSpy).toHaveBeenCalledTimes(2);
+      expect(onCancelSpy).toHaveBeenCalledTimes(1);
     });
 
     it("does not call the supplied onChange function when the same month year is clicked", () => {

--- a/src/test/multiple_selected_dates.test.tsx
+++ b/src/test/multiple_selected_dates.test.tsx
@@ -5,6 +5,10 @@ import DatePicker from "../";
 
 import type { DatePickerProps } from "../index";
 
+// see https://github.com/microsoft/TypeScript/issues/31501
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type OmitUnion<T, K extends keyof any> = T extends any ? Omit<T, K> : never;
+
 describe("Multiple Dates Selected", function () {
   function getDatePicker(
     extraProps: Partial<
@@ -16,7 +20,7 @@ describe("Multiple Dates Selected", function () {
         | "onSelect"
       >
     > &
-      Omit<
+      OmitUnion<
         DatePickerProps,
         | "selectsMultiple"
         | "onChange"

--- a/src/test/year_dropdown_options_test.test.tsx
+++ b/src/test/year_dropdown_options_test.test.tsx
@@ -1,6 +1,5 @@
 import { render, fireEvent } from "@testing-library/react";
 import React from "react";
-import onClickOutside from "react-onclickoutside";
 
 import { addYears, getYear, newDate, subYears } from "../date_utils";
 import YearDropdownOptions from "../year_dropdown_options";
@@ -128,9 +127,8 @@ describe("YearDropdownOptions", () => {
   });
 
   it("calls the supplied onCancel function on handleClickOutside", () => {
-    const WrappedYearDropdownOptions = onClickOutside(YearDropdownOptions);
     render(
-      <WrappedYearDropdownOptions
+      <YearDropdownOptions
         year={2015}
         onChange={mockHandleChange}
         onCancel={onCancelSpy}

--- a/src/year_dropdown.tsx
+++ b/src/year_dropdown.tsx
@@ -1,13 +1,10 @@
 import React, { Component } from "react";
-import onClickOutside from "react-onclickoutside";
 
 import { getYear } from "./date_utils";
 import YearDropdownOptions from "./year_dropdown_options";
 
 interface YearDropdownOptionsProps
   extends React.ComponentPropsWithoutRef<typeof YearDropdownOptions> {}
-
-const WrappedYearDropdownOptions = onClickOutside(YearDropdownOptions);
 
 interface YearDropdownProps
   extends Omit<YearDropdownOptionsProps, "onChange" | "onCancel"> {
@@ -81,7 +78,7 @@ export default class YearDropdown extends Component<
   );
 
   renderDropdown = (): JSX.Element => (
-    <WrappedYearDropdownOptions
+    <YearDropdownOptions
       key="dropdown"
       {...this.props}
       onChange={this.onChange}

--- a/src/year_dropdown_options.tsx
+++ b/src/year_dropdown_options.tsx
@@ -1,6 +1,7 @@
 import { clsx } from "clsx";
 import React, { Component, createRef } from "react";
 
+import { ClickOutsideWrapper } from "./click_outside_wrapper";
 import { getYear } from "./date_utils";
 
 function generateYears(
@@ -174,9 +175,13 @@ export default class YearDropdownOptions extends Component<
     });
 
     return (
-      <div className={dropdownClass} ref={this.dropdownRef}>
+      <ClickOutsideWrapper
+        className={dropdownClass}
+        containerRef={this.dropdownRef}
+        onClickOutside={this.handleClickOutside}
+      >
         {this.renderOptions()}
-      </div>
+      </ClickOutsideWrapper>
     );
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2030,13 +2030,6 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-onclickoutside@^6.7.10":
-  version "6.7.10"
-  resolved "https://registry.yarnpkg.com/@types/react-onclickoutside/-/react-onclickoutside-6.7.10.tgz#aeaf56aac4b67185a69038d22c55bd0726f13123"
-  integrity sha512-Do2eOuqlJ9amXAuQO5gbhp5MAPnzZ7cknmYqX4U44tX22eAAnHgQKjp3SaNhSAuUHBTANWEqn1N+nWd3ea8FyQ==
-  dependencies:
-    "@types/react" "*"
-
 "@types/react@*":
   version "18.2.21"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.21.tgz#774c37fd01b522d0b91aed04811b58e4e0514ed9"
@@ -6355,11 +6348,6 @@ react-is@^18.0.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
-
-react-onclickoutside@^6.13.0:
-  version "6.13.1"
-  resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.13.1.tgz#1f5e0241c08784b6e65745d91aca0d700c548a89"
-  integrity sha512-LdrrxK/Yh9zbBQdFbMTXPp3dTSN9B+9YJQucdDu3JNKRrbdU+H+/TVONJoWtOwy4II8Sqf1y/DTI6w/vGPYW0w==
 
 react@^18.2.0:
   version "18.3.1"


### PR DESCRIPTION
## Description
Closes https://github.com/Hacker0x01/react-datepicker/issues/4801
Closes https://github.com/Hacker0x01/react-datepicker/issues/4605

**Problem**
React 19 removed `findDOMNode` and `react-onclickoutside` is not supported

**Changes**

- Remove `react-onclickoutside` and replace with custom wrapper
- Update the `onClickOutside` to use `MouseEvent` instead of `React.MouseEvent` since it's a document event listener

## Screenshots
<!-- If applicable, add screenshots to help explain your improvements -->

## To reviewers
<!-- Additional comments for reviewers -->

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
