### PR TITLE
🎨🔨 Re-adjust the height of TimePicker on Calendar resize due to number of days

### DIFF
--- a/src/test/calendar_test.test.tsx
+++ b/src/test/calendar_test.test.tsx
@@ -45,6 +45,7 @@ import {
   SafeElementWrapper,
   safeQuerySelector,
   safeQuerySelectorAll,
+  setupMockResizeObserver,
 } from "./test_utils";
 
 import type { ReactDatePickerCustomHeaderProps } from "../calendar";
@@ -135,6 +136,10 @@ describe("Calendar", () => {
       rerender: rerenderFunc,
     };
   }
+
+  beforeAll(() => {
+    setupMockResizeObserver();
+  });
 
   it("should start with the current date in view if no date range", () => {
     const now = newDate();

--- a/src/test/datepicker_test.test.tsx
+++ b/src/test/datepicker_test.test.tsx
@@ -29,7 +29,11 @@ import DatePicker, { registerLocale } from "../index";
 import CustomInput from "./helper_components/custom_input";
 import ShadowRoot from "./helper_components/shadow_root";
 import TestWrapper from "./helper_components/test_wrapper";
-import { getKey, safeQuerySelector } from "./test_utils";
+import {
+  getKey,
+  safeQuerySelector,
+  setupMockResizeObserver,
+} from "./test_utils";
 
 function getSelectedDayNode(container: HTMLElement) {
   return (
@@ -83,6 +87,10 @@ const showDocument = (calendarInput: HTMLElement) => {
 };
 
 describe("DatePicker", () => {
+  beforeEach(() => {
+    setupMockResizeObserver();
+  });
+
   afterEach(() => {
     jest.resetAllMocks();
   });

--- a/src/test/exclude_time_period_test.test.tsx
+++ b/src/test/exclude_time_period_test.test.tsx
@@ -2,9 +2,14 @@ import { render } from "@testing-library/react";
 import React from "react";
 
 import { newDate, setTime } from "../date_utils";
+import { setupMockResizeObserver } from "./test_utils";
 import DatePicker from "../index";
 
 describe("DatePicker", () => {
+  beforeAll(() => {
+    setupMockResizeObserver();
+  });
+
   it("should only display times between minTime and maxTime", () => {
     const now = newDate();
     const { container } = render(

--- a/src/test/exclude_times_test.test.tsx
+++ b/src/test/exclude_times_test.test.tsx
@@ -2,10 +2,15 @@ import { render } from "@testing-library/react";
 import React from "react";
 
 import { setTime, newDate } from "../date_utils";
+import { setupMockResizeObserver } from "./test_utils";
 import DatePicker from "../index";
 
 describe("DatePicker", () => {
   let now: Date, excludeTimes: Date[];
+
+  beforeAll(() => {
+    setupMockResizeObserver();
+  });
 
   beforeEach(() => {
     now = newDate();

--- a/src/test/min_time_test.test.tsx
+++ b/src/test/min_time_test.test.tsx
@@ -3,7 +3,7 @@ import React, { useState } from "react";
 
 import DatePicker from "../index";
 
-import { safeQuerySelector } from "./test_utils";
+import { safeQuerySelector, setupMockResizeObserver } from "./test_utils";
 
 import type { DatePickerProps } from "../index";
 
@@ -44,6 +44,10 @@ const DatePickerWithState = (
 };
 
 describe("Datepicker minTime", () => {
+  beforeAll(() => {
+    setupMockResizeObserver();
+  });
+
   it("should select time 12:00 AM when no minTime constraint is set.", () => {
     const { getByText, container } = render(<DatePickerWithState />);
 

--- a/src/test/show_time_test.test.tsx
+++ b/src/test/show_time_test.test.tsx
@@ -4,9 +4,13 @@ import React from "react";
 import DatePicker from "../index";
 import TimeComponent from "../time";
 
-import { safeQuerySelector } from "./test_utils";
+import { safeQuerySelector, setupMockResizeObserver } from "./test_utils";
 
 describe("DatePicker", () => {
+  beforeAll(() => {
+    setupMockResizeObserver();
+  });
+
   it("should show time component when showTimeSelect prop is present", () => {
     const { container } = render(<DatePicker showTimeSelect open />);
     const timeComponent = container.querySelector(

--- a/src/test/test_utils.ts
+++ b/src/test/test_utils.ts
@@ -123,16 +123,27 @@ export const safeQuerySelectorAll = <T extends HTMLElement = HTMLElement>(
   return elements;
 };
 
+let _resizeObserverCallbackFn: ResizeObserverCallback | null;
+
+export const getResizeObserverCallback = () => _resizeObserverCallbackFn;
+
 export const setupMockResizeObserver = () => {
   const mockObserve = jest.fn();
   const mockDisconnect = jest.fn();
   const mockUnobserve = jest.fn();
 
-  const ResizeObserverMock = jest.fn(() => ({
-    observe: mockObserve,
-    disconnect: mockDisconnect,
-    unobserve: jest.fn(),
-  }));
+  const ResizeObserverMock = jest.fn((fn) => {
+    _resizeObserverCallbackFn = fn;
+
+    return {
+      observe: mockObserve,
+      disconnect: () => {
+        _resizeObserverCallbackFn = null;
+        mockDisconnect();
+      },
+      unobserve: jest.fn(),
+    };
+  });
 
   global.ResizeObserver = ResizeObserverMock;
 

--- a/src/test/test_utils.ts
+++ b/src/test/test_utils.ts
@@ -123,6 +123,26 @@ export const safeQuerySelectorAll = <T extends HTMLElement = HTMLElement>(
   return elements;
 };
 
+export const setupMockResizeObserver = () => {
+  const mockObserve = jest.fn();
+  const mockDisconnect = jest.fn();
+  const mockUnobserve = jest.fn();
+
+  const ResizeObserverMock = jest.fn(() => ({
+    observe: mockObserve,
+    disconnect: mockDisconnect,
+    unobserve: jest.fn(),
+  }));
+
+  global.ResizeObserver = ResizeObserverMock;
+
+  return {
+    observe: mockObserve,
+    disconnect: mockDisconnect,
+    unobserve: mockUnobserve,
+  };
+};
+
 export class SafeElementWrapper<T extends HTMLElement> {
   constructor(private element: T) {}
 

--- a/src/test/time_input_test.test.tsx
+++ b/src/test/time_input_test.test.tsx
@@ -5,9 +5,13 @@ import DatePicker from "../index";
 import InputTimeComponent from "../input_time";
 
 import CustomTimeInput from "./helper_components/custom_time_input";
-import { safeQuerySelector } from "./test_utils";
+import { safeQuerySelector, setupMockResizeObserver } from "./test_utils";
 
 describe("timeInput", () => {
+  beforeEach(() => {
+    setupMockResizeObserver();
+  });
+
   afterEach(() => {
     jest.resetAllMocks();
   });

--- a/src/test/timepicker_test.test.tsx
+++ b/src/test/timepicker_test.test.tsx
@@ -6,6 +6,7 @@ import DatePicker from "../index";
 
 import {
   getKey,
+  getResizeObserverCallback,
   SafeElementWrapper,
   safeQuerySelector,
   safeQuerySelectorAll,
@@ -49,6 +50,14 @@ describe("TimePicker", () => {
       );
       await waitFor(() => {
         expect(mockObserve).toHaveBeenCalledTimes(1);
+
+        const resizeObserverCallback = getResizeObserverCallback();
+        const mockObserveElement = mockObserve.mock.calls[0][0];
+        expect(typeof resizeObserverCallback).toBe("function");
+
+        if (resizeObserverCallback) {
+          resizeObserverCallback([], mockObserveElement);
+        }
       });
     });
 
@@ -65,6 +74,8 @@ describe("TimePicker", () => {
       component.unmount();
       await waitFor(() => {
         expect(mockDisconnect).toHaveBeenCalledTimes(1);
+        const resizeObserverCallback = getResizeObserverCallback();
+        expect(resizeObserverCallback).toBe(null);
       });
     });
   });

--- a/src/time.tsx
+++ b/src/time.tsx
@@ -62,6 +62,7 @@ export default class Time extends Component<TimeProps, TimeState> {
     );
   };
 
+  private resizeObserver?: ResizeObserver;
   state: TimeState = {
     height: null,
   };
@@ -69,11 +70,11 @@ export default class Time extends Component<TimeProps, TimeState> {
   componentDidMount(): void {
     // code to ensure selected time will always be in focus within time window when it first appears
     this.scrollToTheSelectedTime();
-    if (this.props.monthRef && this.header) {
-      this.setState({
-        height: this.props.monthRef.clientHeight - this.header.clientHeight,
-      });
-    }
+    this.observeDatePickerHeightChanges();
+  }
+
+  componentWillUnmount(): void {
+    this.resizeObserver?.disconnect();
   }
 
   private header?: HTMLDivElement;
@@ -81,6 +82,27 @@ export default class Time extends Component<TimeProps, TimeState> {
   private list?: HTMLUListElement;
 
   private centerLi?: HTMLLIElement;
+
+  private observeDatePickerHeightChanges(): void {
+    const { monthRef } = this.props;
+    this.updateContainerHeight();
+
+    if (monthRef) {
+      this.resizeObserver = new ResizeObserver(() => {
+        this.updateContainerHeight();
+      });
+
+      this.resizeObserver.observe(monthRef);
+    }
+  }
+
+  private updateContainerHeight(): void {
+    if (this.props.monthRef && this.header) {
+      this.setState({
+        height: this.props.monthRef.clientHeight - this.header.clientHeight,
+      });
+    }
+  }
 
   scrollToTheSelectedTime = (): void => {
     requestAnimationFrame((): void => {


### PR DESCRIPTION
Closes #5466

## Description
As mentioned in the ticket, the Time Picker height is not getting updated when we switch between months, so sometimes when we switch from 30 days month to 31 days month and vice a versa, we have some UI-issues.  I added a Resize-Observer and update the time picker height whenever calendar popup height changes and updated the test cases for it.

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
