### PR TITLE
fix: remove wrong class assignment on year wrapper

### DIFF
--- a/src/year.tsx
+++ b/src/year.tsx
@@ -407,15 +407,6 @@ export default class Year extends Component<YearProps> {
     return y === preSelected && !isPreSelectedYearDisabled ? "0" : "-1";
   };
 
-  getYearContainerClassNames = () => {
-    const { selectingDate, selectsStart, selectsEnd, selectsRange } =
-      this.props;
-    return clsx("react-datepicker__year", {
-      "react-datepicker__year--selecting-range":
-        selectingDate && (selectsStart || selectsEnd || selectsRange),
-    });
-  };
-
   getYearContent = (y: number) => {
     return this.props.renderYearContent ? this.props.renderYearContent(y) : y;
   };
@@ -475,7 +466,7 @@ export default class Year extends Component<YearProps> {
     }
 
     return (
-      <div className={this.getYearContainerClassNames()}>
+      <div className="react-datepicker__year">
         <div
           className="react-datepicker__year-wrapper"
           onMouseLeave={


### PR DESCRIPTION
## Description

The class `react-datepicker__year--selecting-range` was being added on the entire year wrapper which does not make sense. This causes several UI issues when applying custom CSS using this selector