### PR TITLE
Revert "chore(deps): bump date-fns from 3.6.0 to 4.1.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   "dependencies": {
     "@floating-ui/react": "^0.26.23",
     "clsx": "^2.1.1",
-    "date-fns": "^4.1.0",
+    "date-fns": "^3.6.0",
     "prop-types": "^15.8.1"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4741,10 +4741,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"date-fns@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "date-fns@npm:4.1.0"
-  checksum: 10c0/b79ff32830e6b7faa009590af6ae0fb8c3fd9ffad46d930548fbb5acf473773b4712ae887e156ba91a7b3dc30591ce0f517d69fd83bd9c38650fdc03b4e0bac8
+"date-fns@npm:^3.6.0":
+  version: 3.6.0
+  resolution: "date-fns@npm:3.6.0"
+  checksum: 10c0/0b5fb981590ef2f8e5a3ba6cd6d77faece0ea7f7158948f2eaae7bbb7c80a8f63ae30b01236c2923cf89bb3719c33aeb150c715ea4fe4e86e37dcf06bed42fb6
   languageName: node
   linkType: hard
 
@@ -9286,7 +9286,7 @@ __metadata:
     babel-plugin-transform-react-remove-prop-types: "npm:^0.4.24"
     clsx: "npm:^2.1.1"
     core-js: "npm:^3.38.1"
-    date-fns: "npm:^4.1.0"
+    date-fns: "npm:^3.6.0"
     eslint: "npm:^8.57.0"
     eslint-config-prettier: "npm:^9.1.0"
     eslint-plugin-import: "npm:^2.29.1"


### PR DESCRIPTION
Reverts Hacker0x01/react-datepicker#5102

This upgrade breaks our demo website. Reverting until we've found a fix.

Ref https://github.com/Hacker0x01/react-datepicker/issues/5108