### PR TITLE
Fix #4986: 🐛🎨 Update the hover style to be applied only to the non-disabled calendar items

### DIFF
--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -402,7 +402,7 @@ h2.react-datepicker__current-month {
 .react-datepicker__year-text {
   cursor: pointer;
 
-  &:hover {
+  &:not([aria-disabled="true"]):hover {
     border-radius: $datepicker__border-radius;
     background-color: $datepicker__background-color;
   }
@@ -416,7 +416,7 @@ h2.react-datepicker__current-month {
     background-color: $datepicker__highlighted-color;
     color: #fff;
 
-    &:hover {
+    &:not([aria-disabled="true"]):hover {
       background-color: darken($datepicker__highlighted-color, 5%);
     }
 
@@ -452,7 +452,7 @@ h2.react-datepicker__current-month {
         opacity 0.3s ease-in-out;
     }
 
-    &:hover {
+    &:not([aria-disabled="true"]):hover {
       background-color: darken($datepicker__holidays-color, 10%);
     }
 
@@ -469,7 +469,7 @@ h2.react-datepicker__current-month {
     background-color: $datepicker__selected-color;
     color: #fff;
 
-    &:hover {
+    &:not([aria-disabled="true"]):hover {
       background-color: darken($datepicker__selected-color, 5%);
     }
   }
@@ -479,7 +479,7 @@ h2.react-datepicker__current-month {
     background-color: lighten($datepicker__selected-color, 45%);
     color: rgb(0, 0, 0);
 
-    &:hover {
+    &:not([aria-disabled="true"]):hover {
       background-color: darken($datepicker__selected-color, 5%);
     }
   }
@@ -499,10 +499,6 @@ h2.react-datepicker__current-month {
   &--disabled {
     cursor: default;
     color: $datepicker__muted-color;
-
-    &:hover {
-      background-color: transparent;
-    }
 
     .overlay {
       position: absolute;

--- a/src/test/week_number_test.test.tsx
+++ b/src/test/week_number_test.test.tsx
@@ -113,29 +113,52 @@ describe("WeekNumber", () => {
     });
 
     describe("handleOnKeyDown", () => {
-      const handleOnKeyDownMock = jest.fn((event) => {
-        if (event.key === KeyType.Space) {
-          event.preventDefault();
-          event.key = KeyType.Enter;
-        }
+      it("should not change any other key", () => {
+        const onKeyDownMock = jest.fn();
+
+        const container = renderWeekNumber(1, {
+          handleOnKeyDown: onKeyDownMock,
+        });
+
+        const weekNumberElement = container.querySelector(
+          ".react-datepicker__week-number",
+        )!;
+
+        fireEvent.keyDown(weekNumberElement, {
+          key: KeyType.Enter,
+          preventDefault: jest.fn(),
+        });
+
+        expect(onKeyDownMock).toHaveBeenCalledTimes(1);
+        expect(onKeyDownMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            key: KeyType.Enter,
+          }),
+        );
       });
 
       it("should change space key to Enter", () => {
-        const eventSpace = {
+        const onKeyDownMock = jest.fn();
+
+        const container = renderWeekNumber(1, {
+          handleOnKeyDown: onKeyDownMock,
+        });
+
+        const weekNumberElement = container.querySelector(
+          ".react-datepicker__week-number",
+        )!;
+
+        fireEvent.keyDown(weekNumberElement, {
           key: KeyType.Space,
           preventDefault: jest.fn(),
-        };
-        handleOnKeyDownMock(eventSpace);
-        expect(eventSpace.preventDefault).toHaveBeenCalled();
-        expect(eventSpace.key).toBe(KeyType.Enter);
-      });
+        });
 
-      it("should not change any other key", () => {
-        const eventA = {
-          key: "a",
-        };
-        handleOnKeyDownMock(eventA);
-        expect(eventA.key).toBe("a");
+        expect(onKeyDownMock).toHaveBeenCalledTimes(1);
+        expect(onKeyDownMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            key: KeyType.Enter,
+          }),
+        );
       });
     });
   });


### PR DESCRIPTION
Closes #4986

## Description
As described in the issue, the hover style for the disabled items was set to transparent, hence if the programatically pre-selected is a part of the disabled dates, it'll apply the highlight background to the selected date.  On hovering on this date, we shouldn't change it's background color.  

As a fix, instead of changing the background of the disabled date items to transparent, I apply the hover styles to be applied only for the enabled date items.  As a result, even though the disabled date was pre-selected, on hovering over it won't update it's style.

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
