### PR TITLE
Fix #5366: 🐛 Fix the re-focus issue of the DatePicker element when the open state is controlled manually

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -452,25 +452,20 @@ export default class DatePicker extends Component<
     }
   };
 
-  safeFocus = () => {
-    setTimeout(() => {
-      this.input?.focus?.({ preventScroll: true });
-    }, 0);
-  };
-
-  safeBlur = () => {
-    setTimeout(() => {
-      this.input?.blur?.();
-    }, 0);
-  };
-
   setFocus = () => {
-    this.safeFocus();
+    this.input?.focus?.({ preventScroll: true });
   };
 
   setBlur = () => {
-    this.safeBlur();
+    this.input?.blur?.();
     this.cancelFocusInput();
+  };
+
+  deferBlur = () => {
+    requestAnimationFrame(() => {
+      console.log("reached");
+      this.setBlur();
+    });
   };
 
   setOpen = (open: boolean, skipSetBlur: boolean = false): void => {
@@ -490,7 +485,7 @@ export default class DatePicker extends Component<
               focused: skipSetBlur ? prev.focused : false,
             }),
             () => {
-              !skipSetBlur && this.setBlur();
+              !skipSetBlur && this.deferBlur();
 
               this.setState({ inputValue: null });
             },


### PR DESCRIPTION
Closes #5366

**Problem**
As described in the linked ticket, the fix we made for the issue (related to FireFox Tab press) delays the blur and focus call to the next render cycle.  That's causing an issue when the consumer manually controls the open and the close state via onFocus event.  As a fix I just the defer the execution of the blur call after the state updates for setOpen.  

**Changes**
- Defer the blur call alone to fix the issue #5084
- Fix the bug caused in the commit d07308d3860389449e069ad766b966467d328a2c
- In the old PR itself we covered the fix made, which will also include the current fix update

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
