### PR TITLE
Fix #5200: Fix the unnecessary highlight on the Week Number when the first day of the week is selected using Keyboard

### DIFF
--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -347,10 +347,7 @@ h2.react-datepicker__current-month {
   &.react-datepicker__week-number--clickable {
     cursor: pointer;
 
-    &:not(
-        .react-datepicker__week-number--selected,
-        .react-datepicker__week-number--keyboard-selected
-      ):hover {
+    &:not(.react-datepicker__week-number--selected):hover {
       border-radius: $datepicker__border-radius;
       background-color: $datepicker__background-color;
     }
@@ -362,17 +359,10 @@ h2.react-datepicker__current-month {
     color: #fff;
 
     &:hover {
-      background-color: color.adjust($datepicker__selected-color, $lightness: -5%);
-    }
-  }
-
-  &--keyboard-selected {
-    border-radius: $datepicker__border-radius;
-    background-color: color.adjust($datepicker__selected-color, $lightness: 10%);
-    color: #fff;
-
-    &:hover {
-      background-color: color.adjust($datepicker__selected-color, $lightness: -5%);
+      background-color: color.adjust(
+        $datepicker__selected-color,
+        $lightness: -5%
+      );
     }
   }
 }
@@ -418,7 +408,10 @@ h2.react-datepicker__current-month {
     color: #fff;
 
     &:not([aria-disabled="true"]):hover {
-      background-color: color.adjust($datepicker__highlighted-color, $lightness: -5%);
+      background-color: color.adjust(
+        $datepicker__highlighted-color,
+        $lightness: -5%
+      );
     }
 
     &-custom-1 {
@@ -454,7 +447,10 @@ h2.react-datepicker__current-month {
     }
 
     &:not([aria-disabled="true"]):hover {
-      background-color: color.adjust($datepicker__holidays-color, $lightness: -10%);
+      background-color: color.adjust(
+        $datepicker__holidays-color,
+        $lightness: -10%
+      );
     }
 
     &:hover .overlay {
@@ -471,17 +467,26 @@ h2.react-datepicker__current-month {
     color: #fff;
 
     &:not([aria-disabled="true"]):hover {
-      background-color: color.adjust($datepicker__selected-color, $lightness: -5%);
+      background-color: color.adjust(
+        $datepicker__selected-color,
+        $lightness: -5%
+      );
     }
   }
 
   &--keyboard-selected {
     border-radius: $datepicker__border-radius;
-    background-color: color.adjust($datepicker__selected-color, $lightness: 45%);
+    background-color: color.adjust(
+      $datepicker__selected-color,
+      $lightness: 45%
+    );
     color: rgb(0, 0, 0);
 
     &:not([aria-disabled="true"]):hover {
-      background-color: color.adjust($datepicker__selected-color, $lightness: -5%);
+      background-color: color.adjust(
+        $datepicker__selected-color,
+        $lightness: -5%
+      );
     }
   }
 
@@ -550,7 +555,10 @@ h2.react-datepicker__current-month {
 
     .react-datepicker__year-read-view--down-arrow,
     .react-datepicker__month-read-view--down-arrow {
-      border-top-color: color.adjust($datepicker__muted-color, $lightness: -10%);
+      border-top-color: color.adjust(
+        $datepicker__muted-color,
+        $lightness: -10%
+      );
     }
   }
 
@@ -613,11 +621,17 @@ h2.react-datepicker__current-month {
     background-color: $datepicker__muted-color;
 
     .react-datepicker__navigation--years-upcoming {
-      border-bottom-color: color.adjust($datepicker__muted-color, $lightness: -10%);
+      border-bottom-color: color.adjust(
+        $datepicker__muted-color,
+        $lightness: -10%
+      );
     }
 
     .react-datepicker__navigation--years-previous {
-      border-top-color: color.adjust($datepicker__muted-color, $lightness: -10%);
+      border-top-color: color.adjust(
+        $datepicker__muted-color,
+        $lightness: -10%
+      );
     }
   }
 

--- a/src/test/week_number_test.test.tsx
+++ b/src/test/week_number_test.test.tsx
@@ -186,11 +186,6 @@ describe("WeekNumber", () => {
         ) as HTMLDivElement;
         expect(weekNumber).not.toBeNull();
 
-        expect(
-          weekNumber?.classList.contains(
-            "react-datepicker__week-number--keyboard-selected",
-          ),
-        ).toBe(false);
         expect(weekNumber?.tabIndex).toBe(0);
       });
 
@@ -212,11 +207,6 @@ describe("WeekNumber", () => {
           ".react-datepicker__week-number",
         ) as HTMLDivElement;
         expect(weekNumber).not.toBeNull();
-        expect(
-          weekNumber?.classList.contains(
-            "react-datepicker__week-number--keyboard-selected",
-          ),
-        ).toBe(true);
         expect(weekNumber.tabIndex).toBe(0);
       });
 
@@ -267,11 +257,6 @@ describe("WeekNumber", () => {
         const weekNumber = container.querySelector(
           ".react-datepicker__week-number",
         ) as HTMLDivElement;
-        expect(
-          weekNumber?.classList.contains(
-            "react-datepicker__week-number--keyboard-selected",
-          ),
-        ).toBe(false);
         expect(weekNumber.tabIndex).toBe(-1);
       });
     });
@@ -403,11 +388,6 @@ describe("WeekNumber", () => {
             "react-datepicker__week-number--selected",
           ),
         ).toBe(false);
-        expect(
-          weekNumber?.classList.contains(
-            "react-datepicker__week-number--keyboard-selected",
-          ),
-        ).toBe(true);
       });
 
       it("should have the class 'react-datepicker__week-number--selected' if selected is not current week and preselected is not current week", () => {
@@ -428,11 +408,6 @@ describe("WeekNumber", () => {
         expect(
           weekNumber?.classList.contains(
             "react-datepicker__week-number--selected",
-          ),
-        ).toBe(false);
-        expect(
-          weekNumber?.classList.contains(
-            "react-datepicker__week-number--keyboard-selected",
           ),
         ).toBe(false);
       });

--- a/src/week_number.tsx
+++ b/src/week_number.tsx
@@ -120,8 +120,6 @@ export default class WeekNumber extends Component<WeekNumberProps> {
       "react-datepicker__week-number--clickable": !!onClick,
       "react-datepicker__week-number--selected":
         !!onClick && isSameDay(this.props.date, this.props.selected),
-      "react-datepicker__week-number--keyboard-selected":
-        this.isKeyboardSelected(),
     };
     return (
       <div


### PR DESCRIPTION
Closes #5200 

## Description
As mentioned in the ticket, when `showWeekNumbers` is enabled in a datepicker, the keyboard select on the first day of the week alone highlights the week number.  When we select any other week days it's not highlighting.  This issue is not occuring in the mouse hover of any week days.  

## Why the issue occurs?
![image](https://github.com/user-attachments/assets/b9f54883-f449-418c-a40a-7fe96d95c09f)

As I shared in the above screenshot, we passed the start of the week to each corresponding week number and in the `<WeekNumber />` component we apply a class `react-datepicker__week-number--keyboard-selected` when the date prop (which is start of the week) is selected. 

**Changes**
- As a fix, I removed the setting of `react-datepicker__week-number--keyboard-selected` to <WeekNumber />.  The reason is because we are not applying any class to it when we hover the first day of the week using mouse.  Also if we plan to highlight the week number it should enabled for all week days and not just the start date and it should be applied to the mouse hover aswell.  But I don't think that's necessary as the week number we're displaying is just looks like a read-only kind of view, as it's grayed out currently.  Hence I feel removing the class `react-datepicker__week-number--keyboard-selected` would be a better way to fix the issue.
- I also updated the existing test cases

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
