### PR TITLE
Fix the broken doc-site example - Custom input with popper positioning

### DIFF
--- a/docs-site/src/components/Example/index.tsx
+++ b/docs-site/src/components/Example/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useMemo, useState } from "react";
+import React, { forwardRef, useMemo, useRef, useState } from "react";
 import { LiveProvider, LiveEditor, LiveError, LivePreview } from "react-live";
 import DatePicker, {
   registerLocale,
@@ -164,6 +164,7 @@ export default class CodeExampleComponent extends React.Component<
                 // NB any globals added here should also be referenced in ../../examples/.eslintrc
                 useState,
                 useMemo,
+                useRef,
                 DatePicker,
                 CalendarContainer,
                 DateFNS,

--- a/docs-site/src/examples/live-provider-globals.d.ts
+++ b/docs-site/src/examples/live-provider-globals.d.ts
@@ -5,6 +5,7 @@ import type { MiddlewareState as MiddlewareStateType } from "@floating-ui/react"
 declare global {
   const useMemo: typeof React.useMemo;
   const useState: typeof React.useState;
+  const useRef: typeof React.useRef;
   const DatePicker: any;
   const CalendarContainer: any;
   const range: any;


### PR DESCRIPTION
## Description
This PR introduces the `useRef` hook to the global context of the `LiveProvider`, allowing for better management of references within the example components. The change fix the example - **Custom input with popper positioning**.


**Problem**
The doc-site example **Custom input with popper positioning** uses `useRef` hook, but the hook was not imported.

**Changes**
- Added  `useRef` hook to the global context of the `LiveProvider`

## Screenshots
**Issue**
<img width="935" height="799" alt="image" src="https://github.com/user-attachments/assets/88881586-9932-4139-a299-8af730905d3f" />

**After the fix**
<img width="881" height="738" alt="image" src="https://github.com/user-attachments/assets/6107cc23-f59c-4b8d-a807-776731f76a11" />

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
