### PR TITLE
test: add tests for openToDate with showTimeSelectOnly

### DIFF
--- a/src/test/show_time_test.test.tsx
+++ b/src/test/show_time_test.test.tsx
@@ -185,4 +185,109 @@ describe("DatePicker", () => {
       expect(onChange).toHaveBeenCalledWith(expectedDate);
     });
   });
+
+  describe("Time Select Only with openToDate", () => {
+    it("should use openToDate as the base date when selecting time with showTimeSelectOnly and selected is null", () => {
+      const onChange = jest.fn();
+      const openToDate = new Date("2025-11-01T00:00:00");
+
+      const { container } = render(
+        <DatePicker
+          selected={null}
+          openToDate={openToDate}
+          onChange={onChange}
+          showTimeSelect
+          showTimeSelectOnly
+        />,
+      );
+
+      const input = safeQuerySelector(container, "input");
+      fireEvent.click(input);
+
+      // Find and click a time option (e.g., 09:00)
+      const timeListItems = container.querySelectorAll(
+        ".react-datepicker__time-list-item",
+      );
+      expect(timeListItems.length).toBeGreaterThan(0);
+
+      // Click on a time option
+      fireEvent.click(timeListItems[0]!);
+
+      expect(onChange).toHaveBeenCalled();
+      const selectedDate = onChange.mock.calls[0][0] as Date;
+
+      // Verify the date part comes from openToDate
+      expect(selectedDate.getFullYear()).toBe(2025);
+      expect(selectedDate.getMonth()).toBe(10); // November is month 10 (0-indexed)
+      expect(selectedDate.getDate()).toBe(1);
+    });
+
+    it("should use current date when showTimeSelectOnly is true and neither selected nor openToDate is provided", () => {
+      const onChange = jest.fn();
+      const today = new Date();
+
+      const { container } = render(
+        <DatePicker
+          selected={null}
+          onChange={onChange}
+          showTimeSelect
+          showTimeSelectOnly
+        />,
+      );
+
+      const input = safeQuerySelector(container, "input");
+      fireEvent.click(input);
+
+      const timeListItems = container.querySelectorAll(
+        ".react-datepicker__time-list-item",
+      );
+      expect(timeListItems.length).toBeGreaterThan(0);
+
+      fireEvent.click(timeListItems[0]!);
+
+      expect(onChange).toHaveBeenCalled();
+      const selectedDate = onChange.mock.calls[0][0] as Date;
+
+      // Verify the date part comes from today
+      expect(selectedDate.getFullYear()).toBe(today.getFullYear());
+      expect(selectedDate.getMonth()).toBe(today.getMonth());
+      expect(selectedDate.getDate()).toBe(today.getDate());
+    });
+
+    it("should use openToDate for showTimeInput when selected is null", () => {
+      const onChange = jest.fn();
+      const openToDate = new Date("2025-11-01T00:00:00");
+
+      const { container } = render(
+        <DatePicker
+          selected={null}
+          openToDate={openToDate}
+          onChange={onChange}
+          showTimeInput
+        />,
+      );
+
+      const input = safeQuerySelector(container, "input");
+      fireEvent.focus(input);
+
+      const timeInput = safeQuerySelector<HTMLInputElement>(
+        container,
+        'input[type="time"].react-datepicker-time__input',
+      );
+
+      fireEvent.change(timeInput, {
+        target: { value: "14:30" },
+      });
+
+      expect(onChange).toHaveBeenCalled();
+      const selectedDate = onChange.mock.calls[0][0] as Date;
+
+      // Verify the date part comes from openToDate
+      expect(selectedDate.getFullYear()).toBe(2025);
+      expect(selectedDate.getMonth()).toBe(10); // November
+      expect(selectedDate.getDate()).toBe(1);
+      expect(selectedDate.getHours()).toBe(14);
+      expect(selectedDate.getMinutes()).toBe(30);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
This PR adds tests to document the existing behavior that `openToDate` can be used to specify the default date when `showTimeSelectOnly` is true and `selected` is null.

## Background
Issue #6032 requested a way to specify a default date when using `showTimeSelectOnly` with a null selected value. The user wanted to set a specific date (e.g., 2025-11-01) that would be used when a time is selected, instead of defaulting to the current date.

**Good news: This feature already exists!** The `openToDate` prop can be used for exactly this purpose.

## Example Usage
```tsx
<DatePicker
  selected={null}
  openToDate={new Date("2025-11-01")}
  onChange={(date) => console.log(date)}
  showTimeSelect
  showTimeSelectOnly
/>
```

When the user selects a time (e.g., 09:06), the resulting date will be `2025-11-01 09:06:00` instead of `{today} 09:06:00`.

## Tests Added
- `should use openToDate as the base date when selecting time with showTimeSelectOnly and selected is null`
- `should use current date when showTimeSelectOnly is true and neither selected nor openToDate is provided`
- `should use openToDate for showTimeInput when selected is null`

Closes #6032

🤖 Generated with [Claude Code](https://claude.com/claude-code)