### PR TITLE
fix(types): `PropsWithChildren` type argument issue

### DIFF
--- a/src/calendar_container.tsx
+++ b/src/calendar_container.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 
-export interface CalendarContainerProps extends React.PropsWithChildren {
+export interface CalendarContainerProps
+  extends React.PropsWithChildren<HTMLDivElement> {
   showTimeSelectOnly?: boolean;
   showTime?: boolean;
-  className?: string;
 }
 
 const CalendarContainer: React.FC<CalendarContainerProps> = function ({

--- a/src/popper_component.tsx
+++ b/src/popper_component.tsx
@@ -7,6 +7,7 @@ import TabLoop from "./tab_loop";
 import withFloating from "./with_floating";
 
 import type { FloatingProps } from "./with_floating";
+import type { ReactNode } from "react";
 
 interface PortalProps
   extends Omit<React.ComponentPropsWithoutRef<typeof Portal>, "children"> {}
@@ -20,7 +21,7 @@ interface PopperComponentProps
   className?: string;
   wrapperClassName?: string;
   popperComponent: React.ReactNode;
-  popperContainer?: React.FC<React.PropsWithChildren>;
+  popperContainer?: React.FC<{ children?: ReactNode | undefined }>;
   targetComponent: React.ReactNode;
   popperOnKeyDown: React.KeyboardEventHandler<HTMLDivElement>;
   showArrow?: boolean;

--- a/src/tab_loop.tsx
+++ b/src/tab_loop.tsx
@@ -1,7 +1,10 @@
 import React, { Component, createRef } from "react";
 
-interface TabLoopProps extends React.PropsWithChildren {
+import type { ReactNode } from "react";
+
+interface TabLoopProps {
   enableTabLoop?: boolean;
+  children?: ReactNode | undefined;
 }
 
 const focusableElementsSelector =


### PR DESCRIPTION
**Problem**
The current CalendarProps type definition is incorrect, leading to type errors when using the component. This issue arises because `React.PropsWithChildren` is a generic type that requires a type argument to specify the component's props.

Same as: #5223

**Changes**
This PR fixes the type definition by correctly combining `React.PropsWithChildren` with `CalendarProps`. This ensures proper type checking and prevents potential runtime errors.

## Screenshots
![error](https://github.com/user-attachments/assets/0b3399d0-a577-46bd-81e9-92ab543e9cb7)


## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
