### PR TITLE
Fix loading indicator flicker when switching TypeScript/JavaScript tabs in docs-site

### DIFF
--- a/docs-site/src/components/Example/index.tsx
+++ b/docs-site/src/components/Example/index.tsx
@@ -62,35 +62,36 @@ export default class CodeExampleComponent extends React.Component<
     registerLocale("en-GB", enGB);
   }
 
-  transpileTsCode = async () => {
-    const tsCode = this.state.tsxCode;
-
-    let stateUpdates = {
-      jsxCode: "",
-      isTranspiling: true,
-    };
-
-    try {
-      const transpiledCode = await transformTsx(tsCode);
-
-      this.lastTranspiledTsCodeRef.current = tsCode;
-      stateUpdates = {
-        jsxCode: transpiledCode,
-        isTranspiling: false,
-      };
-    } catch (err) {
-      stateUpdates = {
-        jsxCode: "// Transpilation failed! Error: " + (err as Error).message,
-        isTranspiling: false,
-      };
-
-      toast.show("Transpilation failed!", "error");
-    }
-
+  applyStateUpdates = (stateUpdates: Partial<TState>) => {
     this.setState((state) => ({
       ...state,
       ...stateUpdates,
     }));
+  };
+
+  transpileTsCode = async () => {
+    this.applyStateUpdates({
+      jsxCode: "",
+      isTranspiling: true,
+    });
+
+    try {
+      const tsCode = this.state.tsxCode;
+      const transpiledCode = await transformTsx(tsCode);
+
+      this.lastTranspiledTsCodeRef.current = tsCode;
+      this.applyStateUpdates({
+        jsxCode: transpiledCode,
+        isTranspiling: false,
+      });
+    } catch (err) {
+      this.applyStateUpdates({
+        jsxCode: "// Transpilation failed! Error: " + (err as Error).message,
+        isTranspiling: false,
+      });
+
+      toast.show("Transpilation failed!", "error");
+    }
   };
 
   handleCodeChange = debounce((code: string) => {


### PR DESCRIPTION
## Description
Ensures the transpilation/loading indicator displays correctly when toggling between the TypeScript and JavaScript tabs in the docs-site, preventing the brief, misleading error flash.

**Problem**
On tab switch, the loading state wasn’t activated early enough and previous error state could render momentarily, causing a transient error display.

**Changes**
- Fix the loading state
- Update the error message properly on transpilation error

## Screenshots
**Current Issue**
https://github.com/user-attachments/assets/1b95b6e2-3b0d-483a-aa88-1aa02d200c21

**After the Fix**
https://github.com/user-attachments/assets/3b0b723d-7601-47a8-aa64-ad38e885864d

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
