### PR TITLE
fix: allow manually typing dates before 1800 when minDate permits

### DIFF
--- a/src/date_utils.ts
+++ b/src/date_utils.ts
@@ -155,17 +155,12 @@ export function parseDate(
 export { isDate, set };
 
 /**
- * Checks if a given date is valid and not before the minimum date.
+ * Checks if a given date is a valid Date object.
  * @param date - The date to be checked.
- * @param minDate - The minimum date allowed. If not provided, defaults to "1/1/1800".
- * @returns A boolean value indicating whether the date is valid and not before the minimum date.
+ * @returns A boolean value indicating whether the date is valid.
  */
-export function isValid(date: Date, minDate?: Date): boolean {
-  /* the fallback date is essential to not break test case
-   * `should auto update calendar when the updated date text is after props.minDate`
-   * and backward compatibility respectfully
-   */
-  return isValidDate(date) && !isBefore(date, minDate ?? new Date("1/1/1800"));
+export function isValid(date: Date): boolean {
+  return isValidDate(date);
 }
 
 // ** Date Formatting **

--- a/src/test/date_utils_test.test.ts
+++ b/src/test/date_utils_test.test.ts
@@ -621,13 +621,15 @@ describe("date_utils", () => {
   });
 
   describe("isValid", () => {
-    it("should return true if date is valid and equal or after minDate", () => {
-      expect(isValid(newDate("2021-11-15"), newDate("2021-11-15"))).toBe(true);
-      expect(isValid(newDate("2021-11-30"), newDate("2021-11-15"))).toBe(true);
+    it("should return true for valid dates", () => {
+      expect(isValid(newDate("2021-11-15"))).toBe(true);
+      expect(isValid(newDate("1350-03-20"))).toBe(true);
+      expect(isValid(newDate("1000-01-01"))).toBe(true);
     });
 
-    it("should return false if date is valid and before minDate", () => {
-      expect(isValid(newDate("2021-11-01"), newDate("2021-11-15"))).toBe(false);
+    it("should return false for invalid dates", () => {
+      expect(isValid(new Date("invalid"))).toBe(false);
+      expect(isValid(new Date(NaN))).toBe(false);
     });
   });
 

--- a/src/test/datepicker_test.test.tsx
+++ b/src/test/datepicker_test.test.tsx
@@ -1998,6 +1998,56 @@ describe("DatePicker", () => {
     });
   });
 
+  describe("when minDate is before 1800", () => {
+    it("should allow manually typing dates before 1800 when minDate allows it", () => {
+      const onChange = jest.fn();
+      const { container } = render(
+        <DatePicker
+          selected={new Date("1500-06-15")}
+          minDate={new Date("1000-01-01")}
+          dateFormat="yyyy-MM-dd"
+          onChange={onChange}
+          open
+        />,
+      );
+
+      const input = safeQuerySelector<HTMLInputElement>(container, "input");
+      fireEvent.change(input, {
+        target: {
+          value: "1350-03-20",
+        },
+      });
+
+      expect(onChange).toHaveBeenCalled();
+      const calledWith = onChange.mock.calls[0][0];
+      expect(calledWith.getFullYear()).toBe(1350);
+      expect(calledWith.getMonth()).toBe(2); // March is 0-indexed as 2
+      expect(calledWith.getDate()).toBe(20);
+    });
+
+    it("should update calendar view when typing a date before 1800 with appropriate minDate", () => {
+      const { container } = render(
+        <DatePicker
+          selected={new Date("1500-06-15")}
+          minDate={new Date("1000-01-01")}
+          dateFormat="yyyy-MM-dd"
+          open
+        />,
+      );
+
+      const input = safeQuerySelector<HTMLInputElement>(container, "input");
+      fireEvent.change(input, {
+        target: {
+          value: "1350-03-20",
+        },
+      });
+
+      expect(
+        container.querySelector(".react-datepicker__current-month")?.innerHTML,
+      ).toBe("March 1350");
+    });
+  });
+
   it("should not manual select date if before minDate", () => {
     const minDate = subDays(newDate(), 1);
     const data = getOnInputKeyDownStuff({


### PR DESCRIPTION
Remove hardcoded 1800 minimum date from isValid() function. The isValid function now only checks if a Date object is valid (not NaN), leaving minDate validation to isDayDisabled() which properly respects the user's minDate prop.

Fixes #5718