### PR TITLE
test: fix a test that would always fail if run on first day of month

### DIFF
--- a/src/test/exclude_dates.test.tsx
+++ b/src/test/exclude_dates.test.tsx
@@ -1,14 +1,18 @@
 import { render } from "@testing-library/react";
-import { subDays } from "date-fns";
+import { addDays, subDays } from "date-fns";
 import React from "react";
 
 import DatePicker from "../index";
 
 describe("DatePicker", () => {
-  const excludeDates = [new Date(), subDays(new Date(), 1)];
+  const today = new Date();
+  // otherDate must be in same month, otherwise it will not be shown on the calendar
+  const otherDate =
+    today.getDate() === 1 ? addDays(today, 1) : subDays(today, 1);
+  const excludeDates = [today, otherDate];
   const excludeDatesWithMessages = [
-    { date: subDays(new Date(), 1), message: "This day is excluded" },
-    { date: new Date(), message: "Today is excluded" },
+    { date: otherDate, message: "This day is excluded" },
+    { date: today, message: "Today is excluded" },
   ];
 
   it("should disable dates specified in excludeDates props", () => {
@@ -40,11 +44,11 @@ describe("DatePicker", () => {
     );
 
     expect(disabledTimeItems.length).toBe(excludeDatesWithMessages.length);
-    expect(disabledTimeItems[0]?.getAttribute("title")).toBe(
-      "This day is excluded",
-    );
-    expect(disabledTimeItems[1]?.getAttribute("title")).toBe(
-      "Today is excluded",
-    );
+    expect(
+      disabledTimeItems[today < otherDate ? 1 : 0]?.getAttribute("title"),
+    ).toBe("This day is excluded");
+    expect(
+      disabledTimeItems[today < otherDate ? 0 : 1]?.getAttribute("title"),
+    ).toBe("Today is excluded");
   });
 });


### PR DESCRIPTION
## Description
**Problem**
The test suite failed on September 1st, and every 1st of the month in the past, because this test assumes `today` and `subDays(today, 1)` are in the same month.

**Changes**
We check if today is the first of the month, and if so, we use `addDays(today, 1)` instead of `subDays(today, 1)`.

## Contribution checklist
- [X] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [X] I have added sufficient test coverage for my changes.
- [X] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
