### PR TITLE
fix: add explicit return type to TabLoop render method (#6075)

### DIFF
--- a/src/tab_loop.tsx
+++ b/src/tab_loop.tsx
@@ -85,7 +85,7 @@ export default class TabLoop extends Component<TabLoopProps> {
     tabChildren && tabChildren.length > 1 && tabChildren[0].focus();
   };
 
-  render() {
+  render(): React.ReactNode {
     if (!(this.props.enableTabLoop ?? TabLoop.defaultProps.enableTabLoop)) {
       return this.props.children;
     }


### PR DESCRIPTION
The render() method lacked an explicit return type, causing TypeScript to infer an overly broad type that included bigint in the generated .d.ts file. This caused transpilation errors in React 18 projects.

fixes https://github.com/Hacker0x01/react-datepicker/issues/6075