### PR TITLE
fix: correct type inheritance in CalendarContainer props

### DIFF
--- a/src/calendar_container.tsx
+++ b/src/calendar_container.tsx
@@ -1,7 +1,7 @@
-import React from "react";
+import React, { type HTMLAttributes } from "react";
 
 export interface CalendarContainerProps
-  extends React.PropsWithChildren<HTMLDivElement> {
+  extends React.PropsWithChildren<HTMLAttributes<HTMLDivElement>> {
   showTimeSelectOnly?: boolean;
   showTime?: boolean;
 }


### PR DESCRIPTION
## Description

**Linked issue**: #5364 

**Problem**
The `CalendarContainerProps` interface currently extends `React.PropsWithChildren<HTMLDivElement>`, which causes TypeScript errors when using CalendarContainer in custom implementations. This incorrect type inheritance prevents proper type checking for HTML attributes.

**Changes**
- Updated `CalendarContainerProps` to extend `React.PropsWithChildren<React.HTMLAttributes<HTMLDivElement>>` instead of `HTMLDivElement`
- This change allows the component to properly type-check all valid HTML attributes that can be passed to a div element
- Fixes TypeScript errors that occur when using CalendarContainer in custom container implementations

## Screenshots
N/A

## To reviewers
This is a type-only change that fixes TypeScript errors while maintaining the same runtime behavior. The change makes the type definition more accurate by properly inheriting HTML attribute types.

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.