### PR TITLE
🐛 Fix #5084: Fixfox Tab switch issue

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -454,17 +454,13 @@ export default class DatePicker extends Component<
 
   safeFocus = () => {
     setTimeout(() => {
-      if (this.input && this.input.focus) {
-        this.input.focus({ preventScroll: true });
-      }
+      this.input?.focus?.({ preventScroll: true });
     }, 0);
   };
 
   safeBlur = () => {
     setTimeout(() => {
-      if (this.input && this.input.blur) {
-        this.input.blur();
-      }
+      this.input?.blur?.();
     }, 0);
   };
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -452,6 +452,14 @@ export default class DatePicker extends Component<
     }
   };
 
+  safeFocus = () => {
+    setTimeout(() => {
+      if (this.input && this.input.focus) {
+        this.input.focus({ preventScroll: true });
+      }
+    }, 0);
+  };
+
   safeBlur = () => {
     setTimeout(() => {
       if (this.input && this.input.blur) {
@@ -461,9 +469,7 @@ export default class DatePicker extends Component<
   };
 
   setFocus = () => {
-    if (this.input && this.input.focus) {
-      this.input.focus({ preventScroll: true });
-    }
+    this.safeFocus();
   };
 
   setBlur = () => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -452,6 +452,14 @@ export default class DatePicker extends Component<
     }
   };
 
+  safeBlur = () => {
+    setTimeout(() => {
+      if (this.input && this.input.blur) {
+        this.input.blur();
+      }
+    }, 0);
+  };
+
   setFocus = () => {
     if (this.input && this.input.focus) {
       this.input.focus({ preventScroll: true });
@@ -459,10 +467,7 @@ export default class DatePicker extends Component<
   };
 
   setBlur = () => {
-    if (this.input && this.input.blur) {
-      this.input.blur();
-    }
-
+    this.safeBlur();
     this.cancelFocusInput();
   };
 

--- a/src/test/datepicker_test.test.tsx
+++ b/src/test/datepicker_test.test.tsx
@@ -580,7 +580,24 @@ describe("DatePicker", () => {
     });
   });
 
-  it("should hide the calendar when the pressing Shift + Tab in the date input", () => {
+  it("should auto-close the datepicker and lose focus when Tab key is pressed when the date input is focused", async () => {
+    const { container } = render(<DatePicker />);
+    const input = safeQuerySelector(container, "input");
+    fireEvent.focus(input);
+
+    let reactCalendar = container.querySelector("div.react-datepicker");
+    expect(reactCalendar).not.toBeNull();
+
+    fireEvent.keyDown(input, getKey(KeyType.Tab));
+
+    reactCalendar = container.querySelector("div.react-datepicker");
+    expect(reactCalendar).toBeNull();
+    await waitFor(() => {
+      expect(document.activeElement).not.toBe(input);
+    });
+  });
+
+  it("should hide the calendar when the pressing Shift + Tab in the date input", async () => {
     // eslint-disable-next-line prefer-const
     let onBlurSpy: ReturnType<typeof jest.spyOn>;
     const onBlur: React.FocusEventHandler<HTMLElement> = (
@@ -594,7 +611,9 @@ describe("DatePicker", () => {
     fireEvent.focus(input);
     fireEvent.keyDown(input, getKey(KeyType.Tab, true));
     expect(container.querySelector(".react-datepicker")).toBeNull();
-    expect(onBlurSpy).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(onBlurSpy).toHaveBeenCalled();
+    });
   });
 
   it("should not apply the react-datepicker-ignore-onclickoutside class to the date input when closed", () => {

--- a/src/test/datepicker_test.test.tsx
+++ b/src/test/datepicker_test.test.tsx
@@ -1983,7 +1983,7 @@ describe("DatePicker", () => {
     });
     expect(div.querySelector("input")).toBe(document.activeElement);
   });
-  it("should autoFocus the input when calling the setFocus method", () => {
+  it("should autoFocus the input when calling the setFocus method", async () => {
     const div = document.createElement("div");
     document.body.appendChild(div);
     let instance: DatePicker | null = null;
@@ -2001,7 +2001,9 @@ describe("DatePicker", () => {
     act(() => {
       instance!.setFocus();
     });
-    expect(div.querySelector("input")).toBe(document.activeElement);
+    await waitFor(() => {
+      expect(div.querySelector("input")).toBe(document.activeElement);
+    });
   });
   it("should clear preventFocus timeout id when component is unmounted", () => {
     const div = document.createElement("div");


### PR DESCRIPTION
Close #5084 

## Description
As @avazhenin mentioned in the attached ticket, we're getting an issue while we try to switch to the next input control via Tab Key on Firefox browser.  

## To Reproduce
Even though @avazhenin shared his code sample along with a video explaining the issue,  I'll share a simple way to recreate the issue.  Goto `https://reactdatepicker.com/` via **FireFox** and click on any date input, now try to press tab when the calendar is getting rendered.  We expect it to auto-close the calendar and switch to the next code sample.  But instead of that it'll refocus the same date input again.  To make it work, we have to press ESC first (which will close the opened calendar popup) and then press Tab, it'll work.  In this case alone it'll work, because as the datepicker is already closed, it won't disturb the tab key press.

Try the same thing in Chrome Browser, it'll auto-close the opened calendar popup and switch to the next code sample editor.

## Reason behind this issue
![image](https://github.com/user-attachments/assets/130e2454-c03a-4f06-a41f-d97e7873e272)

The reason why this issue occurs whenever we press Tab key over the input, we call `setOpen(false)` to close the open popup so that the browser default focus switch will happen to the next control.  

But as I highlighted in the above screenshot, while performing the state update we manually call blur operation on the date input.  We do a state update and along with setting blur to the DOM element.  This issue arises from a combination of 

**1. JavaScript Event Loop & React's Rendering Lifecycle:**
- In the code we call setBlur in the callback of `setState` assuming the blur will happen after the update of state.  But React's state updates are asynchronous and may not complete immediately after `setState()`.  The callback of setState runs after the state update, but not guarantee that the DOM has been fully updated and rendered (unlike the `useEffect` call).

**2. Browser-Specific Focus Behaviour:**
- FireFox (& Safari) enforce focus/blur rules more strictly compared to Chrome's V8 engine.  As a result during re-render, the browser might reapply focus back to the input, overriding the previous instant `blur()` call made by us in-between the state update.

### Changes/Solution
Wrapping the blur() call inside a setTimeout defers it to the next macrotask, ensuring that React's render and browser focus management complete before the blur operation is executed.

As we wrapped `setBlut` call inside the setTimeout, we need to move the focus logic also to setTimeout, as in the case of Esc key press we kind of blur and send focus back to the input.  So in this PR I moved the focus and blur call inside setTimeout.  

I created 2 new methods and moved our existing blur and focus call to it instead of updating the existing methods names.  Updating the existing method names make me update many lines as these functions are used in many places.  So to keep my fix simple and at the same time to emphasize the change I made, I created these 2 new helpers.
![image](https://github.com/user-attachments/assets/5e5305ef-2b60-4384-bea8-912f051c1211)

I updated the existing test cases to adapt with my fix and also added a new test case to check the Tab order.

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
