### PR TITLE
Remove unused prop-types dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,23 @@
   "module": "dist/es/index.js",
   "unpkg": "dist/react-datepicker.min.js",
   "style": "dist/react-datepicker.min.css",
-  "files": ["*.md", "dist", "lib", "es", "src/stylesheets"],
-  "sideEffects": ["**/*.css"],
-  "keywords": ["react", "datepicker", "calendar", "date", "react-component"],
+  "files": [
+    "*.md",
+    "dist",
+    "lib",
+    "es",
+    "src/stylesheets"
+  ],
+  "sideEffects": [
+    "**/*.css"
+  ],
+  "keywords": [
+    "react",
+    "datepicker",
+    "calendar",
+    "date",
+    "react-component"
+  ],
   "repository": {
     "type": "git",
     "url": "git://github.com/Hacker0x01/react-datepicker.git"
@@ -84,8 +98,7 @@
   "dependencies": {
     "@floating-ui/react": "^0.26.23",
     "clsx": "^2.1.1",
-    "date-fns": "^3.6.0",
-    "prop-types": "^15.8.1"
+    "date-fns": "^3.6.0"
   },
   "scripts": {
     "eslint": "eslint --ext .js,.jsx,.ts,.tsx ./src",
@@ -111,7 +124,10 @@
     "prepare": "husky"
   },
   "lint-staged": {
-    "*.{js,jsx,ts,tsx,json,css,scss,md}": ["prettier --write", "git add"]
+    "*.{js,jsx,ts,tsx,json,css,scss,md}": [
+      "prettier --write",
+      "git add"
+    ]
   },
   "packageManager": "yarn@4.4.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9318,7 +9318,6 @@ __metadata:
     lint-staged: "npm:^15.2.9"
     lodash: "npm:^4.17.21"
     prettier: "npm:^3.3.3"
-    prop-types: "npm:^15.8.1"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     rollup: "npm:^4.21.1"


### PR DESCRIPTION
---
name: Remove unused prop-types dependency
about: Found an unused dependency and removed it
title: ""
labels: ""
assignees: ""
---

## Description
Was looking through dependencies and noticed that prop-types was in the dependency list.  This library is not actually imported in the core library and is instead only used inside the demo app.  The Readme also mentions that prop-types is not bundled and should be installed if needed.
**Linked issue**: #(issue number) 

**Problem**
<!-- The problems this PR aims to solve -->

**Changes**
Ran `yarn remove prop-types`
<!-- Changes you have made to address the issue -->

## Screenshots
<!-- If applicable, add screenshots to help explain your improvements -->

## To reviewers
<!-- Additional comments for reviewers -->

## Contribution checklist
- [X] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [X] I have added sufficient test coverage for my changes.
- [X] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
