### PR TITLE
The classname "react-datepicker-ignore-onclickoutside" is not applied to custom input

### DIFF
--- a/docs-site/src/examples/customInput.js
+++ b/docs-site/src/examples/customInput.js
@@ -1,15 +1,17 @@
 () => {
   const [startDate, setStartDate] = useState(new Date());
-  const ExampleCustomInput = forwardRef(({ value, onClick }, ref) => (
-    <button className="example-custom-input" onClick={onClick} ref={ref}>
-      {value}
-    </button>
-  ));
+  const ExampleCustomInput = forwardRef(
+    ({ value, onClick, className }, ref) => (
+      <button className={className} onClick={onClick} ref={ref}>
+        {value}
+      </button>
+    ),
+  );
   return (
     <DatePicker
       selected={startDate}
       onChange={(date) => setStartDate(date)}
-      customInput={<ExampleCustomInput />}
+      customInput={<ExampleCustomInput className="example-custom-input" />}
     />
   );
 };


### PR DESCRIPTION


## Description - The classname "react-datepicker-ignore-onclickoutside" was not applied to custom inputs in the Docs Website example

**Problem**
The classname "react-datepicker-ignore-onclickoutside" was not applied to custom inputs in the Docs Website example.

This lead to opening and closing of the popper when clicking on the input, because it was not considered clicking outside.

https://github.com/user-attachments/assets/c9499d93-1723-4756-acde-bb982901406a

**Changes**
Passed className as props to the example and moved the "example-custom-input"

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
