### PR TITLE
Fix condition preventing props.onFocus execution

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -515,9 +515,13 @@ export default class DatePicker extends Component<
       this.resetHiddenStatus();
     }
 
-    if (!this.state.preventFocus && isOpenAllowed) {
+    if (!this.state.preventFocus) {
       this.props.onFocus?.(event);
-      if (!this.props.preventOpenOnFocus && !this.props.readOnly) {
+      if (
+        isOpenAllowed &&
+        !this.props.preventOpenOnFocus &&
+        !this.props.readOnly
+      ) {
         this.setOpen(true);
       }
     }

--- a/src/test/datepicker_test.test.tsx
+++ b/src/test/datepicker_test.test.tsx
@@ -119,6 +119,32 @@ describe("DatePicker", () => {
     expect(container.querySelector(".react-datepicker")).toBeFalsy();
   });
 
+  it("should be executed props.onFocus on input focus when the document visibility changes", () => {
+    const onFocusSpy = jest.fn();
+
+    const { container } = render(<DatePicker onFocus={onFocusSpy} />);
+
+    const input = safeQuerySelector<HTMLInputElement>(container, "input");
+
+    fireEvent.focus(input);
+    expect(onFocusSpy).toHaveBeenCalled();
+
+    expect(container.querySelector(".react-datepicker")).toBeTruthy();
+    fireEvent.keyDown(input, getKey(KeyType.Escape));
+    fireEvent.blur(input);
+    expect(container.querySelector(".react-datepicker")).toBeFalsy();
+
+    hideDocument(input);
+    showDocument(input);
+
+    expect(onFocusSpy).toHaveBeenCalled();
+    expect(container.querySelector(".react-datepicker")).toBeFalsy();
+
+    fireEvent.click(input);
+    expect(onFocusSpy).toHaveBeenCalled();
+    expect(container.querySelector(".react-datepicker")).toBeTruthy();
+  });
+
   it("should show the calendar when focusing on the date input", () => {
     const { container } = render(<DatePicker />);
 


### PR DESCRIPTION
### Fixing the prevention of executing props.onFocus after the visibilitychange event occurs.
---

**Problem**
In MR https://github.com/Hacker0x01/react-datepicker/pull/4878, the behavior of the calendar popup when switching browser tabs has been fixed. However, the `props.onFocus` callback in the `handleFocus` method was blocked if a browser tab was switched before.

**Changes**
I've moved the `isOpenAllowed` flag condition checking so that the `props.onFocus` callback will execute as before, regardless of the calendar popup opening.

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.