### PR TITLE
fix: add inline styles to sr-only spans for CSS-independent accessibility

### DIFF
--- a/src/calendar.tsx
+++ b/src/calendar.tsx
@@ -509,6 +509,19 @@ export default class Calendar extends Component<CalendarProps, CalendarState> {
       this.props.calendarStartDay,
     );
 
+    // Inline sr-only styles ensure weekday names work without CSS import
+    const srOnlyStyles: React.CSSProperties = {
+      position: "absolute",
+      width: "1px",
+      height: "1px",
+      padding: 0,
+      margin: "-1px",
+      overflow: "hidden",
+      clipPath: "inset(50%)",
+      whiteSpace: "nowrap",
+      border: 0,
+    };
+
     const dayNames: React.ReactElement[] = [];
     if (this.props.showWeekNumbers) {
       dayNames.push(
@@ -517,7 +530,9 @@ export default class Calendar extends Component<CalendarProps, CalendarState> {
           className={`react-datepicker__day-name ${disabled ? "react-datepicker__day-name--disabled" : ""}`}
           role="columnheader"
         >
-          <span className="react-datepicker__sr-only">Week number</span>
+          <span className="react-datepicker__sr-only" style={srOnlyStyles}>
+            Week number
+          </span>
           <span aria-hidden="true">{this.props.weekLabel || "#"}</span>
         </div>,
       );
@@ -568,7 +583,9 @@ export default class Calendar extends Component<CalendarProps, CalendarState> {
               disabled ? "react-datepicker__day-name--disabled" : "",
             )}
           >
-            <span className="react-datepicker__sr-only">{fullDayName}</span>
+            <span className="react-datepicker__sr-only" style={srOnlyStyles}>
+              {fullDayName}
+            </span>
             <span aria-hidden="true">{weekDayName}</span>
           </div>
         );


### PR DESCRIPTION
## Summary
- Adds inline styles to sr-only spans in the calendar header so they work without requiring the datepicker stylesheet
- Fixes an issue where weekday names show full names (e.g., "Thursday") instead of abbreviated names when CSS isn't properly applied

## Problem
In v9.0.0, sr-only spans were added for accessibility (commit 81e9c6f0). These spans contain full weekday names for screen readers, while the visible abbreviated names are in a separate `aria-hidden` span.

When CSS isn't loaded or applied correctly (which can happen in certain environments like Tauri), the sr-only class doesn't hide the full weekday name, causing visual issues.

## Solution
Add inline styles directly to the sr-only spans, ensuring they work regardless of whether the stylesheet is loaded. This maintains the accessibility pattern while being more resilient to CSS loading issues.

## Test plan
- [x] Run `yarn test src/test/calendar_test.test.tsx src/test/datepicker_test.test.tsx` - all 474 tests pass
- [x] Run `yarn lint` - passes
- [x] Run `yarn type-check` - passes

Fixes #6173

🤖 Generated with [Claude Code](https://claude.com/claude-code)