### PR TITLE
fix(calendar): Change type on YearButtonLabel to be the type ReactNode.

### DIFF
--- a/src/calendar.tsx
+++ b/src/calendar.tsx
@@ -163,11 +163,11 @@ type CalendarProps = React.PropsWithChildren<
       onClickOutside: ClickOutsideHandler;
       outsideClickIgnoreClass?: string;
       previousMonthButtonLabel?: React.ReactNode;
-      previousYearButtonLabel?: string;
+      previousYearButtonLabel?: React.ReactNode;
       previousMonthAriaLabel?: string;
       previousYearAriaLabel?: string;
       nextMonthButtonLabel?: React.ReactNode;
-      nextYearButtonLabel?: string;
+      nextYearButtonLabel?: React.ReactNode;
       nextMonthAriaLabel?: string;
       nextYearAriaLabel?: string;
       showPreviousMonths?: boolean;

--- a/src/test/calendar_test.test.tsx
+++ b/src/test/calendar_test.test.tsx
@@ -403,6 +403,25 @@ describe("Calendar", () => {
     expect(nextButtonAriaLabel).toBe(nextButtonAriaLabel);
   });
 
+  it("should render by default aria labels for next and prev months buttons when providing a react node", () => {
+    const previousMonthButtonLabel = <span>Custom react previous month</span>;
+    const nextMonthButtonLabel = <span>Custom react next month</span>;
+    const { calendar } = getCalendar({
+      previousMonthButtonLabel,
+      nextMonthButtonLabel,
+    });
+
+    const previousButtonAriaLabel = calendar
+      .querySelector(".react-datepicker__navigation--previous")
+      ?.getAttribute("aria-label");
+    const nextButtonAriaLabel = calendar
+      .querySelector(".react-datepicker__navigation--next")
+      ?.getAttribute("aria-label");
+
+    expect(previousButtonAriaLabel).toBe("Previous Month");
+    expect(nextButtonAriaLabel).toBe("Next Month");
+  });
+
   it("should render the correct default aria labels for next and prev year buttons", () => {
     const { calendar } = getCalendar({ showYearPicker: true });
     const previousButtonAriaLabel = calendar
@@ -456,6 +475,26 @@ describe("Calendar", () => {
 
     expect(previousButtonAriaLabel).toBe(previousYearAriaLabel);
     expect(nextButtonAriaLabel).toBe(nextYearAriaLabel);
+  });
+
+  it("should render by default aria labels for next and prev year buttons when providing a react node", () => {
+    const previousYearButtonLabel = <span>Custom react previous year</span>;
+    const nextYearButtonLabel = <span>Custom react next year</span>;
+    const { calendar } = getCalendar({
+      showYearPicker: true,
+      previousYearButtonLabel,
+      nextYearButtonLabel,
+    });
+
+    const previousButtonAriaLabel = calendar
+      .querySelector(".react-datepicker__navigation--previous")
+      ?.getAttribute("aria-label");
+    const nextButtonAriaLabel = calendar
+      .querySelector(".react-datepicker__navigation--next")
+      ?.getAttribute("aria-label");
+
+    expect(previousButtonAriaLabel).toBe("Previous Year");
+    expect(nextButtonAriaLabel).toBe("Next Year");
   });
 
   it("should not have previous month button when selecting a date in the second month, when min date is specified", () => {


### PR DESCRIPTION

## Description
This changes the type of `previousYearButtonLabel` and `nextYearButtonLabel` to be `React.ReactNode`. This mirrors `previousMonthButtonLabel` and `nextMonthButtonLabel`, which is already of type React.ReactNode.

**Problem**
When using month picker, the `YearButtonLabel`s allow for specifying a ReactNode (the code [here](https://github.com/Hacker0x01/react-datepicker/blob/main/src/calendar.tsx#L723-L725) implies that it is expected to not always be a string), but typescript rightfully complains because the type doesn't line up.

**Changes**
This PR changes `previousYearButtonLabel` and `nextYearButtonLabel` to be the type `React.ReactNode` instead of `string`

## Screenshots
NA

## To reviewers
<!-- Additional comments for reviewers -->

## Contribution checklist
- [X] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [X] I have added sufficient test coverage for my changes.
- [X] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
