### PR TITLE
(docs-site) 🐛 Fix the cursor position auto-reset while typing in progress

### DIFF
--- a/docs-site/src/components/Example/index.tsx
+++ b/docs-site/src/components/Example/index.tsx
@@ -11,7 +11,6 @@ import { fi } from "date-fns/locale/fi";
 import { ptBR } from "date-fns/locale/pt-BR";
 import { enGB } from "date-fns/locale/en-GB";
 import copy from "copy-to-clipboard";
-import { debounce } from "lodash";
 import slugify from "slugify";
 import range from "lodash/range";
 import { themes } from "prism-react-renderer";
@@ -94,7 +93,7 @@ export default class CodeExampleComponent extends React.Component<
     }
   };
 
-  handleCodeChange = debounce((code: string) => {
+  handleCodeChange = (code: string) => {
     const { activeTab } = this.state;
     const codeProp = activeTab === "ts" ? "tsxCode" : "jsxCode";
 
@@ -102,7 +101,7 @@ export default class CodeExampleComponent extends React.Component<
       ...state,
       [codeProp]: code,
     }));
-  }, 500);
+  };
 
   handleTabChange = async (tab: TState["activeTab"]) => {
     const { tsxCode } = this.state;


### PR DESCRIPTION
## Description
Removed the `debounce` in the `docs-site` example editor so `react-live` no longer resets the cursor position while typing. This ensures smooth, predictable typing behavior in the live code editor.

**Problem**
As a part of enabling the support for TypeScript examples in the `docs-site`, we make `react-live` to be a controlled component so that we can able to use the updated code for JSX transpilation when user switches to the JavaScript tab.  We debounce `onChange` handler.  But with `debounce` enabled, `react-live` occasionally re-renders out of sync during typing, which auto-resets the cursor/selection position mid-input. 

**Changes**
- Removed `debounce` from the example editor’s `onChange` handling in docs-site/src/components/Example/index.tsx.
- Allowed immediate updates to the live code preview to avoid selection jumps.
- Verified typing continuity and cursor stability during rapid input.

## Screenshots
**The issue**
https://github.com/user-attachments/assets/d8d0d6b5-7838-4213-af69-c7356161b7a7

**After the fix**
https://github.com/user-attachments/assets/a1965261-b2fc-4e84-97e5-715f60cd34de

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
