### PR TITLE
feat: Add renderCustomDayName prop for custom weekday header rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,7 @@ es
 tmp
 
 .vscode
+.history
 *.iml
 .idea
 

--- a/docs-site/src/components/Examples/config.tsx
+++ b/docs-site/src/components/Examples/config.tsx
@@ -17,6 +17,7 @@ import ConfigureFloatingUI from "../../examples/ts/configureFloatingUI?raw";
 import CustomInput from "../../examples/ts/customInput?raw";
 import RenderCustomHeader from "../../examples/ts/renderCustomHeader?raw";
 import RenderCustomHeaderTwoMonths from "../../examples/ts/renderCustomHeaderTwoMonths?raw";
+import RenderCustomDayName from "../../examples/ts/renderCustomDayName?raw";
 import RenderCustomDay from "../../examples/ts/renderCustomDay?raw";
 import RenderCustomMonth from "../../examples/ts/renderCustomMonth?raw";
 import RenderCustomQuarter from "../../examples/ts/renderCustomQuarter?raw";
@@ -183,6 +184,10 @@ export const EXAMPLE_CONFIG: IExampleConfig[] = [
   {
     title: "Custom header with two months displayed",
     component: RenderCustomHeaderTwoMonths,
+  },
+  {
+    title: "Custom Day Names",
+    component: RenderCustomDayName,
   },
   {
     title: "Custom Day",

--- a/docs-site/src/examples/ts/renderCustomDayName.tsx
+++ b/docs-site/src/examples/ts/renderCustomDayName.tsx
@@ -1,0 +1,48 @@
+const RenderCustomDayName = () => {
+  const [selectedDate, setSelectedDate] = useState<Date | null>(new Date());
+
+  const renderDayName = ({
+    day,
+    shortName,
+    fullName,
+    customDayNameCount,
+  }: ReactDatePickerCustomDayNameProps): React.ReactNode => {
+    // Example: Add emoji or custom styling to day names
+    const dayEmojis: { [key: string]: string } = {
+      Monday: "🌙",
+      Tuesday: "🔥",
+      Wednesday: "🌊",
+      Thursday: "⚡",
+      Friday: "🎉",
+      Saturday: "🌞",
+      Sunday: "☀️",
+    };
+
+    const emoji = dayEmojis[fullName] || "";
+
+    // Apply different styling based on customDayNameCount when showing multiple months
+    const style = customDayNameCount > 0 ? { color: "red" } : {};
+
+    return (
+      <>
+        <span className="react-datepicker__sr-only">{fullName}</span>
+        <span aria-hidden="true" title={fullName} style={style}>
+          {emoji}
+          <br />
+          {shortName}
+        </span>
+      </>
+    );
+  };
+
+  return (
+    <DatePicker
+      selected={selectedDate}
+      onChange={setSelectedDate}
+      renderCustomDayName={renderDayName}
+      monthsShown={2}
+    />
+  );
+};
+
+render(RenderCustomDayName);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -64,7 +64,10 @@ export { default as CalendarContainer } from "./calendar_container";
 
 export { registerLocale, setDefaultLocale, getDefaultLocale };
 
-export { ReactDatePickerCustomHeaderProps } from "./calendar";
+export {
+  ReactDatePickerCustomHeaderProps,
+  ReactDatePickerCustomDayNameProps,
+} from "./calendar";
 
 // Compares dates year+month combinations
 function hasPreSelectionChanged(

--- a/src/test/calendar_test.test.tsx
+++ b/src/test/calendar_test.test.tsx
@@ -2864,4 +2864,53 @@ describe("Calendar", () => {
       );
     });
   });
