### PR TITLE
Include SCSS files in exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
         "default": "./dist/index.js"
       }
     },
-    "./dist/*.css": "./dist/*.css"
+    "./dist/*.css": "./dist/*.css",
+    "./src/stylesheets/*.scss": "./src/stylesheets/*.scss"
   },
   "files": ["*.md", "dist", "lib", "es", "src/stylesheets"],
   "sideEffects": ["**/*.css"],


### PR DESCRIPTION
## Description
This PR exposes the source SCSS files via the package's exports so projects can import them.

**Problem**
This project's SCSS has a lot of useful variables (e.g. `$datepicker__selected-color`), but no obvious way to change their default values. This way, a project can import the SCSS files with overrides for the variables, instead of setting a bunch of individual attributes. For example:

```
@use 'react-datepicker/src/stylesheets/variables.scss' with (
  $datepicker__selected-color: #000000,
  $datepicker__font-family: inherit,
);
@use 'react-datepicker/src/stylesheets/datepicker.scss';
```

If there is a better way of doing this, please let me know!

**Changes**
Simply add a line to `exports` in package.json with a wildcard for all SCSS files.

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
