### PR TITLE
chore: upgrade to Node 24.x LTS and fix deprecated set-output

### DIFF
--- a/.github/workflows/build-docs-site.yml
+++ b/.github/workflows/build-docs-site.yml
@@ -12,21 +12,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Set Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: 24.x
 
       - name: Corepack enable
         run: corepack enable
 
       - name: Yarn setup
-        run: corepack prepare --activate 
+        run: corepack prepare --activate
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v4
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,21 +9,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Set Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: 24.x
 
       - name: Corepack enable
         run: corepack enable
 
       - name: Yarn setup
-        run: corepack prepare --activate 
+        run: corepack prepare --activate
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
       - name: Install dependencies
         run: yarn install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,28 +13,28 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.x]
+        node-version: [24.x]
 
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Setup kernel for react, increase watchers
         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
 
       - name: Set Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: 24.x
 
       - name: Corepack enable
         run: corepack enable
 
       - name: Yarn setup
-        run: corepack prepare --activate 
+        run: corepack prepare --activate
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v4
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)


### PR DESCRIPTION
- Update all GitHub Actions workflows to use Node 24.x
- Replace deprecated ::set-output with GITHUB_OUTPUT environment file
- Clean up trailing whitespace in workflow files
