### PR TITLE
Fix types build by specifying return type on portal render method

### DIFF
--- a/src/portal.tsx
+++ b/src/portal.tsx
@@ -46,7 +46,7 @@ class Portal extends Component<PortalProps> {
   private el: HTMLDivElement;
   private portalRoot: HTMLElement | null = null;
 
-  render() {
+  render(): React.ReactPortal {
     return ReactDOM.createPortal(this.props.children, this.el);
   }
 }


### PR DESCRIPTION
## Description
**Linked issue**: #5129

**Problem**
There is a warning printed by rollup during build of types, which is preventing the generation of the portal.d.ts file.
Specifically, the TS error is the following:
TS2742: The inferred type of render cannot be named without a reference to react-dom/ node_modules/@types/ react. This is likely not portable. A type annotation is necessary.

This warning is actually an error which is preventing the generation of the declaration file for the portal.tsx.

**Changes**
Added the return type to the render method of the portal class

## Screenshots

## To reviewers

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
