### PR TITLE
fix: improve DatePickerProps discriminated union type inference

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -218,8 +218,8 @@ export type DatePickerProps = OmitUnion<
     ) => void;
   } & (
     | {
-        selectsRange?: never;
-        selectsMultiple?: never;
+        selectsRange?: false | undefined;
+        selectsMultiple?: false | undefined;
         formatMultipleDates?: never;
         onChange?: (
           date: Date | null,
@@ -230,7 +230,7 @@ export type DatePickerProps = OmitUnion<
       }
     | {
         selectsRange: true;
-        selectsMultiple?: never;
+        selectsMultiple?: false | undefined;
         formatMultipleDates?: never;
         onChange?: (
           date: [Date | null, Date | null],
@@ -240,7 +240,7 @@ export type DatePickerProps = OmitUnion<
         ) => void;
       }
     | {
-        selectsRange?: never;
+        selectsRange?: false | undefined;
         selectsMultiple: true;
         formatMultipleDates?: (
           dates: Date[],

--- a/src/test/multiple_selected_dates.test.tsx
+++ b/src/test/multiple_selected_dates.test.tsx
@@ -14,10 +14,7 @@ describe("Multiple Dates Selected", function () {
     extraProps: Partial<
       Pick<
         DatePickerProps,
-        | "selectsMultiple"
-        | "shouldCloseOnSelect"
-        | "disabledKeyboardNavigation"
-        | "onSelect"
+        "shouldCloseOnSelect" | "disabledKeyboardNavigation" | "onSelect"
       >
     > &
       OmitUnion<
@@ -28,7 +25,9 @@ describe("Multiple Dates Selected", function () {
         | "disabledKeyboardNavigation"
         | "onSelect"
         | "selectsRange"
-      >,
+      > & {
+        selectsMultiple?: true;
+      },
   ) {
     return render(
       <DatePicker


### PR DESCRIPTION
This fix addresses issues #5391 and #5198 where TypeScript was not properly inferring types based on selectsRange and selectsMultiple props.

The problem was that using 'never' as the discriminant type for optional properties didn't allow TypeScript to properly narrow the union type.

Changes:
- Changed selectsRange?: never to selectsRange?: false | undefined
- Changed selectsMultiple?: never to selectsMultiple?: false | undefined
- Updated test file to use correct type for selectsMultiple prop

This allows TypeScript to correctly infer:
- onChange receives Date | null when selectsRange is false/undefined
- onChange receives [Date | null, Date | null] when selectsRange is true
- onChange receives Date[] | null when selectsMultiple is true

Fixes #5391
Fixes #5198