### PR TITLE
🐛 Apply --keyboard-selected to <Month /> only if it's not already selected

### DIFF
--- a/src/month.tsx
+++ b/src/month.tsx
@@ -413,6 +413,19 @@ export default class Month extends Component<MonthProps> {
   isSelectedQuarter = (day: Date, q: number, selected: Date): boolean =>
     getQuarter(day) === q && getYear(day) === getYear(selected);
 
+  isMonthSelected = () => {
+    const { day, selected, selectedDates, selectsMultiple } = this.props;
+    const monthIdx = getMonth(day);
+
+    if (selectsMultiple) {
+      return selectedDates?.some((date) =>
+        this.isSelectedMonth(day, monthIdx, date),
+      );
+    }
+
+    return !!selected && this.isSelectedMonth(day, monthIdx, selected);
+  };
+
   renderWeeks = () => {
     const weeks = [];
     const isFixedHeight = this.props.fixedHeight;
@@ -821,6 +834,7 @@ export default class Month extends Component<MonthProps> {
           !this.props.disabledKeyboardNavigation &&
           preSelection &&
           this.isSelectedMonth(day, m, preSelection) &&
+          !this.isMonthSelected() &&
           !this.isMonthDisabled(m),
         "react-datepicker__month-text--in-selecting-range":
           this.isInSelectingRangeMonth(m),

--- a/src/test/month_test.test.tsx
+++ b/src/test/month_test.test.tsx
@@ -2552,6 +2552,56 @@ describe("Month", () => {
       ).toBeNull();
     });
 
+    it("should not apply the keyboard-selected class when the month is a part of selected date", () => {
+      const selectedDate = newDate("2024-06-03");
+      const keyboardSelectedDate = selectedDate;
+
+      const { container } = render(
+        <Month
+          day={selectedDate}
+          selected={selectedDate}
+          preSelection={keyboardSelectedDate}
+          showMonthYearPicker
+        />,
+      );
+
+      const selected = container.querySelector(
+        ".react-datepicker__month-text--selected",
+      );
+      const keyboardSelected = container.querySelector(
+        ".react-datepicker__month-text--keyboard-selected",
+      );
+
+      expect(selected).not.toBeNull();
+      expect(keyboardSelected).toBeNull();
+    });
+
+    it("should not apply the keyboard-selected class when the month is a part of selected dates", () => {
+      const selectedDates = [newDate("2024-06-03")];
+      const keyboardSelectedDate = selectedDates[0];
+      const day = selectedDates[0] as Date;
+
+      const { container } = render(
+        <Month
+          day={day}
+          selectedDates={selectedDates}
+          preSelection={keyboardSelectedDate}
+          selectsMultiple
+          showMonthYearPicker
+        />,
+      );
+
+      const selected = container.querySelector(
+        ".react-datepicker__month-text--selected",
+      );
+      const keyboardSelected = container.querySelector(
+        ".react-datepicker__month-text--keyboard-selected",
+      );
+
+      expect(selected).not.toBeNull();
+      expect(keyboardSelected).toBeNull();
+    });
+
     it("should not apply the keyboard-selected class when the quarter is a part of disabled dates", () => {
       const currentSelectedDate = newDate("2023-08-08");
       const maxDate = newDate("2024-08-03");


### PR DESCRIPTION
Closes #5643

## Description
![image](https://github.com/user-attachments/assets/fbef9f8a-962b-4280-96b5-8a9081634500)

![image](https://github.com/user-attachments/assets/58dcdda1-ff10-4738-8639-d766589359f5)


In the Month Picker component if we select a date, it's style is updated to keyboard selected style and not to a selected style (Refer the First screenshot).  But using keyboard if we select some other date in that particular case the previously selected date is restoring it's old style (Refer the above screenshot).  

But in the normal DatePicker view we're not applying `--keyboard-selected` class if a date is already selected (Refer to the below screenshot).  Currently in the Month picker as we apply two styles at the same time and as the 2 CSS selectors we use have same specificity, `--keyboard-selector` is overriding the `--selected` style due to the order to selectors we have.

![image](https://github.com/user-attachments/assets/1c9bccf0-8ce7-4fc7-a460-e8ff4525963a)

**Changes**
As a fix, I updated MonthPicker similar to DatePicker to set `--keyboard-selected` only if the month is not already selected.

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
