### PR TITLE
fix(types): `PropsWithChildren` type argument issue

### DIFF
--- a/src/calendar.tsx
+++ b/src/calendar.tsx
@@ -108,105 +108,105 @@ type CalendarProps = React.PropsWithChildren<
     YearDropdownProps,
     "date" | "onChange" | "year" | "minDate" | "maxDate"
   > &
-  Omit<MonthDropdownProps, "month" | "onChange"> &
-  Omit<MonthYearDropdownProps, "date" | "onChange" | "minDate" | "maxDate"> &
-  Omit<
-    YearProps,
-    | "onDayClick"
-    | "selectingDate"
-    | "clearSelectingDate"
-    | "onYearMouseEnter"
-    | "onYearMouseLeave"
-    | "minDate"
-    | "maxDate"
-  > &
-  Omit<
-    MonthProps,
-    | "ariaLabelPrefix"
-    | "onChange"
-    | "day"
-    | "onDayClick"
-    | "handleOnKeyDown"
-    | "handleOnMonthKeyDown"
-    | "onDayMouseEnter"
-    | "onMouseLeave"
-    | "orderInDisplay"
-    | "monthShowsDuplicateDaysEnd"
-    | "monthShowsDuplicateDaysStart"
-    | "minDate"
-    | "maxDate"
-  > &
-  Omit<TimeProps, "onChange" | "format" | "intervals" | "monthRef"> &
-  Omit<InputTimeProps, "date" | "timeString" | "onChange"> & {
-    className?: string;
-    container?: React.ElementType;
-    showYearPicker?: boolean;
-    showMonthYearPicker?: boolean;
-    showQuarterYearPicker?: boolean;
-    showTimeSelect?: boolean;
-    showTimeInput?: boolean;
-    showYearDropdown?: boolean;
-    showMonthDropdown?: boolean;
-    yearItemNumber?: number;
-    useWeekdaysShort?: boolean;
-    forceShowMonthNavigation?: boolean;
-    showDisabledMonthNavigation?: boolean;
-    formatWeekDay?: (date: string) => string;
-    onDropdownFocus?: (event: React.FocusEvent<HTMLDivElement>) => void;
-    calendarStartDay?: Day;
-    weekDayClassName?: (date: Date) => string;
-    onMonthChange?: (date: Date) => void;
-    onYearChange?: (date: Date) => void;
-    onDayMouseEnter?: (date: Date) => void;
-    onMonthMouseLeave?: VoidFunction;
-    weekLabel?: string;
-    onClickOutside: ClickOutsideHandler;
-    outsideClickIgnoreClass?: string;
-    previousMonthButtonLabel?: React.ReactNode;
-    previousYearButtonLabel?: string;
-    previousMonthAriaLabel?: string;
-    previousYearAriaLabel?: string;
-    nextMonthButtonLabel?: React.ReactNode;
-    nextYearButtonLabel?: string;
-    nextMonthAriaLabel?: string;
-    nextYearAriaLabel?: string;
-    showPreviousMonths?: boolean;
-    monthsShown?: number;
-    monthSelectedIn?: number;
-    onSelect: (
-      day: Date,
-      event?:
-        | React.MouseEvent<HTMLDivElement>
-        | React.KeyboardEvent<HTMLDivElement>,
-      monthSelectedIn?: number,
-    ) => void;
-    renderCustomHeader?: (
-      props: ReactDatePickerCustomHeaderProps,
-    ) => JSX.Element;
-    onYearMouseEnter?: YearProps["onYearMouseEnter"];
-    onYearMouseLeave?: YearProps["onYearMouseLeave"];
-    monthAriaLabelPrefix?: MonthProps["ariaLabelPrefix"];
-    handleOnDayKeyDown?: MonthProps["handleOnKeyDown"];
-    handleOnKeyDown?: (
-      event:
-        | React.KeyboardEvent<HTMLDivElement>
-        | React.KeyboardEvent<HTMLLIElement>
-        | React.KeyboardEvent<HTMLButtonElement>,
-    ) => void;
-    onTimeChange?: TimeProps["onChange"] | InputTimeProps["onChange"];
-    timeFormat?: TimeProps["format"];
-    timeIntervals?: TimeProps["intervals"];
-  } & (
-    | ({
-        showMonthYearDropdown: true;
-      } & Pick<MonthYearDropdownProps, "maxDate" | "minDate">)
-    | ({
-        showMonthYearDropdown?: never;
-      } & Pick<YearDropdownProps, "maxDate" | "minDate"> &
-        Pick<YearProps, "maxDate" | "minDate"> &
-        Pick<MonthProps, "maxDate" | "minDate">)
-  )
->
+    Omit<MonthDropdownProps, "month" | "onChange"> &
+    Omit<MonthYearDropdownProps, "date" | "onChange" | "minDate" | "maxDate"> &
+    Omit<
+      YearProps,
+      | "onDayClick"
+      | "selectingDate"
+      | "clearSelectingDate"
+      | "onYearMouseEnter"
+      | "onYearMouseLeave"
+      | "minDate"
+      | "maxDate"
+    > &
+    Omit<
+      MonthProps,
+      | "ariaLabelPrefix"
+      | "onChange"
+      | "day"
+      | "onDayClick"
+      | "handleOnKeyDown"
+      | "handleOnMonthKeyDown"
+      | "onDayMouseEnter"
+      | "onMouseLeave"
+      | "orderInDisplay"
+      | "monthShowsDuplicateDaysEnd"
+      | "monthShowsDuplicateDaysStart"
+      | "minDate"
+      | "maxDate"
+    > &
+    Omit<TimeProps, "onChange" | "format" | "intervals" | "monthRef"> &
+    Omit<InputTimeProps, "date" | "timeString" | "onChange"> & {
+      className?: string;
+      container?: React.ElementType;
+      showYearPicker?: boolean;
+      showMonthYearPicker?: boolean;
+      showQuarterYearPicker?: boolean;
+      showTimeSelect?: boolean;
+      showTimeInput?: boolean;
+      showYearDropdown?: boolean;
+      showMonthDropdown?: boolean;
+      yearItemNumber?: number;
+      useWeekdaysShort?: boolean;
+      forceShowMonthNavigation?: boolean;
+      showDisabledMonthNavigation?: boolean;
+      formatWeekDay?: (date: string) => string;
+      onDropdownFocus?: (event: React.FocusEvent<HTMLDivElement>) => void;
+      calendarStartDay?: Day;
+      weekDayClassName?: (date: Date) => string;
+      onMonthChange?: (date: Date) => void;
+      onYearChange?: (date: Date) => void;
+      onDayMouseEnter?: (date: Date) => void;
+      onMonthMouseLeave?: VoidFunction;
+      weekLabel?: string;
+      onClickOutside: ClickOutsideHandler;
+      outsideClickIgnoreClass?: string;
+      previousMonthButtonLabel?: React.ReactNode;
+      previousYearButtonLabel?: string;
+      previousMonthAriaLabel?: string;
+      previousYearAriaLabel?: string;
+      nextMonthButtonLabel?: React.ReactNode;
+      nextYearButtonLabel?: string;
+      nextMonthAriaLabel?: string;
+      nextYearAriaLabel?: string;
+      showPreviousMonths?: boolean;
+      monthsShown?: number;
+      monthSelectedIn?: number;
+      onSelect: (
+        day: Date,
+        event?:
+          | React.MouseEvent<HTMLDivElement>
+          | React.KeyboardEvent<HTMLDivElement>,
+        monthSelectedIn?: number,
+      ) => void;
+      renderCustomHeader?: (
+        props: ReactDatePickerCustomHeaderProps,
+      ) => JSX.Element;
+      onYearMouseEnter?: YearProps["onYearMouseEnter"];
+      onYearMouseLeave?: YearProps["onYearMouseLeave"];
+      monthAriaLabelPrefix?: MonthProps["ariaLabelPrefix"];
+      handleOnDayKeyDown?: MonthProps["handleOnKeyDown"];
+      handleOnKeyDown?: (
+        event:
+          | React.KeyboardEvent<HTMLDivElement>
+          | React.KeyboardEvent<HTMLLIElement>
+          | React.KeyboardEvent<HTMLButtonElement>,
+      ) => void;
+      onTimeChange?: TimeProps["onChange"] | InputTimeProps["onChange"];
+      timeFormat?: TimeProps["format"];
+      timeIntervals?: TimeProps["intervals"];
+    } & (
+      | ({
+          showMonthYearDropdown: true;
+        } & Pick<MonthYearDropdownProps, "maxDate" | "minDate">)
+      | ({
+          showMonthYearDropdown?: never;
+        } & Pick<YearDropdownProps, "maxDate" | "minDate"> &
+          Pick<YearProps, "maxDate" | "minDate"> &
+          Pick<MonthProps, "maxDate" | "minDate">)
+    )
+>;
 
 interface CalendarState
   extends Pick<YearProps, "selectingDate">,

