### PR TITLE
fix: remove empty :global selector that breaks Lightning CSS

### DIFF
--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -2,8 +2,8 @@
 @use "variables" as *;
 @use "mixins" as *;
 
-/* sr-only utility class for accessibility */
 .react-datepicker__sr-only {
+  // sr-only utility class for accessibility
   position: absolute;
   width: 1px;
   height: 1px;


### PR DESCRIPTION
## Summary
- Moved the sr-only comment from above the `.react-datepicker__sr-only` selector to inside it
- This prevents Sass from generating an empty `:global {}` block in the CSS modules output when compiling `datepicker-cssmodules.scss`
- Fixes build failures when using Rolldown Vite with Lightning CSS minification, which throws "SyntaxError: Invalid empty selector"

## Root Cause
When the `/* sr-only utility class for accessibility */` comment was placed as a standalone comment before the `.react-datepicker__sr-only` class, Sass would wrap it in its own `:global {}` block in the CSS modules output:

```css
:global {
  /* sr-only utility class for accessibility */
}
```

Since a comment doesn't count as actual CSS content, this resulted in an empty selector block that Lightning CSS rejects.

## Test plan
- [x] Verified `yarn build` completes successfully
- [x] Verified no empty `:global {}` blocks in generated CSS modules files
- [x] All 1448 tests pass

Fixes #5989

🤖 Generated with [Claude Code](https://claude.com/claude-code)