### PR TITLE
fix: prevent webpack warning for optional date-fns-tz dependency

### DIFF
--- a/src/date_utils.ts
+++ b/src/date_utils.ts
@@ -112,8 +112,12 @@ function getDateFnsTz(): DateFnsTz | null {
 
   try {
     // Dynamic require for date-fns-tz
+    // Use a variable to prevent webpack from statically analyzing the require
+    // and showing warnings when the optional dependency is not installed
+    // See: https://github.com/Hacker0x01/react-datepicker/issues/6154
+    const dateFnsTzModuleName = "date-fns-tz";
     // eslint-disable-next-line @typescript-eslint/no-require-imports
-    dateFnsTz = require("date-fns-tz") as DateFnsTz;
+    dateFnsTz = require(dateFnsTzModuleName) as DateFnsTz;
   } catch {
     /* istanbul ignore next - only executes when date-fns-tz is not installed */
     dateFnsTz = null;


### PR DESCRIPTION
## Summary
- Use a variable for the module name in the dynamic require to prevent webpack from statically analyzing it
- This eliminates the "Module not found: Error: Can't resolve 'date-fns-tz'" warning when the optional peer dependency is not installed

## Root Cause
The `require("date-fns-tz")` statement used a string literal, which webpack's static analysis detected and flagged as a missing module—even though it was wrapped in a try-catch and `date-fns-tz` is listed as optional in `peerDependenciesMeta`.

## Fix
Changed from:
```typescript
dateFnsTz = require("date-fns-tz") as DateFnsTz;
```

To:
```typescript
const dateFnsTzModuleName = "date-fns-tz";
dateFnsTz = require(dateFnsTzModuleName) as DateFnsTz;
```

This prevents webpack from statically analyzing the require and showing warnings.

Fixes #6154

## Test plan
- [x] All existing tests pass (1445 tests)
- [x] Verified the built output uses the variable pattern
- [x] Linter passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)