### PR TITLE
feat(datepicker): added `showSelectedCount` for the component

### DIFF
--- a/src/date_utils.ts
+++ b/src/date_utils.ts
@@ -308,14 +308,14 @@ export function safeMultipleDatesFormat(
   props: {
     dateFormat: string | string[];
     locale?: Locale;
-    showCount?: boolean;
+    showSelectedCount?: boolean;
   },
 ): string {
   if (!dates?.length) {
     return "";
   }
 
-  if (props?.showCount === false) {
+  if (props?.showSelectedCount === false) {
     const formattedAllDates = dates.map((date) => safeDateFormat(date, props));
     return formattedAllDates.join(", ");
   }

--- a/src/date_utils.ts
+++ b/src/date_utils.ts
@@ -305,10 +305,19 @@ export function safeDateRangeFormat(
  */
 export function safeMultipleDatesFormat(
   dates: Date[],
-  props: { dateFormat: string | string[]; locale?: Locale },
+  props: {
+    dateFormat: string | string[];
+    locale?: Locale;
+    showCount?: boolean;
+  },
 ): string {
   if (!dates?.length) {
     return "";
+  }
+
+  if (props?.showCount === false) {
+    const formattedAllDates = dates.map((date) => safeDateFormat(date, props));
+    return formattedAllDates.join(", ");
   }
 
   const formattedFirstDate = dates[0] ? safeDateFormat(dates[0], props) : "";

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -206,6 +206,7 @@ export type DatePickerProps = OmitUnion<
     | {
         selectsRange?: never;
         selectsMultiple?: never;
+        showCount?: never;
         onChange?: (
           date: Date | null,
           event?:
@@ -216,6 +217,7 @@ export type DatePickerProps = OmitUnion<
     | {
         selectsRange: true;
         selectsMultiple?: never;
+        showCount?: never;
         onChange?: (
           date: [Date | null, Date | null],
           event?:
@@ -226,6 +228,7 @@ export type DatePickerProps = OmitUnion<
     | {
         selectsRange?: never;
         selectsMultiple: true;
+        showCount?: boolean;
         onChange?: (
           date: Date[] | null,
           event?:
@@ -301,6 +304,7 @@ export default class DatePicker extends Component<
       calendarStartDay: undefined,
       toggleCalendarOnIconClick: false,
       usePointerEvent: false,
+      showCount: true,
     };
   }
 
@@ -1337,8 +1341,11 @@ export default class DatePicker extends Component<
 
     const customInput = this.props.customInput || <input type="text" />;
     const customInputRef = this.props.customInputRef || "ref";
-    const { dateFormat = DatePicker.defaultProps.dateFormat, locale } =
-      this.props;
+    const {
+      dateFormat = DatePicker.defaultProps.dateFormat,
+      locale,
+      showCount = DatePicker.defaultProps.showCount,
+    } = this.props;
     const inputValue =
       typeof this.props.value === "string"
         ? this.props.value
@@ -1353,6 +1360,7 @@ export default class DatePicker extends Component<
               ? safeMultipleDatesFormat(this.props.selectedDates ?? [], {
                   dateFormat,
                   locale,
+                  showCount,
                 })
               : safeDateFormat(this.props.selected, {
                   dateFormat,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -206,7 +206,7 @@ export type DatePickerProps = OmitUnion<
     | {
         selectsRange?: never;
         selectsMultiple?: never;
-        showCount?: never;
+        showSelectedCount?: never;
         onChange?: (
           date: Date | null,
           event?:
@@ -217,7 +217,7 @@ export type DatePickerProps = OmitUnion<
     | {
         selectsRange: true;
         selectsMultiple?: never;
-        showCount?: never;
+        showSelectedCount?: never;
         onChange?: (
           date: [Date | null, Date | null],
           event?:
@@ -228,7 +228,7 @@ export type DatePickerProps = OmitUnion<
     | {
         selectsRange?: never;
         selectsMultiple: true;
-        showCount?: boolean;
+        showSelectedCount?: boolean;
         onChange?: (
           date: Date[] | null,
           event?:
@@ -304,7 +304,7 @@ export default class DatePicker extends Component<
       calendarStartDay: undefined,
       toggleCalendarOnIconClick: false,
       usePointerEvent: false,
-      showCount: true,
+      showSelectedCount: true,
     };
   }
 
@@ -1344,7 +1344,7 @@ export default class DatePicker extends Component<
     const {
       dateFormat = DatePicker.defaultProps.dateFormat,
       locale,
-      showCount = DatePicker.defaultProps.showCount,
+      showSelectedCount = DatePicker.defaultProps.showSelectedCount,
     } = this.props;
     const inputValue =
       typeof this.props.value === "string"
@@ -1360,7 +1360,7 @@ export default class DatePicker extends Component<
               ? safeMultipleDatesFormat(this.props.selectedDates ?? [], {
                   dateFormat,
                   locale,
-                  showCount,
+                  showSelectedCount,
                 })
               : safeDateFormat(this.props.selected, {
                   dateFormat,

--- a/src/test/date_utils_test.test.ts
+++ b/src/test/date_utils_test.test.ts
@@ -51,6 +51,7 @@ import {
   getMidnightDate,
   registerLocale,
   isMonthYearDisabled,
+  safeMultipleDatesFormat,
 } from "../date_utils";
 
 registerLocale("pt-BR", ptBR);
@@ -1227,6 +1228,33 @@ describe("date_utils", () => {
       expect(safeDateRangeFormat(startDate, endDate, props)).toBe(
         "04/20/2021 - 04/28/2021",
       );
+    });
+  });
+
+  describe("safeMultipleDatesFormat", () => {
+    const props = {
+      dateFormat: "MM/dd/yyyy",
+      locale: "en",
+    };
+
+    const dates = [
+      new Date("2024-11-14 00:00:00"),
+      new Date("2024-11-15 00:00:00"),
+      new Date("2024-11-16 00:00:00"),
+    ];
+
+    it("should return a blank string when the dates array is null", () => {
+      expect(safeMultipleDatesFormat([], props)).toBe("");
+    });
+
+    it("should return the correct count when multiple dates are selected", () => {
+      expect(safeMultipleDatesFormat(dates, props)).toBe("11/14/2024 (+2)");
+    });
+
+    it("should return each selected date when showSelectedCount is false", () => {
+      expect(
+        safeMultipleDatesFormat(dates, { ...props, showSelectedCount: false }),
+      ).toBe("11/14/2024, 11/15/2024, 11/16/2024");
     });
   });
 

--- a/src/test/min_time_test.test.tsx
+++ b/src/test/min_time_test.test.tsx
@@ -24,6 +24,7 @@ const DatePickerWithState = (
       | "dateFormat"
       | "selectsRange"
       | "selectsMultiple"
+      | "showSelectedCount"
       | "onSelect"
     >,
 ) => {


### PR DESCRIPTION
**Description**

This PR introduces a new feature to the component: the ability to customize how multiple selected dates are displayed in the input field. By adding the `showSelectedCount` prop, developers can choose between displaying a count of selected dates or a comma-separated list.
##


**Problem**

The existing behavior of displaying a date count in the input field can be less informative for users who need to see the exact dates that have been selected, especially when dealing with a large number of selected dates.
##

**Changes**
- A new boolean prop, `showSelectedCount`, has been added to the component.
 
- The component's rendering logic has been updated to conditionally render either the date count or a comma-separated list based on the value of the `showSelectedCount` prop.

- The `showSelectedCount` prop defaults to true for backward compatibility.

- I've added unit tests to cover the new functionality and ensure that existing functionality remains unaffected.
##

**Screenshots**

`showSelectedCount`: true

![Screenshot 2024-11-14 at 13 10 13](https://github.com/user-attachments/assets/8ddbb391-aa51-414f-89c9-790de735e30d)

`showSelectedCount`: false
![Screenshot 2024-11-14 at 13 10 46](https://github.com/user-attachments/assets/9193727a-a7e5-4a60-8db9-962595b34f8e)
##

**Contribution checklist**
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
