### PR TITLE
fix: parse holiday date strings as local time to prevent timezone shift

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -410,10 +410,12 @@ export class DatePicker extends Component<DatePickerProps, DatePickerState> {
           : newDate();
 
   // Convert the date from string format to standard Date format
+  // Uses parseDate with ISO format to parse as local time, preventing
+  // dates from shifting in timezones west of UTC. See issue #6105.
   modifyHolidays = () =>
     this.props.holidays?.reduce<HolidayItem[]>((accumulator, holiday) => {
-      const date = new Date(holiday.date);
-      if (!isValid(date)) {
+      const date = parseDate(holiday.date, "yyyy-MM-dd", undefined, false);
+      if (!date) {
         return accumulator;
       }
 

--- a/src/test/datepicker_test.test.tsx
+++ b/src/test/datepicker_test.test.tsx
@@ -5461,6 +5461,40 @@ describe("DatePicker", () => {
       expect(container.querySelector(".react-datepicker")).not.toBeNull();
     });
 
+    it("should apply holiday class to correct date regardless of timezone (issue #6105)", () => {
+      // This test verifies that holidays specified as ISO date strings (YYYY-MM-DD)
+      // are displayed on the correct date. The bug was that new Date("YYYY-MM-DD")
+      // parses as UTC midnight, causing dates to shift in western timezones.
+      const holidays = [{ date: "2024-01-15", holidayName: "Test Holiday" }];
+
+      const { container } = render(
+        <DatePicker
+          selected={new Date(2024, 0, 15)} // January 15, 2024 in local time
+          onChange={() => {}}
+          holidays={holidays}
+          inline
+        />,
+      );
+
+      // Find the day element for January 15th and verify it has the holiday class
+      const jan15 = container.querySelector(
+        ".react-datepicker__day--015:not(.react-datepicker__day--outside-month)",
+      );
+      expect(jan15).not.toBeNull();
+      expect(jan15?.classList.contains("react-datepicker__day--holidays")).toBe(
+        true,
+      );
+
+      // Verify January 14th does NOT have the holiday class (the bug would show it here)
+      const jan14 = container.querySelector(
+        ".react-datepicker__day--014:not(.react-datepicker__day--outside-month)",
+      );
+      expect(jan14).not.toBeNull();
+      expect(jan14?.classList.contains("react-datepicker__day--holidays")).toBe(
+        false,
+      );
+    });
+
     it("should handle deferFocusInput and cancelFocusInput", () => {
       jest.useFakeTimers();
 


### PR DESCRIPTION
## Summary

Fixes #6105

This PR fixes a bug where holidays specified as ISO date strings (e.g., `"2025-01-01"`) would display on the wrong day in timezones west of UTC.

### The Problem

When holiday dates are provided as ISO date strings (`YYYY-MM-DD`), the previous implementation used `new Date(string)` to parse them. Per JavaScript specification, ISO date strings without a time component are parsed as **UTC midnight**.

Later, when the date is formatted using `date-fns`'s `format()` function, it converts the date to the **local timezone**. This causes the date to shift backward by one day for users in timezones west of UTC.

**Example of the bug:**
- Input: `"2025-01-01"` 
- Parsed as: `2025-01-01T00:00:00.000Z` (UTC midnight)
- In PST (UTC-8): `2024-12-31T16:00:00.000-08:00` 
- Result: Holiday displays on **December 31st** instead of January 1st

### The Fix

The fix uses the existing `parseDate` utility function with the `"yyyy-MM-dd"` format. This leverages `date-fns`'s `parse` function which treats the date string as **local time** rather than UTC, ensuring holidays display on the intended date regardless of timezone.

**Before:**
```typescript
const date = new Date(holiday.date);
```

**After:**
```typescript
const date = parseDate(holiday.date, "yyyy-MM-dd", undefined, false);
```