### PR TITLE
Fix "Cannot find module 'date-fns/types' ..."

### DIFF
--- a/src/calendar.tsx
+++ b/src/calendar.tsx
@@ -50,7 +50,7 @@ import Year from "./year";
 import YearDropdown from "./year_dropdown";
 
 import type { ClickOutsideHandler } from "./click_outside_wrapper";
-import type { Day } from "date-fns/types";
+import type { Day } from "date-fns";
 
 interface YearDropdownProps
   extends React.ComponentPropsWithoutRef<typeof YearDropdown> {}


### PR DESCRIPTION
## Description

**Problem**

Upgraded to `react-datepicker@7` and `date-fns@3`, and now getting the following error when checking types with `typescript@5.5`:

```
node_modules/react-datepicker/dist/calendar.d.ts:10:26 - error TS2307: Cannot find module 'date-fns/types' or its corresponding type declarations.

10 import type { Day } from "date-fns/types";
                            ~~~~~~~~~~~~~~~~


Found 1 error in node_modules/react-datepicker/dist/calendar.d.ts:10
```

**Changes**

Simply corrected the import from `date-fns/types` to `date-fns`.

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
