### PR TITLE
Added react ^19 and ^19.0.0-rc as peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,8 +78,8 @@
     "typescript": "^5.5.4"
   },
   "peerDependencies": {
-    "react": "^16.9.0 || ^17 || ^18",
-    "react-dom": "^16.9.0 || ^17 || ^18"
+    "react": "^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+    "react-dom": "^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc"
   },
   "dependencies": {
     "@floating-ui/react": "^0.26.23",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9333,8 +9333,8 @@ __metadata:
     tslib: "npm:^2.7.0"
     typescript: "npm:^5.5.4"
   peerDependencies:
-    react: ^16.9.0 || ^17 || ^18
-    react-dom: ^16.9.0 || ^17 || ^18
+    react: ^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc
+    react-dom: ^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Added react ^19 and ^19.0.0-rc as peer dependency. Some projects like Next.js already utilize react 19 release candidate, so that installing react-datepicker can only be done with `--legacy-peer-deps`. I have tested the `react-datepicker` with Next.js and react 19 release candidate and it works. So I have added react ^19 and ^19.0.0-rc as peer dep

---
name: Pull Request
about: Create a pull request to improve this repository
title: ""
labels: ""
assignees: ""
---

## Description
**Linked issue**: #(<none>) 

**Problem**
Using react-datepicker with Next.js only works with --legacy-peer-deps

**Changes**
Added react ^19 and ^19.0.0-rc as peer dep

## Screenshots
<!-- If applicable, add screenshots to help explain your improvements -->

## To reviewers
<!-- Additional comments for reviewers -->

## Contribution checklist
- [X ] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [X ] I have added sufficient test coverage for my changes. - no explicit test added, but all tests pass.
- [ X] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
