### PR TITLE
fix: "previous month" button appears when selecting a date

### DIFF
--- a/src/calendar.tsx
+++ b/src/calendar.tsx
@@ -528,6 +528,14 @@ export default class Calendar extends Component<CalendarProps, CalendarState> {
       return;
     }
 
+    const monthsShown =
+      this.props.monthsShown ?? Calendar.defaultProps.monthsShown;
+    const monthsToSubtract = this.props.showPreviousMonths
+      ? monthsShown - 1
+      : 0;
+    const monthSelectedIn = this.props.monthSelectedIn ?? monthsToSubtract;
+    const fromMonthDate = subMonths(this.state.date, monthSelectedIn);
+
     let allPrevDaysDisabled;
     switch (true) {
       case this.props.showMonthYearPicker:
@@ -543,7 +551,7 @@ export default class Calendar extends Component<CalendarProps, CalendarState> {
         );
         break;
       default:
-        allPrevDaysDisabled = monthDisabledBefore(this.state.date, this.props);
+        allPrevDaysDisabled = monthDisabledBefore(fromMonthDate, this.props);
         break;
     }
 

--- a/src/test/calendar_test.test.tsx
+++ b/src/test/calendar_test.test.tsx
@@ -458,11 +458,19 @@ describe("Calendar", () => {
       />,
     );
 
+    expect(
+      container.querySelector(".react-datepicker__navigation--previous"),
+    ).toBe(null);
+
     const secondMonthDate = safeQuerySelectorAll(
       container,
       ".react-datepicker__day--009",
     )[1];
-    fireEvent.click(secondMonthDate!);
+    if (!secondMonthDate) {
+      throw new Error("second month date is not found");
+    }
+
+    fireEvent.click(secondMonthDate);
 
     expect(
       container.querySelector(".react-datepicker__navigation--previous"),

--- a/src/test/calendar_test.test.tsx
+++ b/src/test/calendar_test.test.tsx
@@ -448,6 +448,27 @@ describe("Calendar", () => {
     expect(nextButtonAriaLabel).toBe(nextYearAriaLabel);
   });
 
+  it("should not have previous month button when selecting a date in the second month, when min date is specified", () => {
+    const { container } = render(
+      <DatePicker
+        inline
+        monthsShown={2}
+        minDate={new Date("2024-11-06")}
+        maxDate={new Date("2025-01-01")}
+      />,
+    );
+
+    const secondMonthDate = safeQuerySelectorAll(
+      container,
+      ".react-datepicker__day--009",
+    )[1];
+    fireEvent.click(secondMonthDate!);
+
+    expect(
+      container.querySelector(".react-datepicker__navigation--previous"),
+    ).toBe(null);
+  });
+
   describe("custom header", () => {
     const months = [
       "January",


### PR DESCRIPTION
## Description
**Linked issue**: #5193

**Problem**
Even though the min date is provided, when selecting the second month, "previous month" button still appears. It shouldn't happen, because the calendar from the screenshots starts at November. 

**Changes**
Changed the calculation logic that determines whether previous month button should appear or not (borrowed some code from `renderMonths`, big thanks to @pmacmillan). Added a test case, in which a calendar is rendered with min date, after that the date from the second month is selected and it is expected for "previous month" button not to appear.

## Screenshots
*Calendar starts at November 7*

**Before**
![image](https://github.com/user-attachments/assets/a96e3f4d-3391-4a6f-a156-a7ca7ff19450)
**After**
![image](https://github.com/user-attachments/assets/a2ea5edf-12d8-4535-80b7-f12cfcb706db)


## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
