### PR TITLE
try fixing JS error on website

### DIFF
--- a/src/time.tsx
+++ b/src/time.tsx
@@ -187,7 +187,8 @@ export default class Time extends Component<TimeProps, TimeState> {
 
   renderTimes = (): JSX.Element[] => {
     let times: Date[] = [];
-    const format = this.props.format ? this.props.format : "p";
+    const format =
+      typeof this.props.format === "string" ? this.props.format : "p";
     const intervals = this.props.intervals ?? Time.defaultProps.intervals;
 
     const activeDate =


### PR DESCRIPTION
Our main website is getting an error: https://reactdatepicker.com/

`TypeError: k.format is not a function`

Possible fix for https://github.com/Hacker0x01/react-datepicker/issues/5108