### PR TITLE
🔧 Update the ES output path to be direct child of dist/ dir

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,14 +7,14 @@
   "homepage": "https://github.com/Hacker0x01/react-datepicker",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "module": "dist/es/index.js",
+  "module": "dist/index.es.js",
   "unpkg": "dist/react-datepicker.min.js",
   "style": "dist/react-datepicker.min.css",
   "exports": {
     ".": {
       "import": {
         "types": "./dist/index.d.ts",
-        "default": "./dist/es/index.js"
+        "default": "./dist/index.es.js"
       },
       "require": {
         "types": "./dist/index.d.ts",


### PR DESCRIPTION
- Updated as @rollup/plugin-typescript v12.1.2 has some issue in parsing the nested directories of declarationDir ("./dist")

Related issues
https://github.com/rollup/plugins/issues/1813
https://github.com/rollup/plugins/issues/1772

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
