### PR TITLE
✨ Add a support for `visibleYearsRange` in the `renderCustomHeader` of the YearPicker

### DIFF
--- a/src/calendar.tsx
+++ b/src/calendar.tsx
@@ -101,6 +101,10 @@ export interface ReactDatePickerCustomHeaderProps {
   nextMonthButtonDisabled: boolean;
   prevYearButtonDisabled: boolean;
   nextYearButtonDisabled: boolean;
+  visibleYearsRange?: {
+    startYear: number;
+    endYear: number;
+  };
 }
 
 type CalendarProps = React.PropsWithChildren<
@@ -860,6 +864,20 @@ export default class Calendar extends Component<CalendarProps, CalendarState> {
       return null;
     }
 
+    const { showYearPicker, yearItemNumber } = this.props;
+
+    let visibleYearsRange;
+    if (showYearPicker) {
+      const { startPeriod: startYear, endPeriod: endYear } = getYearsPeriod(
+        monthDate,
+        yearItemNumber,
+      );
+      visibleYearsRange = {
+        startYear,
+        endYear,
+      };
+    }
+
     const prevMonthButtonDisabled = monthDisabledBefore(
       this.state.date,
       this.props,
@@ -892,6 +910,7 @@ export default class Calendar extends Component<CalendarProps, CalendarState> {
       >
         {this.props.renderCustomHeader?.({
           ...this.state,
+          ...(showYearPicker && { visibleYearsRange }),
           customHeaderCount: i,
           monthDate,
           changeMonth: this.changeMonth,

--- a/src/test/calendar_test.test.tsx
+++ b/src/test/calendar_test.test.tsx
@@ -550,6 +550,7 @@ describe("Calendar", () => {
     const renderCustomHeader = (params: ReactDatePickerCustomHeaderProps) => {
       const {
         date,
+        visibleYearsRange,
         changeYear,
         changeMonth,
         decreaseMonth,
@@ -560,6 +561,11 @@ describe("Calendar", () => {
 
       return (
         <div className="custom-header">
+          {visibleYearsRange && (
+            <h6 className="visible-years-range">
+              {visibleYearsRange.startYear} to {visibleYearsRange.endYear}
+            </h6>
+          )}
           <button
             className="prevMonth"
             onClick={decreaseMonth}
@@ -692,6 +698,31 @@ describe("Calendar", () => {
       expect(
         calendar.querySelectorAll(".react-datepicker__day-names"),
       ).toHaveLength(1);
+    });
+
+    it("should render custom header with visible year range for YearPicker", () => {
+      const { calendar } = getCalendar({
+        renderCustomHeader,
+        showYearPicker: true,
+      });
+
+      expect(
+        calendar.querySelector(
+          ".react-datepicker__header--custom .visible-years-range",
+        ),
+      ).not.toBeNull();
+    });
+
+    it("should not render visible year range for non-YearPicker views", () => {
+      const { calendar } = getCalendar({
+        renderCustomHeader,
+      });
+
+      expect(
+        calendar.querySelector(
+          ".react-datepicker__header--custom .visible-years-range",
+        ),
+      ).toBeNull();
     });
 
     it("should not render day names with renderCustomHeader & showMonthYearPicker", () => {


### PR DESCRIPTION
## Description
**Linked issue**: #5644

As mentioned in the ticket, I added a support for `visibleYearsRange` in the `renderCustomHeader` of the YearPicker.  This prop will be only available when the `showYearPicker` prop is set and it provides the `startYear` and the `endYear`.

**Changes**
- Updated `ReactDatePickerCustomHeaderProps` with the optional `visibleYearsRange` prop
- Include `visibleYearsRange` when calling `renderCustomHeader` for the YearPicker View
- Testcases to validate the change

![image](https://github.com/user-attachments/assets/668e9c78-452e-41ba-9432-52cbc0a12d74)


## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
