### PR TITLE
Week classname support

### DIFF
--- a/docs-site/src/components/Examples/examples.scss
+++ b/docs-site/src/components/Examples/examples.scss
@@ -133,6 +133,11 @@
   color: #f00;
 }
 
+.react-datepicker__week.highlighted {
+  background-color: #ddffdd;
+  border-radius: 5px;
+}
+
 .example-custom-input {
   cursor: pointer;
   padding: 5px 15px;

--- a/docs-site/src/components/Examples/index.jsx
+++ b/docs-site/src/components/Examples/index.jsx
@@ -18,6 +18,7 @@ import CustomDateFormat from "../../examples/customDateFormat?raw";
 import CustomClassName from "../../examples/customClassName?raw";
 import CustomCalendarClassName from "../../examples/customCalendarClassName?raw";
 import CustomDayClassName from "../../examples/customDayClassName?raw";
+import CustomWeekClassName from "../../examples/customWeekClassName?raw";
 import CustomTimeClassName from "../../examples/customTimeClassName?raw";
 import Today from "../../examples/today?raw";
 import PlaceholderText from "../../examples/placeholderText?raw";
@@ -221,6 +222,10 @@ export default class exampleComponents extends React.Component {
     {
       title: "Custom day class name",
       component: CustomDayClassName,
+    },
+    {
+      title: "Custom week class name",
+      component: CustomWeekClassName,
     },
     {
       title: "Custom date format",

--- a/docs-site/src/examples/customWeekClassName.js
+++ b/docs-site/src/examples/customWeekClassName.js
@@ -1,0 +1,12 @@
+() => {
+  const [selectedDate, setSelectedDate] = useState(new Date());
+  return (
+    <DatePicker
+      selected={selectedDate}
+      onChange={(date) => setSelectedDate(date)}
+      weekClassName={(date) =>
+        getDate(date) % 2 === 0 ? "highlighted" : undefined
+      }
+    />
+  );
+};

--- a/src/test/week_test.test.tsx
+++ b/src/test/week_test.test.tsx
@@ -23,6 +23,23 @@ describe("Week", () => {
     expect(container.querySelector(".react-datepicker__week")).not.toBeNull();
   });
 
+  it("should apply className returned from passed weekClassName prop function", () => {
+    const className = "customClassNameWeek";
+    const monthClassNameFunc = () => className;
+    const { container } = render(
+      <Week
+        day={newDate()}
+        month={getMonth(newDate())}
+        weekClassName={monthClassNameFunc}
+      />,
+    );
+    expect(
+      container
+        .querySelector(".react-datepicker__week")
+        ?.classList.contains(className),
+    ).toBe(true);
+  });
+
   it("should render the days of the week", () => {
     const weekStart = getStartOfWeek(newDate("2015-12-20"));
     const { container } = render(

--- a/src/week.tsx
+++ b/src/week.tsx
@@ -197,6 +197,10 @@ export default class Week extends Component<WeekProps> {
     const customWeekClassName = this.props.weekClassName
       ? this.props.weekClassName(this.startOfWeek())
       : undefined;
-    return <div className={clsx(weekNumberClasses, customWeekClassName)}>{this.renderDays()}</div>;
+    return (
+      <div className={clsx(weekNumberClasses, customWeekClassName)}>
+        {this.renderDays()}
+      </div>
+    );
   }
 }

--- a/src/week.tsx
+++ b/src/week.tsx
@@ -12,6 +12,7 @@ import Day from "./day";
 import WeekNumber from "./week_number";
 
 interface DayProps extends React.ComponentPropsWithoutRef<typeof Day> {}
+
 interface WeekNumberProps
   extends React.ComponentPropsWithoutRef<typeof WeekNumber> {}
 
@@ -38,6 +39,7 @@ interface WeekProps
     weekNumber: number,
     event: React.MouseEvent<HTMLDivElement>,
   ) => void;
+  weekClassName?: (date: Date) => string;
 }
 
 export default class Week extends Component<WeekProps> {
@@ -192,6 +194,9 @@ export default class Week extends Component<WeekProps> {
       ),
       "react-datepicker__week--keyboard-selected": this.isKeyboardSelected(),
     };
-    return <div className={clsx(weekNumberClasses)}>{this.renderDays()}</div>;
+    const customWeekClassName = this.props.weekClassName
+      ? this.props.weekClassName(this.startOfWeek())
+      : undefined;
+    return <div className={clsx(weekNumberClasses, customWeekClassName)}>{this.renderDays()}</div>;
   }
 }


### PR DESCRIPTION
## Description
**Linked issue**: #5744 

**Problem**

See ticket.

**Changes**

I added a `weekClassName` prop to the `Week` component. I also added tests and a custom example.

## Screenshots

<img width="1732" height="696" alt="image" src="https://github.com/user-attachments/assets/f29715c8-48f6-4df4-ace5-9ad0c8f797ac" />

## To reviewers

I would personally make the function signature `(date: Date) => string | undefined` to allow the consumers to return `undefined` declaring that they do not want to add an extra class for this particular week. 

To follow the convention here I decided to keep it as `(date: Date) => string` to be inline with what all the other classname functions are doing. Slightly less elegant but the callers can still opt out by returning an empty string I guess.


## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
