### PR TITLE
chore(deps): upgrade date-fns to v4.1.0 (attempt no. 2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,17 @@
   "homepage": "https://github.com/Hacker0x01/react-datepicker",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "browser": "dist/react-datepicker.min.js",
   "module": "dist/es/index.js",
   "unpkg": "dist/react-datepicker.min.js",
   "style": "dist/react-datepicker.min.css",
+  "exports": {
+    ".": {
+      "import": "./dist/es/index.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/es/index.js"
+    }
+  },
   "files": ["*.md", "dist", "lib", "es", "src/stylesheets"],
   "sideEffects": ["**/*.css"],
   "keywords": ["react", "datepicker", "calendar", "date", "react-component"],

--- a/package.json
+++ b/package.json
@@ -12,11 +12,16 @@
   "style": "dist/react-datepicker.min.css",
   "exports": {
     ".": {
-      "import": "./dist/es/index.js",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts",
-      "default": "./dist/es/index.js"
-    }
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/es/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    },
+    "./dist/*.css": "./dist/*.css"
   },
   "files": ["*.md", "dist", "lib", "es", "src/stylesheets"],
   "sideEffects": ["**/*.css"],

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   "dependencies": {
     "@floating-ui/react": "^0.27.0",
     "clsx": "^2.1.1",
-    "date-fns": "^3.6.0"
+    "date-fns": "^4.1.0"
   },
   "scripts": {
     "eslint": "eslint --ext .js,.jsx,.ts,.tsx ./src",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -26,7 +26,10 @@ const banner = `/*!
 
 const globals = {
   react: "React",
-  "prop-types": "PropTypes",
+  "react-dom": "ReactDOM",
+  clsx: "clsx",
+  "date-fns": "dateFns",
+  "@floating-ui/react": "FloatingUIReact",
 };
 
 // NOTE:https://rollupjs.org/migration/#changed-defaults
@@ -40,7 +43,7 @@ const config = {
   input: "src/index.tsx",
   output: [
     {
-      file: pkg.browser,
+      file: pkg.unpkg,
       format: "umd",
       name: "DatePicker",
       globals,
@@ -49,7 +52,7 @@ const config = {
       plugins: [terser()],
     },
     {
-      file: pkg.browser.replace(".min.js", ".js"),
+      file: pkg.unpkg.replace(".min.js", ".js"),
       format: "umd",
       sourcemap: "inline",
       name: "DatePicker",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -24,25 +24,6 @@ const banner = `/*!
   Released under the ${pkg.license} License.
 */`;
 
-// it's important to mark all subpackages of data-fns as externals
-// see https://github.com/Hacker0x01/react-datepicker/issues/1606
-// We're relying on date-fn's package.json `exports` field to
-// determine the list of directories to include.
-const dateFnsPackageJson = JSON.parse(
-  fs
-    .readFileSync(
-      path.join(
-        path.dirname(fileURLToPath(import.meta.url)),
-        "node_modules/date-fns/package.json",
-      ),
-    )
-    .toString(),
-);
-const dateFnsSubpackages = Object.keys(dateFnsPackageJson.exports)
-  .map((key) => key.replace("./", ""))
-  .filter((key) => key !== "." && key !== "package.json")
-  .map((key) => `date-fns/${key}`);
-
 const globals = {
   react: "React",
   "prop-types": "PropTypes",
@@ -109,7 +90,6 @@ const config = {
   external: [
     ...Object.keys(pkg.dependencies || {}),
     ...Object.keys(pkg.peerDependencies || {}),
-    ...dateFnsSubpackages,
   ],
 };
 

--- a/src/date_utils.ts
+++ b/src/date_utils.ts
@@ -1,64 +1,67 @@
-import { addDays } from "date-fns/addDays";
-import { addHours } from "date-fns/addHours";
-import { addMinutes } from "date-fns/addMinutes";
-import { addMonths } from "date-fns/addMonths";
-import { addQuarters } from "date-fns/addQuarters";
-import { addSeconds } from "date-fns/addSeconds";
-import { addWeeks } from "date-fns/addWeeks";
-import { addYears } from "date-fns/addYears";
-import { differenceInCalendarDays } from "date-fns/differenceInCalendarDays";
-import { differenceInCalendarMonths } from "date-fns/differenceInCalendarMonths";
-import { differenceInCalendarQuarters } from "date-fns/differenceInCalendarQuarters";
-import { differenceInCalendarYears } from "date-fns/differenceInCalendarYears";
-import { endOfDay } from "date-fns/endOfDay";
-import { endOfMonth } from "date-fns/endOfMonth";
-import { endOfWeek } from "date-fns/endOfWeek";
-import { endOfYear } from "date-fns/endOfYear";
-import { format, longFormatters } from "date-fns/format";
-import { getDate } from "date-fns/getDate";
-import { getDay } from "date-fns/getDay";
-import { getHours } from "date-fns/getHours";
-import { getISOWeek } from "date-fns/getISOWeek";
-import { getMinutes } from "date-fns/getMinutes";
-import { getMonth } from "date-fns/getMonth";
-import { getQuarter } from "date-fns/getQuarter";
-import { getSeconds } from "date-fns/getSeconds";
-import { getTime } from "date-fns/getTime";
-import { getYear } from "date-fns/getYear";
-import { isAfter } from "date-fns/isAfter";
-import { isBefore } from "date-fns/isBefore";
-import { isDate } from "date-fns/isDate";
-import { isEqual as dfIsEqual } from "date-fns/isEqual";
-import { isSameDay as dfIsSameDay } from "date-fns/isSameDay";
-import { isSameMonth as dfIsSameMonth } from "date-fns/isSameMonth";
-import { isSameQuarter as dfIsSameQuarter } from "date-fns/isSameQuarter";
-import { isSameYear as dfIsSameYear } from "date-fns/isSameYear";
-import { isValid as isValidDate } from "date-fns/isValid";
-import { isWithinInterval } from "date-fns/isWithinInterval";
-import { max } from "date-fns/max";
-import { min } from "date-fns/min";
-import { parse } from "date-fns/parse";
-import { parseISO } from "date-fns/parseISO";
-import { set } from "date-fns/set";
-import { setHours } from "date-fns/setHours";
-import { setMinutes } from "date-fns/setMinutes";
-import { setMonth } from "date-fns/setMonth";
-import { setQuarter } from "date-fns/setQuarter";
-import { setSeconds } from "date-fns/setSeconds";
-import { setYear } from "date-fns/setYear";
-import { startOfDay } from "date-fns/startOfDay";
-import { startOfMonth } from "date-fns/startOfMonth";
-import { startOfQuarter } from "date-fns/startOfQuarter";
-import { startOfWeek } from "date-fns/startOfWeek";
-import { startOfYear } from "date-fns/startOfYear";
-import { subDays } from "date-fns/subDays";
-import { subMonths } from "date-fns/subMonths";
-import { subQuarters } from "date-fns/subQuarters";
-import { subWeeks } from "date-fns/subWeeks";
-import { subYears } from "date-fns/subYears";
-import { toDate } from "date-fns/toDate";
+import {
+  addDays,
+  addHours,
+  addMinutes,
+  addMonths,
+  addQuarters,
+  addSeconds,
+  addWeeks,
+  addYears,
+  isEqual as dfIsEqual,
+  isSameDay as dfIsSameDay,
+  isSameMonth as dfIsSameMonth,
+  isSameQuarter as dfIsSameQuarter,
+  isSameYear as dfIsSameYear,
+  differenceInCalendarDays,
+  differenceInCalendarMonths,
+  differenceInCalendarQuarters,
+  differenceInCalendarYears,
+  endOfDay,
+  endOfMonth,
+  endOfWeek,
+  endOfYear,
+  format,
+  getDate,
+  getDay,
+  getHours,
+  getISOWeek,
+  getMinutes,
+  getMonth,
+  getQuarter,
+  getSeconds,
+  getTime,
+  getYear,
+  isAfter,
+  isBefore,
+  isDate,
+  isValid as isValidDate,
+  isWithinInterval,
+  longFormatters,
+  max,
+  min,
+  parse,
+  parseISO,
+  set,
+  setHours,
+  setMinutes,
+  setMonth,
+  setQuarter,
+  setSeconds,
+  setYear,
+  startOfDay,
+  startOfMonth,
+  startOfQuarter,
+  startOfWeek,
+  startOfYear,
+  subDays,
+  subMonths,
+  subQuarters,
+  subWeeks,
+  subYears,
+  toDate,
+} from "date-fns";
 
-import type { Day, Locale as DateFnsLocale } from "date-fns";
+import type { Locale as DateFnsLocale, Day } from "date-fns";
 
 export type DateNumberType = Day;
 interface LocaleObj
@@ -340,21 +343,21 @@ export function setTime(
   return setHours(setMinutes(setSeconds(date, second), minute), hour);
 }
 
-export { setMinutes, setHours, setMonth, setQuarter, setYear };
+export { setHours, setMinutes, setMonth, setQuarter, setYear };
 
 // ** Date Getters **
 
 // getDay Returns day of week, getDate returns day of month
 export {
-  getSeconds,
-  getMinutes,
+  getDate,
+  getDay,
   getHours,
+  getMinutes,
   getMonth,
   getQuarter,
-  getYear,
-  getDay,
-  getDate,
+  getSeconds,
   getTime,
+  getYear,
 };
 
 /**
@@ -487,22 +490,22 @@ export function getEndOfMonth(date: Date): Date {
 // *** Addition ***
 
 export {
-  addSeconds,
-  addMinutes,
   addDays,
-  addWeeks,
+  addMinutes,
   addMonths,
   addQuarters,
+  addSeconds,
+  addWeeks,
   addYears,
 };
 
 // *** Subtraction ***
 
-export { addHours, subDays, subWeeks, subMonths, subQuarters, subYears };
+export { addHours, subDays, subMonths, subQuarters, subWeeks, subYears };
 
 // ** Date Comparison **
 
-export { isBefore, isAfter };
+export { isAfter, isBefore };
 
 /**
  * Checks if two dates are in the same year.

--- a/src/test/calendar_test.test.tsx
+++ b/src/test/calendar_test.test.tsx
@@ -3,9 +3,14 @@
  */
 
 import { render, fireEvent, act, waitFor } from "@testing-library/react";
-import { setDate, startOfMonth, eachDayOfInterval, endOfMonth } from "date-fns";
-import { endOfYear } from "date-fns/endOfYear";
-import { isSunday } from "date-fns/isSunday";
+import {
+  setDate,
+  startOfMonth,
+  eachDayOfInterval,
+  endOfMonth,
+  endOfYear,
+  isSunday,
+} from "date-fns";
 import { eo } from "date-fns/locale/eo";
 import { fi } from "date-fns/locale/fi";
 import React from "react";

--- a/src/test/date_utils_test.test.ts
+++ b/src/test/date_utils_test.test.ts
@@ -1,8 +1,11 @@
-import { addYears, setSeconds } from "date-fns";
-import { addQuarters } from "date-fns/addQuarters";
+import {
+  addYears,
+  setSeconds,
+  addQuarters,
+  setHours,
+  setMinutes,
+} from "date-fns";
 import { ptBR } from "date-fns/locale/pt-BR";
-import { setHours } from "date-fns/setHours";
-import { setMinutes } from "date-fns/setMinutes";
 
 import {
   newDate,

--- a/src/test/month_test.test.tsx
+++ b/src/test/month_test.test.tsx
@@ -1,6 +1,6 @@
 /* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "assertDateRangeInclusive", "runAxe"] }] */
 import { render, fireEvent } from "@testing-library/react";
-import { es } from "date-fns/locale";
+import { es } from "date-fns/locale/es";
 import React from "react";
 
 import DatePicker from "../";

--- a/yarn.lock
+++ b/yarn.lock
@@ -4178,10 +4178,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"date-fns@npm:^3.6.0":
-  version: 3.6.0
-  resolution: "date-fns@npm:3.6.0"
-  checksum: 10c0/0b5fb981590ef2f8e5a3ba6cd6d77faece0ea7f7158948f2eaae7bbb7c80a8f63ae30b01236c2923cf89bb3719c33aeb150c715ea4fe4e86e37dcf06bed42fb6
+"date-fns@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "date-fns@npm:4.1.0"
+  checksum: 10c0/b79ff32830e6b7faa009590af6ae0fb8c3fd9ffad46d930548fbb5acf473773b4712ae887e156ba91a7b3dc30591ce0f517d69fd83bd9c38650fdc03b4e0bac8
   languageName: node
   linkType: hard
 
@@ -8413,7 +8413,7 @@ __metadata:
     babel-plugin-transform-react-remove-prop-types: "npm:^0.4.24"
     clsx: "npm:^2.1.1"
     core-js: "npm:^3.38.1"
-    date-fns: "npm:^3.6.0"
+    date-fns: "npm:^4.1.0"
     eslint: "npm:^8.57.0"
     eslint-config-prettier: "npm:^9.1.0"
     eslint-plugin-import: "npm:^2.29.1"


### PR DESCRIPTION
## Description
**Linked issue**: #5177, #5128, #5326

**Problem**

This PR is a second attempt after #5326 to update `date-fns` to the latest version, v4.1.0. Dependabot update breaks the docs website (which is a separate topic in itself, the build system over there is extremely outdated - happy to help with that), my changes fix these issues so the website is still functional (this time for real, I triple checked).

**Changes**
- bumped `date-fns` version in package.json
- adjusted exports in package.json, namely removed `browser` field entirely and added more modern `exports` field
- removed the logic in Rollup that marks date-fns exports as external
- fixed UMD build so it actually works (it was probably broken for a very long time, though)
- adjusted imports to use `date-fns` directly, also in tests for consistency

## To reviewers
So it turns out that the main cause of the docs page failing after all was the `browser` field in package.json. It was pointing to the UMD build, which just wouldn't work with `date-fns` after the update. It points `browser` to an ESM file exporting all the other ESM files with individual functions. ESM and UMD are not compatible with each other (oh well), so there was just no way it would work.

What I did is I simply removed the `browser` field. I honestly think it was just used incorrectly until now. We could keep it (pointing to the ESM build) but if `browser` field is missing bundlers use `module` field anyway, and some (namely `esbuild`) have additional behavior where they can use `main` instead if imported with `require`. From what I've checked most frontend libraries nowadays tend to omit this field, but if you REALLY want to keep it, I can - just need to change it to the ESM build.

I kept the changes from previous PR, namely using only main `date-fns` export as an import source. This is part of the "fixing UMD bundle" effort which I decided to do as soon as I found out... it doesn't work at all. Or I guess it could work but it would require an enormous amount of effort. After extending the `globals` field in Rollup config it's now doable to use it with only CDN-imported dependencies.

I also added the `exports` field which I initially thought was relevant to this. It is not, however I think it's still valuable to keep it. If you'd prefer to do it in a separate PR (I will open one tomorrow re/ docs site), I can do that, too.

I think that's all.

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
