### PR TITLE
fix: Improve behaviour of highlight dates with swapRange

### DIFF
--- a/src/day.tsx
+++ b/src/day.tsx
@@ -67,6 +67,7 @@ interface DayProps
   locale?: Locale;
   monthShowsDuplicateDaysEnd?: boolean;
   monthShowsDuplicateDaysStart?: boolean;
+  swapRange?: boolean;
 }
 
 /**
@@ -288,6 +289,7 @@ export default class Day extends Component<DayProps> {
       selectsRange,
       selectsDisabledDaysInRange,
       startDate,
+      swapRange,
       endDate,
     } = this.props;
 
@@ -317,13 +319,18 @@ export default class Day extends Component<DayProps> {
       return isDayInRange(day, startDate, selectingDate);
     }
 
-    if (
-      selectsRange &&
-      startDate &&
-      !endDate &&
-      (isAfter(selectingDate, startDate) || isEqual(selectingDate, startDate))
-    ) {
-      return isDayInRange(day, startDate, selectingDate);
+    if (selectsRange && startDate && !endDate) {
+      if (isEqual(selectingDate, startDate)) {
+        return isDayInRange(day, startDate, selectingDate);
+      }
+
+      if (isAfter(selectingDate, startDate)) {
+        return isDayInRange(day, startDate, selectingDate);
+      }
+
+      if (swapRange && isBefore(selectingDate, startDate)) {
+        return isDayInRange(day, selectingDate, startDate);
+      }
     }
 
     return false;

--- a/src/day.tsx
+++ b/src/day.tsx
@@ -341,14 +341,18 @@ export default class Day extends Component<DayProps> {
       return false;
     }
 
-    const { day, startDate, selectsStart } = this.props;
+    const { day, startDate, selectsStart, swapRange, selectsRange } = this.props;
     const selectingDate = this.props.selectingDate ?? this.props.preSelection;
 
     if (selectsStart) {
       return isSameDay(day, selectingDate);
-    } else {
-      return isSameDay(day, startDate);
     }
+
+    if (selectsRange && swapRange && startDate && selectingDate) {
+      return isSameDay(day, isBefore(selectingDate, startDate) ? selectingDate : startDate);
+    }
+
+    return isSameDay(day, startDate);
   };
 
   isSelectingRangeEnd = () => {
@@ -356,14 +360,22 @@ export default class Day extends Component<DayProps> {
       return false;
     }
 
-    const { day, endDate, selectsEnd, selectsRange } = this.props;
+    const { day, endDate, selectsEnd, selectsRange, swapRange, startDate } = this.props;
     const selectingDate = this.props.selectingDate ?? this.props.preSelection;
 
-    if (selectsEnd || selectsRange) {
+    if (selectsEnd) {
       return isSameDay(day, selectingDate);
-    } else {
-      return isSameDay(day, endDate);
     }
+
+    if (selectsRange && swapRange && startDate && selectingDate) {
+      return isSameDay(day, isBefore(selectingDate, startDate) ? startDate : selectingDate);
+    }
+
+    if (selectsRange) {
+      return isSameDay(day, selectingDate);
+    }
+
+    return isSameDay(day, endDate);
   };
 
   isRangeStart = () => {

--- a/src/day.tsx
+++ b/src/day.tsx
@@ -341,7 +341,8 @@ export default class Day extends Component<DayProps> {
       return false;
     }
 
-    const { day, startDate, selectsStart, swapRange, selectsRange } = this.props;
+    const { day, startDate, selectsStart, swapRange, selectsRange } =
+      this.props;
     const selectingDate = this.props.selectingDate ?? this.props.preSelection;
 
     if (selectsStart) {
@@ -349,7 +350,10 @@ export default class Day extends Component<DayProps> {
     }
 
     if (selectsRange && swapRange && startDate && selectingDate) {
-      return isSameDay(day, isBefore(selectingDate, startDate) ? selectingDate : startDate);
+      return isSameDay(
+        day,
+        isBefore(selectingDate, startDate) ? selectingDate : startDate,
+      );
     }
 
     return isSameDay(day, startDate);
@@ -360,7 +364,8 @@ export default class Day extends Component<DayProps> {
       return false;
     }
 
-    const { day, endDate, selectsEnd, selectsRange, swapRange, startDate } = this.props;
+    const { day, endDate, selectsEnd, selectsRange, swapRange, startDate } =
+      this.props;
     const selectingDate = this.props.selectingDate ?? this.props.preSelection;
 
     if (selectsEnd) {
@@ -368,7 +373,10 @@ export default class Day extends Component<DayProps> {
     }
 
     if (selectsRange && swapRange && startDate && selectingDate) {
-      return isSameDay(day, isBefore(selectingDate, startDate) ? startDate : selectingDate);
+      return isSameDay(
+        day,
+        isBefore(selectingDate, startDate) ? startDate : selectingDate,
+      );
     }
 
     if (selectsRange) {

--- a/src/month.tsx
+++ b/src/month.tsx
@@ -1101,8 +1101,6 @@ export default class Month extends Component<MonthProps> {
       ? ariaLabelPrefix.trim() + " "
       : "";
 
-    console.log('Month render:', this.props.selectingDate);
-
     return (
       <div
         className={this.getClassNames()}

--- a/src/month.tsx
+++ b/src/month.tsx
@@ -1101,6 +1101,8 @@ export default class Month extends Component<MonthProps> {
       ? ariaLabelPrefix.trim() + " "
       : "";
 
+    console.log('Month render:', this.props.selectingDate);
+
     return (
       <div
         className={this.getClassNames()}

--- a/src/test/day_test.test.tsx
+++ b/src/test/day_test.test.tsx
@@ -896,6 +896,61 @@ describe("Day", () => {
         ).toBe(true);
       });
     });
+
+    describe("for a date picker with selectsRange and swapRange prop", () => {
+      it("should select range from startDate to selectingDate if selectingDate mote then startDate", () => {
+        const startDate = newDate();
+        const dayInRange = addDays(startDate, 1);
+        const selectingDate = addDays(startDate, 2);
+
+        const containerStartDay = renderDay(dayInRange, {
+          startDate,
+          selectingDate,
+          selectsRange: true,
+          swapRange: true,
+        });
+        expect(
+          containerStartDay
+            .querySelector(".react-datepicker__day")
+            ?.classList.contains(rangeDayClassName),
+        ).toBe(true);
+      })
+
+      it("should select range from selectingDate to startDate if selectingDate less then startDate", () => {
+        const startDate = newDate();
+        const dayInRange = subDays(startDate, 1);
+        const selectingDate = subDays(startDate, 2);
+
+        const containerStartDay = renderDay(dayInRange, {
+          startDate,
+          selectingDate,
+          selectsRange: true,
+          swapRange: true,
+        });
+        expect(
+          containerStartDay
+            .querySelector(".react-datepicker__day")
+            ?.classList.contains(rangeDayClassName),
+        ).toBe(true);
+      });
+
+      it("should select as range if selectingDate is equal to startDate", () => {
+        const startDate = newDate();
+        const selectingDate = startDate
+
+        const containerStartDay = renderDay(startDate, {
+          startDate,
+          selectingDate,
+          selectsRange: true,
+          swapRange: true,
+        });
+        expect(
+          containerStartDay
+            .querySelector(".react-datepicker__day")
+            ?.classList.contains(rangeDayClassName),
+        ).toBe(true);
+      });
+    })
   });
 
   describe("today", () => {

--- a/src/test/day_test.test.tsx
+++ b/src/test/day_test.test.tsx
@@ -898,7 +898,7 @@ describe("Day", () => {
     });
 
     describe("for a date picker with selectsRange and swapRange prop", () => {
-      it("should select range from startDate to selectingDate if selectingDate mote then startDate", () => {
+      it("should select range from startDate to selectingDate if selectingDate more than startDate", () => {
         const startDate = newDate();
         const dayInRange = addDays(startDate, 1);
         const selectingDate = addDays(startDate, 2);
@@ -916,7 +916,7 @@ describe("Day", () => {
         ).toBe(true);
       })
 
-      it("should select range from selectingDate to startDate if selectingDate less then startDate", () => {
+      it("should select range from selectingDate to startDate if selectingDate less than startDate", () => {
         const startDate = newDate();
         const dayInRange = subDays(startDate, 1);
         const selectingDate = subDays(startDate, 2);

--- a/src/test/day_test.test.tsx
+++ b/src/test/day_test.test.tsx
@@ -914,7 +914,7 @@ describe("Day", () => {
             .querySelector(".react-datepicker__day")
             ?.classList.contains(rangeDayClassName),
         ).toBe(true);
-      })
+      });
 
       it("should select range from selectingDate to startDate if selectingDate is before startDate", () => {
         const startDate = newDate();
@@ -936,7 +936,7 @@ describe("Day", () => {
 
       it("should select as range if selectingDate is equal to startDate", () => {
         const startDate = newDate();
-        const selectingDate = startDate
+        const selectingDate = startDate;
 
         const containerStartDay = renderDay(startDate, {
           startDate,
@@ -967,7 +967,6 @@ describe("Day", () => {
             ?.classList.contains(rangeDayStartClassName),
         ).toBe(true);
 
-
         const containerEndDay = renderDay(startDate, {
           startDate,
           selectingDate,
@@ -980,7 +979,7 @@ describe("Day", () => {
             .querySelector(".react-datepicker__day")
             ?.classList.contains(rangeDayEndClassName),
         ).toBe(true);
-      })
+      });
 
       it("should set selectingDate as the end of range and startDate as the start of range if selectingDate is after startDate", () => {
         const startDate = newDate();
@@ -1010,9 +1009,9 @@ describe("Day", () => {
             .querySelector(".react-datepicker__day")
             ?.classList.contains(rangeDayEndClassName),
         ).toBe(true);
-      })
+      });
 
-      it('should set startDate as the end and start range if selectionDate equal startDate', () => {
+      it("should set startDate as the end and start range if selectionDate equal startDate", () => {
         const startDate = newDate();
         const selectingDate = startDate;
 
@@ -1041,7 +1040,7 @@ describe("Day", () => {
             ?.classList.contains(rangeDayEndClassName),
         ).toBe(true);
       });
-    })
+    });
   });
 
   describe("today", () => {

--- a/src/test/day_test.test.tsx
+++ b/src/test/day_test.test.tsx
@@ -898,7 +898,7 @@ describe("Day", () => {
     });
 
     describe("for a date picker with selectsRange and swapRange prop", () => {
-      it("should select range from startDate to selectingDate if selectingDate more than startDate", () => {
+      it("should select range from startDate to selectingDate if selectingDate is after startDate", () => {
         const startDate = newDate();
         const dayInRange = addDays(startDate, 1);
         const selectingDate = addDays(startDate, 2);
@@ -916,7 +916,7 @@ describe("Day", () => {
         ).toBe(true);
       })
 
-      it("should select range from selectingDate to startDate if selectingDate less than startDate", () => {
+      it("should select range from selectingDate to startDate if selectingDate is before startDate", () => {
         const startDate = newDate();
         const dayInRange = subDays(startDate, 1);
         const selectingDate = subDays(startDate, 2);
@@ -948,6 +948,97 @@ describe("Day", () => {
           containerStartDay
             .querySelector(".react-datepicker__day")
             ?.classList.contains(rangeDayClassName),
+        ).toBe(true);
+      });
+
+      it("should set selectingDate as the start of range and startDate as the end of range if selectingDate is before startDate", () => {
+        const startDate = newDate();
+        const selectingDate = subDays(startDate, 1);
+
+        const containerStartDay = renderDay(selectingDate, {
+          startDate,
+          selectingDate,
+          selectsRange: true,
+          swapRange: true,
+        });
+        expect(
+          containerStartDay
+            .querySelector(".react-datepicker__day")
+            ?.classList.contains(rangeDayStartClassName),
+        ).toBe(true);
+
+
+        const containerEndDay = renderDay(startDate, {
+          startDate,
+          selectingDate,
+          selectsRange: true,
+          swapRange: true,
+        });
+
+        expect(
+          containerEndDay
+            .querySelector(".react-datepicker__day")
+            ?.classList.contains(rangeDayEndClassName),
+        ).toBe(true);
+      })
+
+      it("should set selectingDate as the end of range and startDate as the start of range if selectingDate is after startDate", () => {
+        const startDate = newDate();
+        const selectingDate = addDays(startDate, 1);
+
+        const containerStartDay = renderDay(startDate, {
+          startDate,
+          selectingDate,
+          selectsRange: true,
+          swapRange: true,
+        });
+        expect(
+          containerStartDay
+            .querySelector(".react-datepicker__day")
+            ?.classList.contains(rangeDayStartClassName),
+        ).toBe(true);
+
+        const containerEndDay = renderDay(selectingDate, {
+          startDate,
+          selectingDate,
+          selectsRange: true,
+          swapRange: true,
+        });
+
+        expect(
+          containerEndDay
+            .querySelector(".react-datepicker__day")
+            ?.classList.contains(rangeDayEndClassName),
+        ).toBe(true);
+      })
+
+      it('should set startDate as the end and start range if selectionDate equal startDate', () => {
+        const startDate = newDate();
+        const selectingDate = startDate;
+
+        const containerStartDay = renderDay(startDate, {
+          startDate,
+          selectingDate,
+          selectsRange: true,
+          swapRange: true,
+        });
+        expect(
+          containerStartDay
+            .querySelector(".react-datepicker__day")
+            ?.classList.contains(rangeDayStartClassName),
+        ).toBe(true);
+
+        const containerEndDay = renderDay(selectingDate, {
+          startDate,
+          selectingDate,
+          selectsRange: true,
+          swapRange: true,
+        });
+
+        expect(
+          containerEndDay
+            .querySelector(".react-datepicker__day")
+            ?.classList.contains(rangeDayEndClassName),
         ).toBe(true);
       });
     })


### PR DESCRIPTION
## Description
**Linked issue**: #5258 

**Problem**
When I open a date range picker with swapRange, I select the first date. Then, when I hover or focus on the second date, if the second date is before the first date, all dates within this range do not have the following in range classes: react-datepicker__day--in-selecting-range, react-datepicker__day--selecting-range-start, react-datepicker__day--selecting-range-end.

https://github.com/user-attachments/assets/6a1cb8c1-bc32-43ac-8f1f-1916b7ba8c3f



**Changes**
- All days within the selected range now correctly receive the in range classes.
- The classes `react-datepicker__day--selecting-range-start` and `react-datepicker__day--selecting-range-end` are now dynamically setted based on `selectionDate` and `startDate`, but only when the `swapRange` prop is enabled.

## Screenshots

https://github.com/user-attachments/assets/954496c2-49a4-4c42-8742-7dda3a4e9ab4

## To reviewers
<!-- Additional comments for reviewers -->

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
