### PR TITLE
fix: remove extra wrapper div when using withPortal

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1980,10 +1980,10 @@ export class DatePicker extends Component<DatePickerProps, DatePickerState> {
       }
 
       return (
-        <div>
+        <>
           {this.renderInputContainer()}
           {portalContainer}
-        </div>
+        </>
       );
     }
 

--- a/src/test/datepicker_test.test.tsx
+++ b/src/test/datepicker_test.test.tsx
@@ -1300,6 +1300,20 @@ describe("DatePicker", () => {
     expect(container.querySelector(".react-datepicker")).toBeNull();
   });
 
+  it("should not render an extra wrapper div when withPortal is set", () => {
+    // Fixes #5499 - withPortal should use React Fragment instead of a wrapper div
+    const { container } = render(<DatePicker withPortal />);
+
+    // The container should directly contain the input container, not wrapped in an extra div
+    // Before the fix: <div><div class="react-datepicker__input-container">...</div></div>
+    // After the fix: <div class="react-datepicker__input-container">...</div> (no extra wrapper)
+    const inputContainer = container.querySelector(
+      ".react-datepicker__input-container",
+    );
+    expect(inputContainer).not.toBeNull();
+    expect(inputContainer?.parentElement).toBe(container);
+  });
+
   it("should render Calendar in a ReactDOM portal when withPortal is set and portalId is set", () => {
     const { container } = render(
       <DatePicker withPortal portalId="portal-id-dom-test" />,


### PR DESCRIPTION
## Summary
- Replaced the wrapper `<div>` with a React Fragment (`<>...</>`) when rendering with the `withPortal` prop
- This prevents an unnecessary DOM element that interferes with CSS styling and layout

## Background
The wrapper div was originally added before React Fragment syntax was available (~9 years ago). Modern React allows grouping elements without extra DOM nodes using Fragments.

## Before
```html
<div>
  <div class="react-datepicker__input-container">...</div>
  <!-- portal container when open -->
</div>
```

## After
```html
<div class="react-datepicker__input-container">...</div>
<!-- portal container when open -->
```

## Breaking Change
⚠️ The DOM structure when using `withPortal` no longer includes an extra wrapper `<div>` around the input container. Users with CSS selectors or JavaScript that depend on this wrapper will need to update their code.

However, since the wrapper `<div>` had no class, ID, or identifying attributes and was never documented, the impact should be minimal.

## Test Plan
- [x] Added test to verify no extra wrapper div exists with `withPortal`
- [x] All 1449 tests pass
- [x] Linting passes

Fixes #5499

🤖 Generated with [Claude Code](https://claude.com/claude-code)