### PR TITLE
QuarterYearPicker: align selected styling with other pickers and fix multi-select highlighting

### DIFF
--- a/src/month.tsx
+++ b/src/month.tsx
@@ -415,6 +415,11 @@ export default class Month extends Component<MonthProps> {
   isSelectedQuarter = (day: Date, q: number, selected: Date): boolean =>
     getQuarter(selected) === q && getYear(day) === getYear(selected);
 
+  isSelectQuarterInList = (day: Date, q: number, selectedDates: Date[]) =>
+    selectedDates.some((selectedDate) =>
+      this.isSelectedQuarter(day, q, selectedDate),
+    );
+
   isMonthSelected = () => {
     const { day, selected, selectedDates, selectsMultiple } = this.props;
     const monthIdx = getMonth(day);
@@ -934,7 +939,6 @@ export default class Month extends Component<MonthProps> {
       day,
       startDate,
       endDate,
-      selected,
       minDate,
       maxDate,
       excludeDates,
@@ -954,13 +958,15 @@ export default class Month extends Component<MonthProps> {
         disabled) &&
       isQuarterDisabled(setQuarter(day, q), this.props);
 
+    const selection = this.getSelection();
+
     return clsx(
       "react-datepicker__quarter-text",
       `react-datepicker__quarter-${q}`,
       {
         "react-datepicker__quarter-text--disabled": isDisabled,
-        "react-datepicker__quarter-text--selected": selected
-          ? this.isSelectedQuarter(day, q, selected)
+        "react-datepicker__quarter-text--selected": selection
+          ? this.isSelectQuarterInList(day, q, selection)
           : undefined,
         "react-datepicker__quarter-text--keyboard-selected":
           !disabledKeyboardNavigation &&

--- a/src/test/month_test.test.tsx
+++ b/src/test/month_test.test.tsx
@@ -1202,6 +1202,56 @@ describe("Month", () => {
     });
 
     it("should have no axe violations", () => runAxe(monthComponent));
+
+    it("should apply the selected class when the quarter is a part of selected date", () => {
+      const selectedDate = newDate("2025-11-01");
+      const keyboardSelectedDate = selectedDate;
+
+      const { container } = render(
+        <Month
+          day={selectedDate}
+          selected={selectedDate}
+          preSelection={keyboardSelectedDate}
+          showQuarterYearPicker
+        />,
+      );
+
+      const selected = container.querySelector(
+        ".react-datepicker__quarter-text--selected",
+      );
+      expect(selected).not.toBeNull();
+      expect(selected?.textContent).toBe("Q4");
+    });
+
+    it("should apply the selected class when the quarter is a part of selected dates", () => {
+      const selectedDates = [newDate("2025-11-01"), newDate("2025-01-01")];
+      const keyboardSelectedDate = selectedDates[0];
+      const day = selectedDates[0] as Date;
+
+      const { container } = render(
+        <Month
+          day={day}
+          selectedDates={selectedDates}
+          preSelection={keyboardSelectedDate}
+          selectsMultiple
+          showQuarterYearPicker
+        />,
+      );
+
+      const selectedElements = Array.from(
+        container.querySelectorAll(".react-datepicker__quarter-text--selected"),
+      );
+      expect(selectedElements.length).toBe(selectedDates.length);
+
+      const expectedQuarterLabels = selectedDates.map(
+        (date) => `Q${getQuarter(date)}`,
+      );
+      expect(
+        expectedQuarterLabels.every((label) =>
+          selectedElements.some((element) => element?.textContent === label),
+        ),
+      ).toBe(true);
+    });
   });
 
   describe("if quarter is not selected", () => {
@@ -2639,6 +2689,32 @@ describe("Month", () => {
           day={selectedDate}
           selected={selectedDate}
           preSelection={keyboardSelectedDate}
+          showQuarterYearPicker
+        />,
+      );
+
+      const selected = container.querySelector(
+        ".react-datepicker__quarter-text--selected",
+      );
+      const keyboardSelected = container.querySelector(
+        ".react-datepicker__quarter-text--keyboard-selected",
+      );
+
+      expect(selected).not.toBeNull();
+      expect(keyboardSelected).toBeNull();
+    });
+
+    it("should not apply the keyboard-selected class when the quarter is a part of selected dates", () => {
+      const selectedDates = [newDate("2025-11-01")];
+      const keyboardSelectedDate = selectedDates[0];
+      const day = selectedDates[0] as Date;
+
+      const { container } = render(
+        <Month
+          day={day}
+          selectedDates={selectedDates}
+          preSelection={keyboardSelectedDate}
+          selectsMultiple
           showQuarterYearPicker
         />,
       );


### PR DESCRIPTION
## Description
**Linked issues**: #5970, #5971

**Problem**
- For `showQuarterYearPicker`, the selected quarter receives both `react-datepicker__quarter-text--selected` and `react-datepicker__quarter-text--keyboard-selected`, causing the keyboard style to override the selected style and diverge from other pickers.  
- With `selectsMultiple`, not all selected quarters consistently show the `react-datepicker__quarter-text--selected` style.

**Changes**
- Skip adding `react-datepicker__quarter-text--keyboard-selected` when a quarter is already selected, matching behavior of other picker modes.
- Ensure multi-select logic applies `react-datepicker__quarter-text--selected` to every selected quarter, regardless of selection order.
- Harmonize quarter selected vs keyboard-selected class behavior to be consistent with month/year/day pickers.
- Add tests to cover both single-select and `selectsMultiple` quarter selection flows.

These fixes are based on the latest commits addressing [#5970](https://github.com/Hacker0x01/react-datepicker/issues/5970) and [#5971](https://github.com/Hacker0x01/react-datepicker/issues/5971).

https://github.com/user-attachments/assets/e8aa9245-cc82-4d6a-8909-e9f2d9676889
