### PR TITLE
Fix #5147: 🐛 Fix navigation issue with disabled dates in date picker

### DIFF
--- a/src/calendar.tsx
+++ b/src/calendar.tsx
@@ -510,7 +510,8 @@ export default class Calendar extends Component<CalendarProps, CalendarState> {
         date: subYears(
           date,
           this.props.showYearPicker
-            ? this.props.yearItemNumber ?? Calendar.defaultProps.yearItemNumber
+            ? (this.props.yearItemNumber ??
+                Calendar.defaultProps.yearItemNumber)
             : 1,
         ),
       }),
@@ -624,7 +625,8 @@ export default class Calendar extends Component<CalendarProps, CalendarState> {
         date: addYears(
           date,
           this.props.showYearPicker
-            ? this.props.yearItemNumber ?? Calendar.defaultProps.yearItemNumber
+            ? (this.props.yearItemNumber ??
+                Calendar.defaultProps.yearItemNumber)
             : 1,
         ),
       }),


### PR DESCRIPTION
Closes #5147

**Problem**
As I described in the linked ticket, the issue is if we select a date and disable the same date in the next or previous months, then when we navigate to the corresponding month and try using arrow keys (Tab) to navigate to the date, it won't work as there is no pre-selected date available in the month due to the fact that the corresponding date we selected previously is disabled in the corresponding month.

**Changes**
- Whenever month gets switched, instead of auto-preselecting the already selected day from the selected date.  I first checked if the same day in the month is disabled, if not pre-select the same day, else pre-select the first enabled date in the month.  If all the days are disabled in the rendered month, didn't pre-select any days.

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
