### PR TITLE
fix: correct usage of customHeaderCount to keep arrows on any monthsShown prop

### DIFF
--- a/docs-site/src/examples/renderCustomHeaderTwoMonths.js
+++ b/docs-site/src/examples/renderCustomHeaderTwoMonths.js
@@ -1,5 +1,6 @@
 () => {
   const [startDate, setStartDate] = useState(new Date());
+  const monthsShown = useMemo(() => 2, []);
   return (
     <DatePicker
       renderCustomHeader={({
@@ -14,7 +15,7 @@
             className={
               "react-datepicker__navigation react-datepicker__navigation--previous"
             }
-            style={customHeaderCount === 1 ? { visibility: "hidden" } : null}
+            style={{ visibility: customHeaderCount === 0 ? 'visible' : 'hidden' }}
             onClick={decreaseMonth}
           >
             <span
@@ -36,7 +37,7 @@
             className={
               "react-datepicker__navigation react-datepicker__navigation--next"
             }
-            style={customHeaderCount === 0 ? { visibility: "hidden" } : null}
+            style={{ visibility: customHeaderCount === monthsShown - 1 ? 'visible' : 'hidden' }}
             onClick={increaseMonth}
           >
             <span
@@ -51,7 +52,7 @@
       )}
       selected={startDate}
       onChange={(date) => setStartDate(date)}
-      monthsShown={2}
+      monthsShown={monthsShown}
     />
   );
 };


### PR DESCRIPTION

fix: correct usage of customHeaderCount to keep arrows on any monthsShown prop
---
name: Pull Request
about: Create a pull request to improve this repository
title: Correct usage of customHeaderCount to keep arrows on any monthsShown prop
labels: docs
assignees: johannrp27
---

## Description
**Linked issue**: #(issue number) 

**Problem**
If you follow the example of **Custom-header-with-two-months-displayed** it actually works ONLY if monthsShown is set to 2. When you set more or less monthsShown values, the arrows does not look good. See reference image.

**Changes**
I found a patch by using monthsShown number. This value has to be stored to use within customHeader alongside customHeaderCount, and invert the style statement condition.
## Screenshots

### Current issue
<img width="879" alt="image" src="https://github.com/user-attachments/assets/ef9bb0fd-1a3c-4a84-884b-70edc937547f" />

<img width="1133" alt="image" src="https://github.com/user-attachments/assets/7a0ed0a1-a47e-4788-b9b1-19399100a82e" />

### After patch
<img width="981" alt="image" src="https://github.com/user-attachments/assets/1b049445-d610-4a6e-9aa0-c24c21fbb00a" />
<img width="966" alt="image" src="https://github.com/user-attachments/assets/a5c2ca3f-83a3-44fe-a6fe-2d2a9e1c82f9" />
<img width="1039" alt="image" src="https://github.com/user-attachments/assets/df4c237b-3f35-4222-973e-3048e3049b77" />

## To reviewers
<!-- Additional comments for reviewers -->

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
