### PR TITLE
fix: Center align day names in DatePicker for improved layout

### DIFF
--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -381,6 +381,7 @@ h2.react-datepicker__current-month {
 }
 
 .react-datepicker__day-names {
+  text-align: center;
   white-space: nowrap;
   margin-bottom: -8px;
 }


### PR DESCRIPTION
## Description
**Linked issue**: #5829 

**Problem**
Wrong alignment of the day names in the header.


**Changes**
Small changes in scss file. Added the same style which have other rows in grid.


## Screenshots
Before: 
<img width="242" height="288" alt="image" src="https://github.com/user-attachments/assets/82999171-0f6d-4d33-b66f-d3e863347bf7" />


After: 
<img width="260" height="288" alt="image" src="https://github.com/user-attachments/assets/4a0ac261-efde-4bd8-860f-a8161635b6a9" />

## To reviewers

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
