### PR TITLE
✨ Add `selectionMeta` param to the onChangeRaw event call when a date is selected

### DIFF
--- a/docs-site/src/examples/rawChange.js
+++ b/docs-site/src/examples/rawChange.js
@@ -1,6 +1,12 @@
 () => {
   const [selectedDate, setSelectedDate] = useState(null);
-  const handleChangeRaw = (value) => {
+  const handleChangeRaw = (value, selectedDateMeta) => {
+    console.log(
+      selectedDateMeta
+        ? `Selected Date Meta: ${JSON.stringify(selectedDateMeta)}`
+        : "No Selection Meta is available",
+    );
+
     if (value === "tomorrow") {
       setSelectedDate(addDays(new Date(), 1));
     }
@@ -10,7 +16,9 @@
       selected={selectedDate}
       onChange={(date) => setSelectedDate(date)}
       placeholderText='Enter "tomorrow"'
-      onChangeRaw={(event) => handleChangeRaw(event.target.value)}
+      onChangeRaw={(event, selectedDateMeta) =>
+        handleChangeRaw(event.target.value, selectedDateMeta)
+      }
     />
   );
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -194,6 +194,10 @@ export type DatePickerProps = OmitUnion<
     rangeSeparator?: string;
     onChangeRaw?: (
       event?: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,
+      selectionMeta?: {
+        date: Date;
+        formattedDate: string;
+      },
     ) => void;
     onSelect?: (
       date: Date | null,
@@ -717,7 +721,9 @@ export class DatePicker extends Component<DatePickerProps, DatePickerState> {
   ) => {
     if (this.props.readOnly) return;
 
-    const { selectsRange, startDate, endDate, swapRange } = this.props;
+    const { selectsRange, startDate, endDate, locale, swapRange } = this.props;
+    const dateFormat =
+      this.props.dateFormat ?? DatePicker.defaultProps.dateFormat;
     const isDateSelectionComplete =
       !selectsRange ||
       (startDate && !endDate && (swapRange || !isDateBefore(date, startDate)));
@@ -732,7 +738,11 @@ export class DatePicker extends Component<DatePickerProps, DatePickerState> {
       this.sendFocusBackToInput();
     }
     if (this.props.onChangeRaw) {
-      this.props.onChangeRaw(event);
+      const formattedDate = safeDateFormat(date, {
+        dateFormat,
+        locale,
+      });
+      this.props.onChangeRaw(event, { date, formattedDate });
     }
     this.setSelected(date, event, false, monthSelectedIn);
     if (this.props.showDateSelect) {

--- a/src/test/datepicker_test.test.tsx
+++ b/src/test/datepicker_test.test.tsx
@@ -4819,4 +4819,68 @@ describe("DatePicker", () => {
       });
     });
   });
+
+  describe("onChangeRaw - selectionMeta", () => {
+    it("should include selectionMeta as a second param to the onChangeRaw when user selected a date to provide extra meta about the selected date element", () => {
+      const selectedDate = newDate("2025-11-05");
+      const onChangeRawSpy = jest.fn();
+      const { container } = render(
+        <DatePicker
+          dateFormat="MM/dd/yyyy"
+          selected={selectedDate}
+          onChangeRaw={onChangeRawSpy}
+        />,
+      );
+      expect(onChangeRawSpy).not.toHaveBeenCalled();
+
+      const input = safeQuerySelector(container, "input");
+      fireEvent.focus(input);
+
+      const day = safeQuerySelector(container, ".react-datepicker__day--002");
+      fireEvent.click(day);
+
+      expect(onChangeRawSpy).toHaveBeenCalledTimes(1);
+      const params = onChangeRawSpy.mock.calls[0];
+      expect(params.length).toBe(2);
+
+      const eventObject = params[0];
+      expect(typeof eventObject).toBe("object");
+
+      const selectionMeta = params[1];
+      expect(typeof selectionMeta).toBe("object");
+      expect(selectionMeta).toHaveProperty("date");
+      expect(selectionMeta).toHaveProperty("formattedDate");
+      expect(selectionMeta.formattedDate).toBe("11/02/2025");
+      expect(selectionMeta.date).toBeInstanceOf(Date);
+    });
+
+    it("should not include selectionMeta as a second param to the onChangeRaw when user updated date using date input", () => {
+      const selectedDate = newDate("2025-11-05");
+      const onChangeRawSpy = jest.fn();
+      const { container } = render(
+        <DatePicker
+          dateFormat="MM/dd/yyyy"
+          selected={selectedDate}
+          onChangeRaw={onChangeRawSpy}
+        />,
+      );
+      expect(onChangeRawSpy).not.toHaveBeenCalled();
+
+      const input = safeQuerySelector(container, "input");
+      const inputValue = "11/02/2025";
+      fireEvent.change(input, {
+        target: {
+          value: inputValue,
+        },
+      });
+      expect(onChangeRawSpy).toHaveBeenCalledTimes(1);
+
+      const params = onChangeRawSpy.mock.calls[0];
+      expect(params.length).toBe(1);
+
+      const eventObject = params[0];
+      expect(typeof eventObject).toBe("object");
+      expect(eventObject.target?.value).toBe(inputValue);
+    });
+  });
 });


### PR DESCRIPTION
## Description
**Linked issue**: #5701 

As mentioned in the linked issue, currently `onChangeRaw` will just include the corresponding event as the only param.  In this PR, I enhanced it a little bit by including the `selectionMeta` when a day is selected.  This includes the selected date object along with the formatted date string.  `formattedDate` contains the formatted version of the selected date.  

We're also emitting `onChangeRaw` when user directly change the date input value with change event, but as it's a change event and not specifically related to any day click, I'm not including the selectionMeta there.  


**Problem**
To include the additional meta of the selected date element.

**Changes**
- Add `selectionMeta` as a second optional param - to include additional details about the selected date
- Updated the example of `onChangeRaw` usage
- Test case update

## Screenshots
<img width="680" height="163" alt="image" src="https://github.com/user-attachments/assets/9a45e7f6-1d18-47b3-8bab-84c09f578055" />

## Contribution checklist
- [ ] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [ ] I have added sufficient test coverage for my changes.
- [ ] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
