### PR TITLE
fix calendar weekday name with custom styles

### DIFF
--- a/src/calendar.tsx
+++ b/src/calendar.tsx
@@ -481,6 +481,18 @@ export default class Calendar extends Component<CalendarProps, CalendarState> {
       this.props.calendarStartDay,
     );
 
+    const srOnlyStyles: React.CSSProperties = {
+      position: "absolute",
+      width: "1px",
+      height: "1px",
+      padding: 0,
+      margin: "-1px",
+      overflow: "hidden",
+      clipPath: "inset(50%)",
+      whiteSpace: "nowrap",
+      border: 0,
+    };
+
     const dayNames: React.ReactElement[] = [];
     if (this.props.showWeekNumbers) {
       dayNames.push(
@@ -489,7 +501,9 @@ export default class Calendar extends Component<CalendarProps, CalendarState> {
           className={`react-datepicker__day-name ${disabled ? "react-datepicker__day-name--disabled" : ""}`}
           role="columnheader"
         >
-          <span className="react-datepicker__sr-only">Week number</span>
+          <span className="react-datepicker__sr-only" style={srOnlyStyles}>
+            Week number
+          </span>
           <span aria-hidden="true">{this.props.weekLabel || "#"}</span>
         </div>,
       );
@@ -513,7 +527,7 @@ export default class Calendar extends Component<CalendarProps, CalendarState> {
               disabled ? "react-datepicker__day-name--disabled" : "",
             )}
           >
-            <span className="react-datepicker__sr-only">
+            <span className="react-datepicker__sr-only" style={srOnlyStyles}>
               {formatDate(day, "EEEE", this.props.locale)}
             </span>
             <span aria-hidden="true">{weekDayName}</span>


### PR DESCRIPTION
## Description
**Linked issue**: #(issue number) 

**Problem**
There is an issue with weekday name when using `datepicker` component without using datepicker styles 
i.e: `import "react-datepicker/dist/react-datepicker.css";`



**Changes**
The issue has been introduced in this [pr](https://github.com/qburst/react-datepicker-3/pull/56) that fixes this [issue](https://github.com/Hacker0x01/react-datepicker/issues/3797). 
But instead of using `sr-only` class on an extra `span` element which will be rendered if we don't import the stylesheet. 
I have reverted it back to use `aria-label` but kept the inner `span` with `aria-hidden="true"`; so the screen-readers will skip it and announce the `aria-label` prop.

## Screenshots
- Before: Notice the duplicate of weekday -> `SundaySu`
<img width="302" height="338" alt="Screenshot 2025-11-02 at 9 48 09 PM" src="https://github.com/user-attachments/assets/52647720-6c3b-42bf-9186-42d7f4acb5d7" />

- After
<img width="296" height="323" alt="Screenshot 2025-11-02 at 9 48 56 PM" src="https://github.com/user-attachments/assets/2ec81da9-1a4d-4a70-83bb-fc1b3aa96ada" />


## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
