### PR TITLE
feat: adding named exports for react datepicker

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -249,10 +249,7 @@ interface DatePickerState {
   isRenderAriaLiveMessage?: boolean;
 }
 
-export default class DatePicker extends Component<
-  DatePickerProps,
-  DatePickerState
-> {
+export class DatePicker extends Component<DatePickerProps, DatePickerState> {
   static get defaultProps() {
     return {
       allowSameDay: false,
@@ -1524,3 +1521,4 @@ export default class DatePicker extends Component<
 
 const PRESELECT_CHANGE_VIA_INPUT = "input";
 const PRESELECT_CHANGE_VIA_NAVIGATE = "navigate";
+export default DatePicker;


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to improve this repository
title: ""
labels: ""
assignees: ""
---

## Description
This PR aims to resolve issue [4039](https://github.com/Hacker0x01/react-datepicker/issues/4039)

**Problem**
An consumer of this library gets the error `JSX element type 'DatePicker' does not have any construct or call signatures` when importing this library when they have the moduleResolution nodenext/node16. 

**Changes**
Add an named export of the main DatePicker picker component so that users have alternative methods to import this library other than the current default export.

## To reviewers
<!-- Additional comments for reviewers -->

## Contribution checklist
- [ ] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [ ] I have added sufficient test coverage for my changes.
- [ ] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
