### PR TITLE
Fix readOnly prop for a clearButton and inline calendare

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1388,9 +1388,11 @@ export default class DatePicker extends Component<
       clearButtonClassName = "",
       ariaLabelClose = "Close",
       selectedDates,
+      readOnly,
     } = this.props;
     if (
       isClearable &&
+      !readOnly &&
       (selected != null ||
         startDate != null ||
         endDate != null ||

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -659,6 +659,7 @@ export default class DatePicker extends Component<
     event?: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,
     monthSelectedIn?: number,
   ) => {
+    if (this.props.readOnly) return;
     if (this.props.shouldCloseOnSelect && !this.props.showTimeSelect) {
       // Preventing onFocus event to fix issue
       // https://github.com/Hacker0x01/react-datepicker/issues/628
@@ -829,6 +830,7 @@ export default class DatePicker extends Component<
 
   // When checking preSelection via min/maxDate, times need to be manipulated via getStartOfDay/getEndOfDay
   setPreSelection = (date?: Date | null): void => {
+    if (this.props.readOnly) return;
     const hasMinDate = isDate(this.props.minDate);
     const hasMaxDate = isDate(this.props.maxDate);
     let isValidDateSelection = true;


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to improve this repository
title: "Fix readOnly prop"
labels: bug
assignees: "Sergey Kazarinov"
---

## Description

**Problem**
- When I set readOnly prop and I have a clearButton, I can click on it and the date will be deleted
- If I use inline calendare, also I can change date when I have the readOnly prop
<!-- The problems this PR aims to solve -->

**Changes**
- If set readOnly prop, clearButton is hidde
- If set readOnly prop, I cannot change date to inline calendar
<!-- Changes you have made to address the issue -->

## Screenshots
![image](https://github.com/user-attachments/assets/11198c6d-79be-4ece-a154-51f1cc4034be)
![image](https://github.com/user-attachments/assets/c177ff2a-86b3-402f-a931-1651d5b3326a)
![image](https://github.com/user-attachments/assets/698069f4-66c2-4756-ae70-9aa5d1fe0a63)


<!-- If applicable, add screenshots to help explain your improvements -->

## To reviewers
<!-- Additional comments for reviewers -->

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [ ] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