--- a/src/calendar.tsx
+++ b/src/calendar.tsx
@@ -103,7 +103,7 @@ export interface ReactDatePickerCustomHeaderProps {
   nextYearButtonDisabled: boolean;
 }
 
-type CalendarProps = React.PropsWithChildren &
+type CalendarProps = React.PropsWithChildren<
   Omit<
     YearDropdownProps,
     "date" | "onChange" | "year" | "minDate" | "maxDate"
@@ -205,7 +205,8 @@ type CalendarProps = React.PropsWithChildren &
       } & Pick<YearDropdownProps, "maxDate" | "minDate"> &
         Pick<YearProps, "maxDate" | "minDate"> &
         Pick<MonthProps, "maxDate" | "minDate">)
-  );
+  )
+>
 
 interface CalendarState
   extends Pick<YearProps, "selectingDate">,


### PR DESCRIPTION
**Problem**
The current CalendarProps type definition is incorrect, leading to type errors when using the component. This issue arises because `React.PropsWithChildren` is a generic type that requires a type argument to specify the component's props.

**Changes**
This PR fixes the type definition by correctly combining `React.PropsWithChildren` with `CalendarProps`. This ensures proper type checking and prevents potential runtime errors.

## Screenshots
![error](https://github.com/user-attachments/assets/0b3399d0-a577-46bd-81e9-92ab543e9cb7)


## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
