### PR TITLE
chore(deps): upgrade date-fns to v4.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   "dependencies": {
     "@floating-ui/react": "^0.27.0",
     "clsx": "^2.1.1",
-    "date-fns": "^3.6.0"
+    "date-fns": "^4.1.0"
   },
   "scripts": {
     "eslint": "eslint --ext .js,.jsx,.ts,.tsx ./src",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -24,25 +24,6 @@ const banner = `/*!
   Released under the ${pkg.license} License.
 */`;
 
-// it's important to mark all subpackages of data-fns as externals
-// see https://github.com/Hacker0x01/react-datepicker/issues/1606
-// We're relying on date-fn's package.json `exports` field to
-// determine the list of directories to include.
-const dateFnsPackageJson = JSON.parse(
-  fs
-    .readFileSync(
-      path.join(
-        path.dirname(fileURLToPath(import.meta.url)),
-        "node_modules/date-fns/package.json",
-      ),
-    )
-    .toString(),
-);
-const dateFnsSubpackages = Object.keys(dateFnsPackageJson.exports)
-  .map((key) => key.replace("./", ""))
-  .filter((key) => key !== "." && key !== "package.json")
-  .map((key) => `date-fns/${key}`);
-
 const globals = {
   react: "React",
   "prop-types": "PropTypes",
@@ -109,7 +90,6 @@ const config = {
   external: [
     ...Object.keys(pkg.dependencies || {}),
     ...Object.keys(pkg.peerDependencies || {}),
-    ...dateFnsSubpackages,
   ],
 };
 

--- a/src/date_utils.ts
+++ b/src/date_utils.ts
@@ -1,64 +1,67 @@
-import { addDays } from "date-fns/addDays";
-import { addHours } from "date-fns/addHours";
-import { addMinutes } from "date-fns/addMinutes";
-import { addMonths } from "date-fns/addMonths";
-import { addQuarters } from "date-fns/addQuarters";
-import { addSeconds } from "date-fns/addSeconds";
-import { addWeeks } from "date-fns/addWeeks";
-import { addYears } from "date-fns/addYears";
-import { differenceInCalendarDays } from "date-fns/differenceInCalendarDays";
-import { differenceInCalendarMonths } from "date-fns/differenceInCalendarMonths";
-import { differenceInCalendarQuarters } from "date-fns/differenceInCalendarQuarters";
-import { differenceInCalendarYears } from "date-fns/differenceInCalendarYears";
-import { endOfDay } from "date-fns/endOfDay";
-import { endOfMonth } from "date-fns/endOfMonth";
-import { endOfWeek } from "date-fns/endOfWeek";
-import { endOfYear } from "date-fns/endOfYear";
-import { format, longFormatters } from "date-fns/format";
-import { getDate } from "date-fns/getDate";
-import { getDay } from "date-fns/getDay";
-import { getHours } from "date-fns/getHours";
-import { getISOWeek } from "date-fns/getISOWeek";
-import { getMinutes } from "date-fns/getMinutes";
-import { getMonth } from "date-fns/getMonth";
-import { getQuarter } from "date-fns/getQuarter";
-import { getSeconds } from "date-fns/getSeconds";
-import { getTime } from "date-fns/getTime";
-import { getYear } from "date-fns/getYear";
-import { isAfter } from "date-fns/isAfter";
-import { isBefore } from "date-fns/isBefore";
-import { isDate } from "date-fns/isDate";
-import { isEqual as dfIsEqual } from "date-fns/isEqual";
-import { isSameDay as dfIsSameDay } from "date-fns/isSameDay";
-import { isSameMonth as dfIsSameMonth } from "date-fns/isSameMonth";
-import { isSameQuarter as dfIsSameQuarter } from "date-fns/isSameQuarter";
-import { isSameYear as dfIsSameYear } from "date-fns/isSameYear";
-import { isValid as isValidDate } from "date-fns/isValid";
-import { isWithinInterval } from "date-fns/isWithinInterval";
-import { max } from "date-fns/max";
-import { min } from "date-fns/min";
-import { parse } from "date-fns/parse";
-import { parseISO } from "date-fns/parseISO";
-import { set } from "date-fns/set";
-import { setHours } from "date-fns/setHours";
-import { setMinutes } from "date-fns/setMinutes";
-import { setMonth } from "date-fns/setMonth";
-import { setQuarter } from "date-fns/setQuarter";
-import { setSeconds } from "date-fns/setSeconds";
-import { setYear } from "date-fns/setYear";
-import { startOfDay } from "date-fns/startOfDay";
-import { startOfMonth } from "date-fns/startOfMonth";
-import { startOfQuarter } from "date-fns/startOfQuarter";
-import { startOfWeek } from "date-fns/startOfWeek";
-import { startOfYear } from "date-fns/startOfYear";
-import { subDays } from "date-fns/subDays";
-import { subMonths } from "date-fns/subMonths";
-import { subQuarters } from "date-fns/subQuarters";
-import { subWeeks } from "date-fns/subWeeks";
-import { subYears } from "date-fns/subYears";
-import { toDate } from "date-fns/toDate";
+import {
+  addDays,
+  addHours,
+  addMinutes,
+  addMonths,
+  addQuarters,
+  addSeconds,
+  addWeeks,
+  addYears,
+  isEqual as dfIsEqual,
+  isSameDay as dfIsSameDay,
+  isSameMonth as dfIsSameMonth,
+  isSameQuarter as dfIsSameQuarter,
+  isSameYear as dfIsSameYear,
+  differenceInCalendarDays,
+  differenceInCalendarMonths,
+  differenceInCalendarQuarters,
+  differenceInCalendarYears,
+  endOfDay,
+  endOfMonth,
+  endOfWeek,
+  endOfYear,
+  format,
+  getDate,
+  getDay,
+  getHours,
+  getISOWeek,
+  getMinutes,
+  getMonth,
+  getQuarter,
+  getSeconds,
+  getTime,
+  getYear,
+  isAfter,
+  isBefore,
+  isDate,
+  isValid as isValidDate,
+  isWithinInterval,
+  longFormatters,
+  max,
+  min,
+  parse,
+  parseISO,
+  set,
+  setHours,
+  setMinutes,
+  setMonth,
+  setQuarter,
+  setSeconds,
+  setYear,
+  startOfDay,
+  startOfMonth,
+  startOfQuarter,
+  startOfWeek,
+  startOfYear,
+  subDays,
+  subMonths,
+  subQuarters,
+  subWeeks,
+  subYears,
+  toDate,
+} from "date-fns";
 
-import type { Day, Locale as DateFnsLocale } from "date-fns";
+import type { Locale as DateFnsLocale, Day } from "date-fns";
 
 export type DateNumberType = Day;
 interface LocaleObj
@@ -340,21 +343,21 @@ export function setTime(
   return setHours(setMinutes(setSeconds(date, second), minute), hour);
 }
 
-export { setMinutes, setHours, setMonth, setQuarter, setYear };
+export { setHours, setMinutes, setMonth, setQuarter, setYear };
 
 // ** Date Getters **
 
 // getDay Returns day of week, getDate returns day of month
 export {
-  getSeconds,
-  getMinutes,
+  getDate,
+  getDay,
   getHours,
+  getMinutes,
   getMonth,
   getQuarter,
-  getYear,
-  getDay,
-  getDate,
+  getSeconds,
   getTime,
+  getYear,
 };
 
 /**
@@ -487,22 +490,22 @@ export function getEndOfMonth(date: Date): Date {
 // *** Addition ***
 
 export {
-  addSeconds,
-  addMinutes,
   addDays,
-  addWeeks,
+  addMinutes,
   addMonths,
   addQuarters,
+  addSeconds,
+  addWeeks,
   addYears,
 };
 
 // *** Subtraction ***
 
-export { addHours, subDays, subWeeks, subMonths, subQuarters, subYears };
+export { addHours, subDays, subMonths, subQuarters, subWeeks, subYears };
 
 // ** Date Comparison **
 
-export { isBefore, isAfter };
+export { isAfter, isBefore };
 
 /**
  * Checks if two dates are in the same year.

--- a/src/test/calendar_test.test.tsx
+++ b/src/test/calendar_test.test.tsx
@@ -3,9 +3,14 @@
  */
 
 import { render, fireEvent, act, waitFor } from "@testing-library/react";
-import { setDate, startOfMonth, eachDayOfInterval, endOfMonth } from "date-fns";
-import { endOfYear } from "date-fns/endOfYear";
-import { isSunday } from "date-fns/isSunday";
+import {
+  setDate,
+  startOfMonth,
+  eachDayOfInterval,
+  endOfMonth,
+  endOfYear,
+  isSunday,
+} from "date-fns";
 import { eo } from "date-fns/locale/eo";
 import { fi } from "date-fns/locale/fi";
 import React from "react";

--- a/src/test/date_utils_test.test.ts
+++ b/src/test/date_utils_test.test.ts
@@ -1,8 +1,11 @@
-import { addYears, setSeconds } from "date-fns";
-import { addQuarters } from "date-fns/addQuarters";
+import {
+  addYears,
+  setSeconds,
+  addQuarters,
+  setHours,
+  setMinutes,
+} from "date-fns";
 import { ptBR } from "date-fns/locale/pt-BR";
-import { setHours } from "date-fns/setHours";
-import { setMinutes } from "date-fns/setMinutes";
 
 import {
   newDate,

--- a/src/test/month_test.test.tsx
+++ b/src/test/month_test.test.tsx
@@ -1,6 +1,6 @@
 /* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "assertDateRangeInclusive", "runAxe"] }] */
 import { render, fireEvent } from "@testing-library/react";
-import { es } from "date-fns/locale";
+import { es } from "date-fns/locale/es";
 import React from "react";
 
 import DatePicker from "../";

--- a/yarn.lock
+++ b/yarn.lock
@@ -4133,10 +4133,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"date-fns@npm:^3.6.0":
-  version: 3.6.0
-  resolution: "date-fns@npm:3.6.0"
-  checksum: 10c0/0b5fb981590ef2f8e5a3ba6cd6d77faece0ea7f7158948f2eaae7bbb7c80a8f63ae30b01236c2923cf89bb3719c33aeb150c715ea4fe4e86e37dcf06bed42fb6
+"date-fns@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "date-fns@npm:4.1.0"
+  checksum: 10c0/b79ff32830e6b7faa009590af6ae0fb8c3fd9ffad46d930548fbb5acf473773b4712ae887e156ba91a7b3dc30591ce0f517d69fd83bd9c38650fdc03b4e0bac8
   languageName: node
   linkType: hard
 
@@ -8368,7 +8368,7 @@ __metadata:
     babel-plugin-transform-react-remove-prop-types: "npm:^0.4.24"
     clsx: "npm:^2.1.1"
     core-js: "npm:^3.38.1"
-    date-fns: "npm:^3.6.0"
+    date-fns: "npm:^4.1.0"
     eslint: "npm:^8.57.0"
     eslint-config-prettier: "npm:^9.1.0"
     eslint-plugin-import: "npm:^2.29.1"


### PR DESCRIPTION
## Description
**Linked issue**: #5177, #5128

**Problem**
This PR update `date-fns` to the latest version, v4.1.0. Dependabot update breaks the docs website (which is a separate topic in itself, the build system over there is extremely outdated - happy to help with that), my changes fix these issues so the website is still functional.

**Changes**
- bumped version in package.json
- removed the logic in Rollup that marks date-fns exports as external
- adjusted imports to use `date-fns` directly, also in tests for consistency

## To reviewers
This might seem like a bad decision, after all previous contributors were using direct date-fns exports to reduce the bundle size! This isn't actually correct after v4.1.0. Since v4, `date-fns` is marked as `type: "module"`, so really any somewhat up-to-date bundle will handle tree shaking correctly (in fact this might've been the case even earlier as date-fns was providing ESM exports back in v3, too). I have a hard time imagining that people stuck on super old bundlers that don't work with ESM are keeping this library up to date.

On another note, if this was an issue, someone would likely report it already, because there was a direct `date-fns` import in `src/calendar.tsx` for a while now, so for CJS builds this would've had an impact already anyway.

As a small positive side effect, the final bundle size is slightly smaller for every produced target.

After this is merged I believe both linked issues can be closed; one is the dependabot's PR, the other contains a subset of my changes.

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
