### PR TITLE
fix(date_utils): update getDayOfWeekCode to use "E" format instead of "ddd"

### DIFF
--- a/src/date_utils.ts
+++ b/src/date_utils.ts
@@ -325,7 +325,7 @@ export function getWeek(date: Date): number {
  * @returns - The day of the week code.
  */
 export function getDayOfWeekCode(day: Date, locale?: Locale): string {
-  return formatDate(day, "ddd", locale);
+  return formatDate(day, "E", locale);
 }
 
 // *** Start of ***


### PR DESCRIPTION
## Description

Update format strings to match date-fns syntax after migrating from Moment.js, as the original format patterns were no longer compatible

**Problem**

After migrating from Moment.js to date-fns, the date format string were still using the old Moment.js syntax.
* [The current "ddd" means a day of week code in `moment`](https://momentjs.com/docs/#/displaying/format/:~:text=Mo%20...%20Fr%20Sa-,ddd,Sun%20Mon%20...%20Fri%20Sat,-dddd), but the same in `date-fns` is not.
* It looks good to update it with 'E' [as represents a day of week in date-fns](https://date-fns.org/v4.1.0/docs/format#:~:text=3-,Day%20of%20week%20(formatting),-E..EEE)

**Changes**

Update getDayOfWeekCode to use "E" format instead of "ddd"

## Screenshots
<!-- If applicable, add screenshots to help explain your improvements -->

## To reviewers
<!-- Additional comments for reviewers -->

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
