### PR TITLE
Fix #5274: 🐛 Auto refresh the input value with the previously entered valid value if any invalid value is entered (when the open state is closed)

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -564,6 +564,10 @@ export default class DatePicker extends Component<
       this.props.onBlur?.(event);
     }
 
+    if (this.state.open && this.props.open === false) {
+      this.setOpen(false);
+    }
+
     this.setState({ focused: false });
   };
 

--- a/src/test/datepicker_test.test.tsx
+++ b/src/test/datepicker_test.test.tsx
@@ -1,7 +1,7 @@
 import { render, act, waitFor, fireEvent } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import { enUS, enGB } from "date-fns/locale";
-import React from "react";
+import React, { useState } from "react";
 
 import {
   KeyType,
@@ -4241,6 +4241,46 @@ describe("DatePicker", () => {
           formatDate(data.instance.state.preSelection!, data.testFormat),
         ).toBe(formatDate(new Date("2021-03-01"), data.testFormat));
       });
+    });
+  });
+
+  describe("input reset", () => {
+    const renderDatePickerInput = () => {
+      const WrapperComponent = () => {
+        const [date, setDate] = useState<Date | null>(new Date());
+        return <DatePicker open={false} selected={date} onChange={setDate} />;
+      };
+
+      return render(<WrapperComponent />);
+    };
+
+    it("should reset the date input element with the previously entered value element on blur even when the calendar open is false", () => {
+      const { container } = renderDatePickerInput();
+      const input = safeQuerySelector(container, "input") as HTMLInputElement;
+
+      if (!input) {
+        throw new Error("Input element not found");
+      }
+
+      fireEvent.click(input);
+      const DATE_VALUE = "02/22/2025";
+      fireEvent.change(input, {
+        target: {
+          value: DATE_VALUE,
+        },
+      });
+      fireEvent.blur(input);
+      expect(input.value).toBe(DATE_VALUE);
+
+      fireEvent.click(input);
+      const INVALID_DATE_VALUE = "2025-02-45";
+      fireEvent.change(input, {
+        target: {
+          value: INVALID_DATE_VALUE,
+        },
+      });
+      fireEvent.blur(input);
+      expect(input.value).toBe(DATE_VALUE);
     });
   });
 });


### PR DESCRIPTION
Closes #5274

## Description
**Problem**
As mentioned in the linked ticket, the input value doesn't get reset when the open state is set to false (User just need the date input part, not the datepicker part).  In this case eventhough we didn't emit `onChange` event when the user press invalid input, when we click outside the input, the input value remains invalid.  

However if the user press tab, it's getting reset to the previously received valid value and it's also handled properly when open prop is controlled by our package. 

**Changes**
We have open state and open prop.  I just set the open state to false on blur of the input, which will refresh the input value back to the valid, previously received value prop.

This change is very specific for `open={false}` case, as the other cases were already handled by the existing code.

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
