### PR TITLE
fix: types for startDate and endDate props (#5259)

### DIFF
--- a/src/day.tsx
+++ b/src/day.tsx
@@ -39,7 +39,6 @@ interface DayProps
   disabledKeyboardNavigation?: boolean;
   day: Date;
   dayClassName?: (date: Date) => string;
-  endDate?: Date;
   highlightDates?: Map<string, string[]>;
   holidays?: HolidaysMap;
   inline?: boolean;
@@ -60,7 +59,8 @@ interface DayProps
   selectsDisabledDaysInRange?: boolean;
   selectsMultiple?: boolean;
   selectedDates?: Date[];
-  startDate?: Date;
+  startDate?: Date | null;
+  endDate?: Date | null;
   renderDayContents?: (day: number, date: Date) => React.ReactNode;
   containerRef?: React.RefObject<HTMLDivElement>;
   calendarStartDay?: DateNumberType;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -176,7 +176,8 @@ export type DatePickerProps = OmitUnion<
     calendarIconClassName?: string;
     toggleCalendarOnIconClick?: boolean;
     holidays?: Holiday[];
-    startDate?: Date;
+    startDate?: Date | null;
+    endDate?: Date | null;
     selected?: Date | null;
     value?: string;
     customInputRef?: string;

--- a/src/month.tsx
+++ b/src/month.tsx
@@ -124,6 +124,8 @@ interface MonthProps
   handleOnMonthKeyDown?: (event: React.KeyboardEvent<HTMLDivElement>) => void;
   ariaLabelPrefix?: string;
   day: Date;
+  startDate?: Date | null;
+  endDate?: Date | null;
   orderInDisplay?: number;
   fixedHeight?: boolean;
   peekNextMonth?: boolean;

--- a/src/year.tsx
+++ b/src/year.tsx
@@ -30,7 +30,6 @@ interface YearProps
   clearSelectingDate?: VoidFunction;
   date?: Date;
   disabledKeyboardNavigation?: boolean;
-  endDate?: Date;
   onDayClick?: (
     date: Date,
     event:
@@ -55,7 +54,8 @@ interface YearProps
   selectsEnd?: boolean;
   selectsStart?: boolean;
   selectsRange?: boolean;
-  startDate?: Date;
+  startDate?: Date | null;
+  endDate?: Date | null;
   yearItemNumber?: number;
   handleOnKeyDown?: React.KeyboardEventHandler<HTMLDivElement>;
   yearClassName?: (date: Date) => string;


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to improve this repository
title: "Fix types for startDate and endDate props"
labels: "Typescript"
assignees: "Sergey Kazarinov"
---

## Description
**Linked issue**: #5259  

**Problem**
Solves the type issue for startDate and endDate props when I select selectsRange

**Changes**
Extend the typing of startDate and endDate props. Added union type Date | null

## Screenshots
![image](https://github.com/user-attachments/assets/43cf6d8c-7015-47a0-a7bc-0eae4e1c69ca)  
![image](https://github.com/user-attachments/assets/e7c156ee-32b2-44df-b733-f38661308584)


## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
