### PR TITLE
fix: prevent Safari auto-translate from breaking calendar

### DIFF
--- a/src/calendar_container.tsx
+++ b/src/calendar_container.tsx
@@ -25,6 +25,7 @@ const CalendarContainer: React.FC<CalendarContainerProps> = function ({
       aria-label={ariaLabel}
       role={inline ? undefined : "dialog"}
       aria-modal={inline ? undefined : "true"}
+      translate="no"
     >
       {children}
     </div>

--- a/src/test/calendar_container.test.tsx
+++ b/src/test/calendar_container.test.tsx
@@ -98,4 +98,16 @@ describe("CalendarContainer", () => {
     expect(dialog?.getAttribute("aria-modal")).toBe("true");
     expect(dialog?.getAttribute("aria-label")).toBe("Choose Date");
   });
+
+  it("has translate='no' to prevent browser auto-translation breaking the calendar", () => {
+    // Fixes #5824 - Safari auto-translate breaks calendar navigation
+    const { container } = render(
+      <CalendarContainer>
+        <div>Content</div>
+      </CalendarContainer>,
+    );
+
+    const dialog = container.querySelector('[role="dialog"]');
+    expect(dialog?.getAttribute("translate")).toBe("no");
+  });
 });


### PR DESCRIPTION
## Summary
- Added `translate="no"` attribute to the CalendarContainer root element
- Prevents browser auto-translation features from interfering with the calendar

## Problem
When Safari's auto-translate feature is enabled, it attempts to translate the calendar's date/month names. This breaks React's virtual DOM reconciliation and causes:
- "NotFoundError: The object can not be found here" console errors
- Blank page when navigating between months
- Layout issues with overlapping text and broken grid

## Solution
The `translate="no"` attribute is a [standard HTML attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/translate) that tells browsers not to translate the content within the element. This allows the library's own localization (via date-fns locales) to work correctly while preventing browser translation interference.

## Test Plan
- [x] Added test to verify `translate="no"` attribute is present
- [x] All 1449 tests pass
- [x] Linting passes

## Browser Support
The `translate` attribute is supported in all modern browsers including Safari, Chrome, Firefox, and Edge.

Fixes #5824

🤖 Generated with [Claude Code](https://claude.com/claude-code)