### PR TITLE
Simplify event handlers

### DIFF
--- a/src/calendar.tsx
+++ b/src/calendar.tsx
@@ -339,7 +339,7 @@ export default class Calendar extends Component<CalendarProps, CalendarState> {
       | React.KeyboardEvent<HTMLDivElement>,
     monthSelectedIn?: number,
   ): void => {
-    this.props.onSelect(day, event, monthSelectedIn);
+    this.props.onSelect?.(day, event, monthSelectedIn);
     this.props.setPreSelection && this.props.setPreSelection(day);
   };
 
@@ -374,9 +374,7 @@ export default class Calendar extends Component<CalendarProps, CalendarState> {
       this.setState({ isRenderAriaLiveMessage: true });
     }
     if (this.props.adjustDateOnChange) {
-      if (this.props.onSelect) {
-        this.props.onSelect(date);
-      }
+      this.props.onSelect?.(date);
       if (this.props.setOpen) {
         this.props.setOpen(true);
       }
@@ -388,9 +386,7 @@ export default class Calendar extends Component<CalendarProps, CalendarState> {
   handleMonthChange = (date: Date): void => {
     this.handleCustomMonthChange(date);
     if (this.props.adjustDateOnChange) {
-      if (this.props.onSelect) {
-        this.props.onSelect(date);
-      }
+      this.props.onSelect?.(date);
       if (this.props.setOpen) {
         this.props.setOpen(true);
       }
@@ -780,7 +776,7 @@ export default class Calendar extends Component<CalendarProps, CalendarState> {
   };
 
   handleTodayButtonClick = (event: React.MouseEvent<HTMLDivElement>): void => {
-    this.props.onSelect(getStartOfToday(), event);
+    this.props.onSelect?.(getStartOfToday(), event);
     this.props.setPreSelection && this.props.setPreSelection(getStartOfToday());
   };
 

--- a/src/calendar.tsx
+++ b/src/calendar.tsx
@@ -283,7 +283,7 @@ export default class Calendar extends Component<CalendarProps, CalendarState> {
   assignMonthContainer: void | undefined;
 
   handleClickOutside = (event: MouseEvent): void => {
-    this.props.onClickOutside?.(event);
+    this.props.onClickOutside(event);
   };
 
   setClickOutsideRef = (): HTMLDivElement | null => {
@@ -339,7 +339,7 @@ export default class Calendar extends Component<CalendarProps, CalendarState> {
       | React.KeyboardEvent<HTMLDivElement>,
     monthSelectedIn?: number,
   ): void => {
-    this.props.onSelect?.(day, event, monthSelectedIn);
+    this.props.onSelect(day, event, monthSelectedIn);
     this.props.setPreSelection && this.props.setPreSelection(day);
   };
 
@@ -372,7 +372,7 @@ export default class Calendar extends Component<CalendarProps, CalendarState> {
     this.props.onYearChange?.(date);
     this.setState({ isRenderAriaLiveMessage: true });
     if (this.props.adjustDateOnChange) {
-      this.props.onSelect?.(date);
+      this.props.onSelect(date);
       this.props.setOpen?.(true);
     }
 
@@ -382,7 +382,7 @@ export default class Calendar extends Component<CalendarProps, CalendarState> {
   handleMonthChange = (date: Date): void => {
     this.handleCustomMonthChange(date);
     if (this.props.adjustDateOnChange) {
-      this.props.onSelect?.(date);
+      this.props.onSelect(date);
       this.props.setOpen?.(true);
     }
 
@@ -768,7 +768,7 @@ export default class Calendar extends Component<CalendarProps, CalendarState> {
   };
 
   handleTodayButtonClick = (event: React.MouseEvent<HTMLDivElement>): void => {
-    this.props.onSelect?.(getStartOfToday(), event);
+    this.props.onSelect(getStartOfToday(), event);
     this.props.setPreSelection && this.props.setPreSelection(getStartOfToday());
   };
 

--- a/src/calendar.tsx
+++ b/src/calendar.tsx
@@ -283,7 +283,7 @@ export default class Calendar extends Component<CalendarProps, CalendarState> {
   assignMonthContainer: void | undefined;
 
   handleClickOutside = (event: MouseEvent): void => {
-    this.props.onClickOutside(event);
+    this.props.onClickOutside?.(event);
   };
 
   setClickOutsideRef = (): HTMLDivElement | null => {
@@ -369,10 +369,8 @@ export default class Calendar extends Component<CalendarProps, CalendarState> {
   };
 
   handleYearChange = (date: Date): void => {
-    if (this.props.onYearChange) {
-      this.props.onYearChange(date);
-      this.setState({ isRenderAriaLiveMessage: true });
-    }
+    this.props.onYearChange?.(date);
+    this.setState({ isRenderAriaLiveMessage: true });
     if (this.props.adjustDateOnChange) {
       this.props.onSelect?.(date);
       if (this.props.setOpen) {

--- a/src/calendar.tsx
+++ b/src/calendar.tsx
@@ -373,9 +373,7 @@ export default class Calendar extends Component<CalendarProps, CalendarState> {
     this.setState({ isRenderAriaLiveMessage: true });
     if (this.props.adjustDateOnChange) {
       this.props.onSelect?.(date);
-      if (this.props.setOpen) {
-        this.props.setOpen(true);
-      }
+      this.props.setOpen?.(true);
     }
 
     this.props.setPreSelection && this.props.setPreSelection(date);
@@ -385,9 +383,7 @@ export default class Calendar extends Component<CalendarProps, CalendarState> {
     this.handleCustomMonthChange(date);
     if (this.props.adjustDateOnChange) {
       this.props.onSelect?.(date);
-      if (this.props.setOpen) {
-        this.props.setOpen(true);
-      }
+      this.props.setOpen?.(true);
     }
 
     this.props.setPreSelection && this.props.setPreSelection(date);

--- a/src/calendar.tsx
+++ b/src/calendar.tsx
@@ -396,10 +396,8 @@ export default class Calendar extends Component<CalendarProps, CalendarState> {
   };
 
   handleCustomMonthChange = (date: Date): void => {
-    if (this.props.onMonthChange) {
-      this.props.onMonthChange(date);
-      this.setState({ isRenderAriaLiveMessage: true });
-    }
+    this.props.onMonthChange?.(date);
+    this.setState({ isRenderAriaLiveMessage: true });
   };
 
   handleMonthYearChange = (date: Date): void => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -267,7 +267,6 @@ export default class DatePicker extends Component<
       onBlur() {},
       onKeyDown() {},
       onInputClick() {},
-      onSelect() {},
       onClickOutside() {},
       onMonthChange() {},
       onCalendarOpen() {},
@@ -793,8 +792,7 @@ export default class DatePicker extends Component<
     }
 
     if (!keepInput) {
-      const onSelect = this.props.onSelect ?? DatePicker.defaultProps.onSelect;
-      onSelect(changedDate, event);
+      this.props.onSelect?.(changedDate, event);
       this.setState({ inputValue: null });
     }
   };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -260,7 +260,6 @@ export default class DatePicker extends Component<
       allowSameDay: false,
       dateFormat: "MM/dd/yyyy",
       dateFormatCalendar: "LLLL yyyy",
-      onChange() {},
       disabled: false,
       disabledKeyboardNavigation: false,
       dropdownMode: "scroll" as const,
@@ -751,41 +750,27 @@ export default class DatePicker extends Component<
         const hasStartRange = startDate && !endDate;
         const isRangeFilled = startDate && endDate;
         if (noRanges) {
-          onChange
-            ? onChange([changedDate, null], event)
-            : DatePicker.defaultProps.onChange;
+          onChange?.([changedDate, null], event);
         } else if (hasStartRange) {
           if (changedDate === null) {
-            onChange
-              ? onChange([null, null], event)
-              : DatePicker.defaultProps.onChange;
+            onChange?.([null, null], event);
           } else if (isDateBefore(changedDate, startDate)) {
             if (swapRange) {
-              onChange
-                ? onChange([changedDate, startDate], event)
-                : DatePicker.defaultProps.onChange;
+              onChange?.([changedDate, startDate], event);
             } else {
-              onChange
-                ? onChange([changedDate, null], event)
-                : DatePicker.defaultProps.onChange;
+              onChange?.([changedDate, null], event);
             }
           } else {
-            onChange
-              ? onChange([startDate, changedDate], event)
-              : DatePicker.defaultProps.onChange;
+            onChange?.([startDate, changedDate], event);
           }
         }
         if (isRangeFilled) {
-          onChange
-            ? onChange([changedDate, null], event)
-            : DatePicker.defaultProps.onChange;
+          onChange?.([changedDate, null], event);
         }
       } else if (selectsMultiple) {
         if (changedDate !== null) {
           if (!selectedDates?.length) {
-            onChange
-              ? onChange([changedDate], event)
-              : DatePicker.defaultProps.onChange;
+            onChange?.([changedDate], event);
           } else {
             const isChangedDateAlreadySelected = selectedDates.some(
               (selectedDate) => isSameDay(selectedDate, changedDate),
@@ -796,20 +781,14 @@ export default class DatePicker extends Component<
                 (selectedDate) => !isSameDay(selectedDate, changedDate),
               );
 
-              onChange
-                ? onChange(nextDates, event)
-                : DatePicker.defaultProps.onChange;
+              onChange?.(nextDates, event);
             } else {
-              onChange
-                ? onChange([...selectedDates, changedDate], event)
-                : DatePicker.defaultProps.onChange;
+              onChange?.([...selectedDates, changedDate], event);
             }
           }
         }
       } else {
-        onChange
-          ? onChange(changedDate, event)
-          : DatePicker.defaultProps.onChange;
+        onChange?.(changedDate, event);
       }
     }
 
@@ -876,8 +855,7 @@ export default class DatePicker extends Component<
       preSelection: changedDate,
     });
 
-    const onChange = this.props.onChange ?? DatePicker.defaultProps.onChange;
-    onChange(changedDate);
+    this.props.onChange?.(changedDate);
     if (this.props.shouldCloseOnSelect && !this.props.showTimeInput) {
       this.sendFocusBackToInput();
       this.setOpen(false);
@@ -1175,11 +1153,9 @@ export default class DatePicker extends Component<
 
     const { selectsRange, onChange } = this.props;
     if (selectsRange) {
-      onChange
-        ? onChange([null, null], event)
-        : DatePicker.defaultProps.onChange();
+      onChange?.([null, null], event);
     } else {
-      onChange ? onChange(null, event) : DatePicker.defaultProps.onChange();
+      onChange?.(null, event);
     }
 
     this.setState({ inputValue: null });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -263,17 +263,7 @@ export default class DatePicker extends Component<
       disabled: false,
       disabledKeyboardNavigation: false,
       dropdownMode: "scroll" as const,
-      onFocus() {},
-      onBlur() {},
-      onKeyDown() {},
-      onInputClick() {},
-      onClickOutside() {},
-      onMonthChange() {},
-      onCalendarOpen() {},
-      onCalendarClose() {},
       preventOpenOnFocus: false,
-      onYearChange() {},
-      onInputError() {},
       monthsShown: 1,
       readOnly: false,
       withPortal: false,
@@ -889,7 +879,7 @@ export default class DatePicker extends Component<
         eventKey === KeyType.ArrowUp ||
         eventKey === KeyType.Enter
       ) {
-        this.onInputClick();
+        this.onInputClick?.();
       }
       return;
     }
@@ -1102,9 +1092,7 @@ export default class DatePicker extends Component<
         break;
     }
     if (!newSelection) {
-      if (this.props.onInputError) {
-        this.props.onInputError({ code: 1, msg: INPUT_ERR_1 });
-      }
+      this.props.onInputError?.({ code: 1, msg: INPUT_ERR_1 });
       return;
     }
     event.preventDefault();

--- a/src/year_dropdown.tsx
+++ b/src/year_dropdown.tsx
@@ -118,14 +118,12 @@ export default class YearDropdown extends Component<
     date: Date,
     event?: React.MouseEvent<HTMLDivElement>,
   ): void => {
-    this.onSelect(date, event);
+    this.onSelect?.(date, event);
     this.setOpen();
   };
 
   onSelect = (date: Date, event?: React.MouseEvent<HTMLDivElement>): void => {
-    if (this.props.onSelect) {
-      this.props.onSelect(date, event);
-    }
+    this.props.onSelect?.(date, event);
   };
 
   setOpen = (): void => {

--- a/src/year_dropdown.tsx
+++ b/src/year_dropdown.tsx
@@ -127,9 +127,7 @@ export default class YearDropdown extends Component<
   };
 
   setOpen = (): void => {
-    if (this.props.setOpen) {
-      this.props.setOpen(true);
-    }
+    this.props.setOpen?.(true);
   };
 
   render(): JSX.Element {


### PR DESCRIPTION
## Description
**Linked issue**: #5044 

**Problem**
As described in the linked issue, there are many instances where default prop event handlers are referenced for not reason (they are empty functions, and the code is not actually calling them in most places).

**Changes**
Refactor the groups of 3 lines into 1, and remove default props that are empty functions.

For example
```
onChange
    ? onChange(changedDate, event)
    : DatePicker.defaultProps.onChange;
```
is changed to
`onChange?.(changedDate, event)`

## Contribution checklist
- [X] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [X] I have added sufficient test coverage for my changes.
- [X] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
