### PR TITLE
feat: allow onClickOutside to prevent calendar from closing

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -717,10 +717,13 @@ export class DatePicker extends Component<DatePickerProps, DatePickerState> {
   };
 
   handleCalendarClickOutside = (event: MouseEvent) => {
-    if (!this.props.inline) {
+    // Call user's onClickOutside first, allowing them to call preventDefault()
+    this.props.onClickOutside?.(event);
+
+    // Only close if not prevented and not inline
+    if (!this.props.inline && !event.defaultPrevented) {
       this.setOpen(false);
     }
-    this.props.onClickOutside?.(event);
     if (this.props.withPortal) {
       event.preventDefault();
     }

--- a/src/test/datepicker_test.test.tsx
+++ b/src/test/datepicker_test.test.tsx
@@ -2793,6 +2793,28 @@ describe("DatePicker", () => {
     expect(onClickOutsideSpy).toHaveBeenCalledTimes(1);
   });
 
+  it("should not close date picker when onClickOutside calls preventDefault", () => {
+    const onClickOutside = (event: MouseEvent) => {
+      event.preventDefault();
+    };
+    const { container } = render(
+      <div>
+        <span className="outsideElement">outside</span>
+        <DatePicker onClickOutside={onClickOutside} />
+      </div>,
+    );
+
+    const input = safeQuerySelector(container, "input");
+    fireEvent.focus(input);
+    expect(container.querySelector(".react-datepicker")).not.toBeNull();
+
+    const outsideElement = safeQuerySelector(container, ".outsideElement");
+    fireEvent.mouseDown(outsideElement);
+
+    // Calendar should remain open because preventDefault was called
+    expect(container.querySelector(".react-datepicker")).not.toBeNull();
+  });
+
   it("should not close date picker on input click", () => {
     const onClickOutsideSpy = jest.fn();
     const { container } = render(


### PR DESCRIPTION
## Summary
- Allow `onClickOutside` callback to prevent the calendar from closing by calling `event.preventDefault()`
- The callback is now called **before** the calendar closes, giving users control over the close behavior

## Problem
When using custom portal-based dropdowns in the calendar header (e.g., custom month/year selectors), clicking on the portal menu triggers `onClickOutside` and closes the calendar, even though the click was on a valid UI element.

Previously, the close happened before `onClickOutside` was called, so users couldn't prevent it.

## Solution
Call `onClickOutside` first, then check `event.defaultPrevented` before closing:

```tsx
<DatePicker
  onClickOutside={(event) => {
    // Check if click was inside your portal
    if (myPortalRef.current?.contains(event.target)) {
      event.preventDefault(); // Keeps calendar open
    }
  }}
/>
```

## Test plan
- [x] Added test: "should not close date picker when onClickOutside calls preventDefault"
- [x] All 1472 tests pass
- [x] Lint passes
- [x] Type-check passes

Fixes #5666

🤖 Generated with [Claude Code](https://claude.com/claude-code)