+
+  describe("handleMonthChange with adjustDateOnChange but without setOpen", () => {
+    it("should call onSelect when adjustDateOnChange is true but setOpen is not provided", () => {
+      const onSelect = jest.fn();
+      const setPreSelection = jest.fn();
+
+      const { instance } = getCalendar({
+        adjustDateOnChange: true,
+        onSelect,
+        setPreSelection,
+        // setOpen is intentionally NOT provided to cover line 442
+        selected: new Date("2024-01-15T00:00:00"),
+      });
+
+      const targetMonth = new Date("2024-02-01T00:00:00");
+      act(() => {
+        instance?.handleMonthChange(targetMonth);
+      });
+
+      expect(onSelect).toHaveBeenCalled();
+      expect(setPreSelection).toHaveBeenCalled();
+    });
+  });
+
+  describe("header method with invalid date", () => {
+    it("should return empty array when date is invalid", () => {
+      const { instance } = getCalendar({
+        selected: new Date("2024-01-15T00:00:00"),
+      });
+
+      // Call header method with invalid date
+      const result = instance?.header(new Date("invalid"));
+
+      expect(result).toEqual([]);
+    });
+
+    it("should use default date parameter when not provided", () => {
+      const { instance } = getCalendar({
+        selected: new Date("2024-01-15T00:00:00"),
+      });
+
+      // Call header method without arguments to cover default parameter
+      const result = instance?.header();
+
+      expect(result).toBeDefined();
+      expect(Array.isArray(result)).toBe(true);
+      expect(result?.length).toBeGreaterThan(0);
+    });
+  });
 });

