### PR TITLE
🐛 Refactor DatePicker component to handle null startDate date range selection properly

### DIFF
--- a/src/date_utils.ts
+++ b/src/date_utils.ts
@@ -245,11 +245,11 @@ export function safeDateRangeFormat(
     rangeSeparator?: string;
   },
 ): string {
-  if (!startDate) {
+  if (!startDate && !endDate) {
     return "";
   }
 
-  const formattedStartDate = safeDateFormat(startDate, props);
+  const formattedStartDate = startDate ? safeDateFormat(startDate, props) : "";
   const formattedEndDate = endDate ? safeDateFormat(endDate, props) : "";
   const dateRangeSeparator = props.rangeSeparator || DATE_RANGE_SEPARATOR;
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -670,12 +670,14 @@ export class DatePicker extends Component<DatePickerProps, DatePickerState> {
         this.props.locale,
         strictParsing,
       );
-      const endDateNew = parseDate(
-        valueEnd ?? "",
-        dateFormat,
-        this.props.locale,
-        strictParsing,
-      );
+      const endDateNew = startDateNew
+        ? parseDate(
+            valueEnd ?? "",
+            dateFormat,
+            this.props.locale,
+            strictParsing,
+          )
+        : null;
       const startChanged = startDate?.getTime() !== startDateNew?.getTime();
       const endChanged = endDate?.getTime() !== endDateNew?.getTime();
 
@@ -832,6 +834,7 @@ export class DatePicker extends Component<DatePickerProps, DatePickerState> {
       if (selectsRange) {
         const noRanges = !startDate && !endDate;
         const hasStartRange = startDate && !endDate;
+        const hasOnlyEndRange = !startDate && !!endDate;
         const isRangeFilled = startDate && endDate;
         if (noRanges) {
           onChange?.([changedDate, null], event);
@@ -846,6 +849,12 @@ export class DatePicker extends Component<DatePickerProps, DatePickerState> {
             }
           } else {
             onChange?.([startDate, changedDate], event);
+          }
+        } else if (hasOnlyEndRange) {
+          if (changedDate && isDateBefore(changedDate, endDate)) {
+            onChange?.([changedDate, endDate], event);
+          } else {
+            onChange?.([changedDate, null], event);
           }
         }
         if (isRangeFilled) {

--- a/src/test/date_utils_test.test.ts
+++ b/src/test/date_utils_test.test.ts
@@ -1264,6 +1264,14 @@ describe("date_utils", () => {
       );
     });
 
+    it("should return a formatted endDate prefixed by a dash when startDate is null", () => {
+      const startDate = null;
+      const endDate = new Date("2021-04-20 00:00:00");
+      expect(safeDateRangeFormat(startDate, endDate, props)).toBe(
+        " - 04/20/2021",
+      );
+    });
+
     it("should return a formatted startDate followed by a dash followed by a formatted endDate when startDate and endDate both have values", () => {
       const startDate = new Date("2021-04-20 00:00:00");
       const endDate = new Date("2021-04-28 00:00:00");


### PR DESCRIPTION
## Description
**Linked issue**: #5759

**Problem**
As mentioned in the linked ticket, we are having an issue when the user tries to clear the `startDate` value (when the `endDate` is available) using the date input, suddenly the datepicker becomes unresponsive.  User can't see any value in the date input and they won't be able to select any new value from the date picker popup also.

**Changes**
- Update Input Value get logic to return empty string only when both `startDate` & `endDate` is null.  Because the current logic is returning empty string when the `startDate` is not available regardless of checking the existence of the `endDate`
- Update Input change logic to properly handle start date change when `endDate` is available.  It'll either set the `startDate` by retaining the endDate (if its less than the existing `endDate`) or set the `startDate` by clearing the `endDate` (If the existing `endDate` is less than the current `startDate`).
- Update the Calendar Popup selection logic to properly handle the update of start date when the `endDate` is available

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
