### PR TITLE
fix: clear selection when masked input is cleared on blur

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -707,6 +707,20 @@ export class DatePicker extends Component<DatePickerProps, DatePickerState> {
       this.props.onBlur?.(event);
     }
 
+    // If user cleared the input via a mask library (inputValue has no date-like
+    // characters), clear the selection on blur (fixes issue #5814 with mask inputs)
+    const { inputValue } = this.state;
+    if (typeof inputValue === "string" && inputValue.length > 0) {
+      // Check if input looks like a cleared mask (no alphanumeric characters)
+      // This distinguishes between:
+      // - "__/__/____" (cleared mask) → should clear selection
+      // - "2025-02-45" (invalid date) → should keep previous selection
+      const hasDateCharacters = /[a-zA-Z0-9]/.test(inputValue);
+      if (!hasDateCharacters && this.props.selected) {
+        this.setSelected(null, undefined, true);
+      }
+    }
+
     this.resetInputValue();
 
     if (this.state.open && this.props.open === false) {


### PR DESCRIPTION
## Summary

- Fixes issue where `customInput` with mask library (like `react-input-mask`) doesn't clear properly in React 18
- When user clears a masked input, the value becomes a mask pattern like `__/__/____` instead of empty string
- Previously, on blur the DatePicker would reset the input to the previously selected date
- This fix detects cleared mask patterns (no alphanumeric characters) and clears the selection instead

## Technical Details

The fix distinguishes between:
- `__/__/____` (cleared mask) → clears the selection on blur
- `2025-02-45` (invalid date) → keeps previous selection (existing behavior preserved)

This is done by checking if the input value contains any alphanumeric characters. If it doesn't (like a mask pattern with only underscores and slashes), we clear the selection.

## Test plan

- [x] Added test for controlled component clearing behavior
- [x] Added test specifically for mask pattern clearing (`__/__/____`)
- [x] Verified existing "input reset" tests still pass (invalid dates should reset to previous value)
- [x] Full test suite passes (1473 tests)

Fixes #5814

🤖 Generated with [Claude Code](https://claude.com/claude-code)