### PR TITLE
fix: remove date-fns as external package

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -24,25 +24,6 @@ const banner = `/*!
   Released under the ${pkg.license} License.
 */`;
 
-// it's important to mark all subpackages of data-fns as externals
-// see https://github.com/Hacker0x01/react-datepicker/issues/1606
-// We're relying on date-fn's package.json `exports` field to
-// determine the list of directories to include.
-const dateFnsPackageJson = JSON.parse(
-  fs
-    .readFileSync(
-      path.join(
-        path.dirname(fileURLToPath(import.meta.url)),
-        "node_modules/date-fns/package.json",
-      ),
-    )
-    .toString(),
-);
-const dateFnsSubpackages = Object.keys(dateFnsPackageJson.exports)
-  .map((key) => key.replace("./", ""))
-  .filter((key) => key !== "." && key !== "package.json")
-  .map((key) => `date-fns/${key}`);
-
 const globals = {
   react: "React",
   "prop-types": "PropTypes",
@@ -109,7 +90,6 @@ const config = {
   external: [
     ...Object.keys(pkg.dependencies || {}),
     ...Object.keys(pkg.peerDependencies || {}),
-    ...dateFnsSubpackages,
   ],
 };
 


### PR DESCRIPTION
---
name: fix: remove date-fns as external package
about: Update of date-fns library from 3.6 to 4.1 was running into a issue with current rollup configuration
title: Remove date-fns as external package
labels: ""
assignees: "[martijnrusschen](https://github.com/martijnrusschen)"
---

## Description
**Linked issue**: #5108 

**Problem**
Get back online page with latest version of date-fns

**Changes**
Rollup issue remove

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
