### PR TITLE
🎨♿ Fix keyboard-selected + hovered date text color for accessibility

### DIFF
--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -506,6 +506,7 @@ h2.react-datepicker__current-month {
         $datepicker__selected-color,
         $lightness: -5%
       );
+      color: #fff;
     }
   }
 


### PR DESCRIPTION
**Problem**
This PR focus a small accessibility related issue in the DatePicker.  When a day is both keyboard selected and mouse hovered, it's color is black which makes it hard to read in it's dark background color.  In this PR, I just reset the color back to white for keyboard selected + mouse hovered day.

**Changes**
- Reset the style back to white

## Screenshots
**The Issue**
<img width="825" height="352" alt="image" src="https://github.com/user-attachments/assets/72406cf5-3614-4b38-90f1-9ecac124f51b" />

**After the fix**
<img width="722" height="290" alt="image" src="https://github.com/user-attachments/assets/e46ca065-eb2c-4989-89b8-4337da17a097" />

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
