### PR TITLE
🔧 Update the production build script config to include css:modules:prod

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "test": "NODE_ENV=test jest",
     "test:ci": "NODE_ENV=test jest --ci --coverage",
     "test:watch": "NODE_OPTIONS=--openssl-legacy-provider NODE_ENV=test jest --watch",
-    "build": "NODE_ENV=production yarn run build:src && NODE_ENV=production yarn run css:prod && NODE_ENV=production yarn run css:modules:dev && NODE_ENV=production yarn run css:dev && NODE_ENV=production yarn run css:modules:dev",
+    "build": "NODE_ENV=production yarn run build:src && NODE_ENV=production yarn run css:prod && NODE_ENV=production yarn run css:modules:prod && NODE_ENV=production yarn run css:dev && NODE_ENV=production yarn run css:modules:dev",
     "build-dev": "NODE_ENV=development yarn run js:dev && NODE_ENV=development yarn run css:dev && NODE_ENV=development yarn run css:modules:dev",
     "css:prod": "sass --style compressed src/stylesheets/datepicker.scss > dist/react-datepicker.min.css",
     "css:modules:prod": "sass --style compressed src/stylesheets/datepicker-cssmodules.scss | tee dist/react-datepicker-cssmodules.min.css dist/react-datepicker-min.module.css",


### PR DESCRIPTION
## Description
When I explored the `package.json` file I found our `build` script is using `css:modules:dev` which actually compile scss to css in an expanded view, not compressed.  

I also noticed we are calling `css:modules:dev` twice.  
![image](https://github.com/user-attachments/assets/cd8e609a-dc49-4414-8820-5d75ed4dbc08)

**Changes**
As a fix I just replaced the redundant `css:modules:dev` script run with `css:modules:prod`.  So that it'll also include the compressed css module file in the dist folder.

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