--- a/src/test/render_custom_day_name.test.tsx
+++ b/src/test/render_custom_day_name.test.tsx
@@ -1,0 +1,161 @@
+import { render } from "@testing-library/react";
+import React from "react";
+
+import DatePicker from "../index";
+import { ReactDatePickerCustomDayNameProps } from "../calendar";
+
+describe("renderCustomDayName", () => {
+  it("should call renderCustomDayName function with correct parameters", () => {
+    const renderCustomDayName = jest.fn(
+      ({ shortName }: ReactDatePickerCustomDayNameProps) => (
+        <span>{shortName}</span>
+      ),
+    );
+
+    render(<DatePicker renderCustomDayName={renderCustomDayName} inline />);
+
+    // Should be called 7 times (one for each day of the week)
+    expect(renderCustomDayName).toHaveBeenCalledTimes(7);
+
+    // Check that it's called with correct parameters
+    const firstCall = renderCustomDayName.mock.calls[0]?.[0];
+    expect(firstCall).toBeDefined();
+    expect(firstCall).toHaveProperty("day");
+    expect(firstCall).toHaveProperty("shortName");
+    expect(firstCall).toHaveProperty("fullName");
+    expect(firstCall).toHaveProperty("locale");
+    expect(firstCall).toHaveProperty("customDayNameCount");
+    expect(firstCall?.day).toBeInstanceOf(Date);
+    expect(typeof firstCall?.shortName).toBe("string");
+    expect(typeof firstCall?.fullName).toBe("string");
+    expect(typeof firstCall?.customDayNameCount).toBe("number");
+  });
+
+  it("should render custom day names", () => {
+    const renderCustomDayName = ({
+      shortName,
+    }: ReactDatePickerCustomDayNameProps) => (
+      <span className="custom-day-name">Custom-{shortName}</span>
+    );
+
+    const { container } = render(
+      <DatePicker renderCustomDayName={renderCustomDayName} inline />,
+    );
+
+    const customDayNames = container.querySelectorAll(".custom-day-name");
+    expect(customDayNames).toHaveLength(7);
+    expect(customDayNames[0]?.textContent).toContain("Custom-");
+  });
+
+  it("should render default day names when renderCustomDayName is not provided", () => {
+    const { container } = render(<DatePicker inline />);
+
+    const dayNames = container.querySelectorAll(".react-datepicker__day-name");
+    expect(dayNames).toHaveLength(7);
+
+    // Check that default structure is present (sr-only + aria-hidden)
+    const firstDayName = dayNames[0];
+    expect(
+      firstDayName?.querySelector(".react-datepicker__sr-only"),
+    ).not.toBeNull();
+    expect(firstDayName?.querySelector('[aria-hidden="true"]')).not.toBeNull();
+  });
+
+  it("should use custom day names with accessibility", () => {
+    const renderCustomDayName = ({
+      shortName,
+      fullName,
+    }: ReactDatePickerCustomDayNameProps) => (
+      <>
+        <span className="react-datepicker__sr-only">{fullName}</span>
+        <span aria-hidden="true">{shortName}</span>
+      </>
+    );
+
+    const { container } = render(
+      <DatePicker renderCustomDayName={renderCustomDayName} inline />,
+    );
+
+    const dayNames = container.querySelectorAll(".react-datepicker__day-name");
+    expect(dayNames).toHaveLength(7);
+
+    // Check that accessibility structure is maintained
+    dayNames.forEach((dayName) => {
+      expect(
+        dayName.querySelector(".react-datepicker__sr-only"),
+      ).not.toBeNull();
+      expect(dayName.querySelector('[aria-hidden="true"]')).not.toBeNull();
+    });
+  });
+
+  it("should apply weekDayClassName along with custom day names", () => {
+    const weekDayClassName = (date: Date) => {
+      return date.getDay() === 0 || date.getDay() === 6 ? "weekend" : "";
+    };
+
+    const renderCustomDayName = ({
+      shortName,
+    }: ReactDatePickerCustomDayNameProps) => <span>{shortName}</span>;
+
+    const { container } = render(
+      <DatePicker
+        renderCustomDayName={renderCustomDayName}
+        weekDayClassName={weekDayClassName}
+        inline
+      />,
+    );
+
+    const weekendDays = container.querySelectorAll(
+      ".react-datepicker__day-name.weekend",
+    );
+    // Should have 2 weekend days (Saturday and Sunday)
+    expect(weekendDays.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("should pass locale to renderCustomDayName", () => {
+    const renderCustomDayName = jest.fn(
+      ({ shortName }: ReactDatePickerCustomDayNameProps) => (
+        <span>{shortName}</span>
+      ),
+    );
+
+    render(
+      <DatePicker
+        renderCustomDayName={renderCustomDayName}
+        locale="en-US"
+        inline
+      />,
+    );
+
+    const firstCall = renderCustomDayName.mock.calls[0]?.[0];
+    expect(firstCall?.locale).toBe("en-US");
+  });
+
+  it("should pass customDayNameCount when displaying multiple months", () => {
+    const renderCustomDayName = jest.fn(
+      ({ shortName }: ReactDatePickerCustomDayNameProps) => (
+        <span>{shortName}</span>
+      ),
+    );
+
+    render(
+      <DatePicker
+        renderCustomDayName={renderCustomDayName}
+        monthsShown={3}
+        inline
+      />,
+    );
+
+    // Should be called 7 times per month, so 21 times for 3 months
+    expect(renderCustomDayName).toHaveBeenCalledTimes(21);
+
+    // Check that customDayNameCount is different for each month
+    const firstMonthCall = renderCustomDayName.mock.calls[0]?.[0];
+    const secondMonthCall = renderCustomDayName.mock.calls[7]?.[0];
+    const thirdMonthCall = renderCustomDayName.mock.calls[14]?.[0];
+
+    expect(firstMonthCall?.customDayNameCount).toBe(0);
+    expect(secondMonthCall?.customDayNameCount).toBe(1);
+    expect(thirdMonthCall?.customDayNameCount).toBe(2);
+  });
+});


### PR DESCRIPTION
## Description
Adds `renderCustomDayName` prop to DatePicker component, enabling custom rendering of weekday names in the calendar header (similar to existing `renderCustomHeader` functionality).

## Motivation
Provides developers with flexibility to customize day name display, such as adding emojis, icons, or custom styling based on the displayed month position when showing multiple months.

## Changes
- Added `ReactDatePickerCustomDayNameProps` interface
- Added `renderCustomDayName` prop to Calendar component
- Added `customDayNameCount` parameter (similar to `customHeaderCount`)
- Added 7 comprehensive test cases
- Added example in docs-site
- Exported new interface in public API

## Example Usage
```tsx
<DatePicker
  monthsShown={2}
  renderCustomDayName={({ shortName, fullName, customDayNameCount }) => (
    <span style={{ fontWeight: customDayNameCount === 0 ? 'bold' : 'normal' }}>
      {shortName}
    </span>
  )}
/>