### PR TITLE
Include src files in package to resolve source map warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,23 @@
     "./dist/*.css": "./dist/*.css",
     "./src/stylesheets/*.scss": "./src/stylesheets/*.scss"
   },
-  "files": ["*.md", "dist", "lib", "es", "src/stylesheets"],
-  "sideEffects": ["**/*.css"],
-  "keywords": ["react", "datepicker", "calendar", "date", "react-component"],
+  "files": [
+    "*.md",
+    "dist",
+    "lib",
+    "es",
+    "src"
+  ],
+  "sideEffects": [
+    "**/*.css"
+  ],
+  "keywords": [
+    "react",
+    "datepicker",
+    "calendar",
+    "date",
+    "react-component"
+  ],
   "repository": {
     "type": "git",
     "url": "git://github.com/Hacker0x01/react-datepicker.git"
@@ -126,7 +140,10 @@
     "prepare": "husky"
   },
   "lint-staged": {
-    "*.{js,jsx,ts,tsx,json,css,scss,md}": ["prettier --write", "git add"]
+    "*.{js,jsx,ts,tsx,json,css,scss,md}": [
+      "prettier --write",
+      "git add"
+    ]
   },
   "packageManager": "yarn@4.7.0"
 }

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -41,6 +41,7 @@ const migrateRollup2to3OutputOptions = {
 /** @type {import('rollup').RollupOptions} */
 const config = {
   input: "src/index.tsx",
+  sourcemap: true,
   output: [
     {
       file: pkg.unpkg,
@@ -50,11 +51,12 @@ const config = {
       banner,
       ...migrateRollup2to3OutputOptions,
       plugins: [terser()],
+      sourcemap: true,
     },
     {
       file: pkg.unpkg.replace(".min.js", ".js"),
       format: "umd",
-      sourcemap: "inline",
+      sourcemap: true,
       name: "DatePicker",
       globals,
       banner,
@@ -63,7 +65,7 @@ const config = {
     {
       file: pkg.main,
       format: "cjs",
-      sourcemap: "inline",
+      sourcemap: true,
       name: "DatePicker",
       banner,
       ...migrateRollup2to3OutputOptions,
@@ -71,7 +73,7 @@ const config = {
     {
       file: pkg.module,
       format: "es",
-      sourcemap: "inline",
+      sourcemap: true,
       banner,
       ...migrateRollup2to3OutputOptions,
     },


### PR DESCRIPTION
---
name: Include src files in package
about: Include src files in package to resolve source map warnings
title: "Include src files in package to resolve source map warnings"
labels: "bug"
assignees: "[martijnrusschen](https://github.com/martijnrusschen)"
---

## Description
**Linked issue**: #5416

**Problem**
The published `npm` package includes source maps in the `/dist` folder that point to original source files in a `/src` directory. However, the `/src` directory itself is not included in the published package, causing `source-map-loader` to fail with an `ENOENT` error. 

**Changes**
This PR updates the build configuration to correctly generate and include source maps. This resolves the common "Failed to parse source map" warnings for developers using the library in modern bundlers. The main changes include updating `rollup.config.mjs` to enable source map generation for all outputs and modifying `package.json` to include the `/src` directory in the published package.

## To reviewers
Here are the steps I used to verify changes:

1. Checkout the changes and build the project as normal: `yarn build`
2. Generate the published package: `yarn pack`
3. Check for the now existing source files in the package: `tar -tvf package.tgz | grep "src/"`

This PR does increase the package size from ~375kb to ~499kb due to additional source files included in the package. These source files are used for development-time debugging only and are not included in the final production builds of applications that use `react-datepicker`, so there is no impact on end-user application size or performance.

## Contribution checklist
- [ ] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [ ] I have added sufficient test coverage for my changes.
- [ ] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
