### PR TITLE
:ambulance: Fix the problem where pressing Enter after deleting a value in the custom input results in the first value being incorrectly formatted as '2001'.

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -962,6 +962,7 @@ export default class DatePicker extends Component<
       const copy = newDate(this.state.preSelection);
       if (eventKey === KeyType.Enter) {
         event.preventDefault();
+        (event.target as HTMLInputElement).blur();
         if (
           this.inputOk() &&
           this.state.lastPreSelectChange === PRESELECT_CHANGE_VIA_NAVIGATE
@@ -973,6 +974,7 @@ export default class DatePicker extends Component<
         }
       } else if (eventKey === KeyType.Escape) {
         event.preventDefault();
+        (event.target as HTMLInputElement).blur();
         this.sendFocusBackToInput();
         this.setOpen(false);
       } else if (eventKey === KeyType.Tab) {


### PR DESCRIPTION
I have an issue where, after typing the year and pressing Enter in the customInput field of React Datepicker, the value is automatically formatted when I delete it.

I'm handling the issue by blurring the field when Enter or Escape is pressed, and ensuring the selected value is preserved.