### PR TITLE
Fix #5137: 🧪✅ Fix the accidental change of the complete month issue with the test cases by selecting to a earlier date in a month

### DIFF
--- a/src/test/datepicker_test.test.tsx
+++ b/src/test/datepicker_test.test.tsx
@@ -1615,8 +1615,12 @@ describe("DatePicker", () => {
   });
 
   it("should be possible to preSelect minDate (no maxDate set)", () => {
+    const minDate = new Date("2024-10-02");
+    const selected = minDate;
+
     const data = getOnInputKeyDownStuff({
-      minDate: newDate(),
+      selected,
+      minDate,
     });
     fireEvent.keyDown(data.dateInput, getKey(KeyType.ArrowDown));
     const selectedDayNode = getSelectedDayNode(data.container);
@@ -1632,9 +1636,14 @@ describe("DatePicker", () => {
   });
 
   it("should be possible to preSelect minDate (maxDate set)", () => {
+    const minDate = new Date("2024-10-02");
+    const maxDate = addDays(minDate, 20);
+    const selected = minDate;
+
     const data = getOnInputKeyDownStuff({
-      minDate: newDate(),
-      maxDate: addDays(newDate(), 20),
+      selected,
+      minDate,
+      maxDate,
     });
     fireEvent.keyDown(data.dateInput, getKey(KeyType.ArrowDown));
     const selectedDayNode = getSelectedDayNode(data.container);


### PR DESCRIPTION
Closes #5137

## Description
I accidentally found this issue with the existing test cases. The issue we're having is with the test module `datepicker_test.test.js`. There currently 2 test blocks are having an issue as I mentioned in the attached screenshot

- `DatePicker › should be possible to preSelect minDate (no maxDate set)`
- `DatePicker › should be possible to preSelect minDate (maxDate set)`

**The Problem**
![image](https://github.com/user-attachments/assets/c74e8f5f-bdd8-4f3a-9708-7123a41405fb)

I shared one of the failed test cases in the above screenshot. The issue there is we're initially getting a selected day using `const selectedDayNode = getSelectedDayNode(data.container)` and then doing right and left arrow click over it. This test case will work in most of the days except the last day of a month. Because, let's consider 30th Sept, 2024 as the selected date. When the user press right, a new month view will get rendered and then the existing selectedDayNode will not be available to us anymore. But in our code we didn't refetch the selectedDayNode and do Left click on it. So only the left click didn't get fired and the test case failed.

If the selected date is not the end of the month, this test case will work. Because, eventhough the actual selecteDayNode gets changed to the next date on the initial right arrow click, but still the date we stored in selecteDayNode is still accessible to us and left click over it, will inturn handled by the corresponding component and the test case will pass.

The same issue happens in the other mentioned test case

**Possible Fixes:**
There are **2 ways** to fix the issue
1. Refetch the selectedDayNode after performing the initial right arrow click and perform left click over it
2. Update the selectedDate and the minDate to some earlier date in a month, so that the right arrow click won't render a new month view

I fixed the issue in the 2nd way as that requires less code change.

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
