### PR TITLE
🐛 Configure esbuild-wasm initialize to use installed package version

### DIFF
--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "copy-to-clipboard": "^3.3.3",
     "date-fns": "^4.1.0",
-    "esbuild-wasm": "^0.25.9",
+    "esbuild-wasm": "^0.25.10",
     "highlight.js": "^11.11.1",
     "lodash": "^4.17.21",
     "prism-react-renderer": "^2.4.1",

--- a/docs-site/src/components/tsxTransformer.ts
+++ b/docs-site/src/components/tsxTransformer.ts
@@ -1,4 +1,5 @@
 import { initialize, transform } from "esbuild-wasm";
+import { version } from "esbuild-wasm/package.json";
 
 let initializeEsBuild: Promise<void> | null = null;
 
@@ -16,7 +17,7 @@ export const initializeTsxTransformer = async () => {
   if (!initializeEsBuild) {
     try {
       initializeEsBuild = initialize({
-        wasmURL: "https://unpkg.com/esbuild-wasm/esbuild.wasm",
+        wasmURL: `https://unpkg.com/esbuild-wasm@${version}/esbuild.wasm`,
       });
     } catch (error) {
       console.error(`Initializing tsx transformer failed:`, error);

--- a/docs-site/yarn.lock
+++ b/docs-site/yarn.lock
@@ -2680,12 +2680,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-wasm@npm:^0.25.9":
-  version: 0.25.9
-  resolution: "esbuild-wasm@npm:0.25.9"
+"esbuild-wasm@npm:^0.25.10":
+  version: 0.25.10
+  resolution: "esbuild-wasm@npm:0.25.10"
   bin:
     esbuild: bin/esbuild
-  checksum: 10c0/8c4865d061c94303939549ba67930dfdd51ced9a46ef1b09f63b15696de5075690c4680f616a1932cb0296eed615eb1fa0670337104c4c83d95fac1c2217cf00
+  checksum: 10c0/2cc225d595be2a0d4c5d599d51fe87845cbd1750b40e84869c51d068c2067d33e307d8cb33d0eec2f638621415075fff01ac2a0ed71ea319c2e3070028d2d410
   languageName: node
   linkType: hard
 
@@ -4878,7 +4878,7 @@ __metadata:
     "@vitejs/plugin-react": "npm:^5.0.3"
     copy-to-clipboard: "npm:^3.3.3"
     date-fns: "npm:^4.1.0"
-    esbuild-wasm: "npm:^0.25.9"
+    esbuild-wasm: "npm:^0.25.10"
     eslint: "npm:^9.35.0"
     eslint-plugin-react: "npm:^7.37.5"
     eslint-plugin-react-hooks: "npm:^6.0.0"


### PR DESCRIPTION
## Description
Configures esbuild-wasm’s initialize to load the WASM from a URL pinned to the installed package version, preventing mismatches between the JS wrapper and the WASM binary. Also upgrades esbuild-wasm to 0.25.10.

**Problem**
Using an unpinned `WASM` URL could fetch a different version than the installed `esbuild-wasm` JS, causing runtime errors and version conflicts.

**Linked PR:** https://github.com/Hacker0x01/react-datepicker/pull/5865

**Changes**
- Configure initialize to use: https://unpkg.com/esbuild-wasm@${version}/esbuild.wasm
- Upgrade esbuild-wasm to 0.25.10.

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
