### PR TITLE
test: add formatWeekDay prop test for DatePicker component

### DIFF
--- a/src/test/datepicker_test.test.tsx
+++ b/src/test/datepicker_test.test.tsx
@@ -4491,6 +4491,21 @@ describe("DatePicker", () => {
     expect(firstDay?.textContent).toBe("Su");
   });
 
+  it("should correctly format weekday using formatWeekDay prop", () => {
+    const { container } = render(
+      <DatePicker formatWeekDay={(day) => day.charAt(0)} />,
+    );
+    const input = safeQuerySelector(container, "input");
+    fireEvent.focus(input);
+
+    const dayNames = container.querySelectorAll(
+      ".react-datepicker__day-names > div[role='columnheader'] > span[aria-hidden='true']",
+    );
+    dayNames.forEach((dayName) => {
+      expect(dayName.textContent).toHaveLength(1);
+    });
+  });
+
   describe("when update the datepicker input text while props.showTimeSelectOnly is set and dateFormat has only time related format", () => {
     const format = "h:mm aa";
 


### PR DESCRIPTION
## Summary
- Adds test coverage for the `formatWeekDay` prop when used through the `DatePicker` component
- The existing test only covered the `Calendar` component directly
- This ensures the prop is properly passed through from `DatePicker` to `Calendar`

## Test plan
- [x] Run `yarn test:ci` - all 1471 tests pass
- [x] Run `yarn lint` - passes
- [x] Run `yarn type-check` - passes

## Related
- Investigated in response to issue #6173
- The issue appears to be environment-specific (Tauri), but this test improves coverage regardless

🤖 Generated with [Claude Code](https://claude.com/claude-code)