### PR TITLE
fix: restore onChange type inference for single date picker

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -258,7 +258,7 @@ export type DatePickerProps = OmitUnion<
         ) => void;
       }
     | {
-        selectsRange?: true;
+        selectsRange: true;
         selectsMultiple?: false | undefined;
         formatMultipleDates?: never;
         onChange?: (
@@ -270,7 +270,7 @@ export type DatePickerProps = OmitUnion<
       }
     | {
         selectsRange?: false | undefined;
-        selectsMultiple?: true;
+        selectsMultiple: true;
         formatMultipleDates?: (
           dates: Date[],
           formatDate: (date: Date) => string,

--- a/src/test/calendar_test.test.tsx
+++ b/src/test/calendar_test.test.tsx
@@ -1373,7 +1373,7 @@ describe("Calendar", () => {
       <DatePicker
         selected={newDate("2017-07-28")}
         adjustDateOnChange
-        onChange={(d: Date | null) => {
+        onChange={(d) => {
           date = d;
         }}
       />,
@@ -1397,7 +1397,7 @@ describe("Calendar", () => {
       <DatePicker
         selected={newDate("2017-07-28")}
         adjustDateOnChange
-        onChange={(d: Date | null) => {
+        onChange={(d) => {
           date = d;
         }}
       />,
@@ -1421,7 +1421,7 @@ describe("Calendar", () => {
       <DatePicker
         selected={newDate("2017-12-31")}
         adjustDateOnChange
-        onChange={(d: Date | null) => {
+        onChange={(d) => {
           date = d;
         }}
       />,

--- a/src/test/datepicker_test.test.tsx
+++ b/src/test/datepicker_test.test.tsx
@@ -1150,7 +1150,7 @@ describe("DatePicker", () => {
       <DatePicker
         inline
         selected={selected}
-        onChange={(d: Date | null) => {
+        onChange={(d) => {
           date = d;
         }}
       />,
@@ -1172,7 +1172,7 @@ describe("DatePicker", () => {
     const { container } = render(
       <DatePicker
         selected={selected}
-        onChange={(d: Date | null) => {
+        onChange={(d) => {
           date = d;
         }}
       />,
@@ -4610,7 +4610,7 @@ describe("DatePicker", () => {
       const { container } = render(
         <DatePicker
           selected={selected}
-          onChange={(d: Date | null) => {
+          onChange={(d) => {
             date = d;
           }}
           showTimeSelect
@@ -4641,7 +4641,7 @@ describe("DatePicker", () => {
     const { container: datepicker } = render(
       <DatePicker
         selected={selected}
-        onChange={(d: Date | null) => {
+        onChange={(d) => {
           date = d;
         }}
         showTimeSelect
@@ -4667,7 +4667,7 @@ describe("DatePicker", () => {
     const { container: datepicker } = render(
       <DatePicker
         selected={selected}
-        onChange={(d: Date | null) => {
+        onChange={(d) => {
           date = d;
         }}
         showTimeSelectOnly
@@ -4691,7 +4691,7 @@ describe("DatePicker", () => {
     const { container } = render(
       <DatePicker
         selected={selected}
-        onChange={(d: Date | null) => (date = d)}
+        onChange={(d) => (date = d)}
         dateFormat="MM/yyyy"
         minDate={newDate("2022-12-31")}
         showMonthYearPicker
@@ -4720,7 +4720,7 @@ describe("DatePicker", () => {
     const { container } = render(
       <DatePicker
         selected={selected}
-        onChange={(d: Date | null) => (date = d)}
+        onChange={(d) => (date = d)}
         dateFormat="yyyy"
         minDate={newDate("2022-12-31")}
         showYearPicker

--- a/src/test/timezone_test.test.tsx
+++ b/src/test/timezone_test.test.tsx
@@ -303,7 +303,7 @@ describe("DatePicker with timeZone prop", () => {
     const { container } = render(
       <DatePicker
         selected={utcDate}
-        onChange={(date: Date | null) => {
+        onChange={(date) => {
           selectedDate = date;
         }}
         timeZone="America/New_York"

--- a/src/test/type_inference_test.test.tsx
+++ b/src/test/type_inference_test.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * Type inference tests for DatePicker onChange callback
+ *
+ * These tests verify that TypeScript can properly infer the type of the
+ * onChange callback parameter without explicit type annotations.
+ *
+ * Related issues:
+ * - #6202: onChange type breaks after updating to 9.1.0
+ * - #6131: selectsMultiple prop type incompatibility when spreading props
+ */
+import React from "react";
+import { render, fireEvent } from "@testing-library/react";
+
+import DatePicker from "../index";
+import { safeQuerySelector } from "./test_utils";
+
+describe("DatePicker onChange type inference", () => {
+  it("should infer Date | null for single date picker without explicit type annotation", () => {
+    // This test verifies fix for issue #6202
+    // If TypeScript cannot infer the type, this test will fail to compile
+    let selectedDate: Date | null = null;
+
+    const { container } = render(
+      <DatePicker
+        selected={selectedDate}
+        // The key test: NO explicit type annotation on `date` parameter
+        // TypeScript should infer `date` as `Date | null`
+        onChange={(date) => {
+          // If type inference works, this assignment should compile without error
+          selectedDate = date;
+        }}
+      />,
+    );
+
+    const input = safeQuerySelector<HTMLInputElement>(container, "input");
+    fireEvent.change(input, { target: { value: "01/01/2024" } });
+
+    expect(selectedDate).not.toBeNull();
+  });
+
+  it("should infer [Date | null, Date | null] for range picker without explicit type annotation", () => {
+    let startDate: Date | null = null;
+    let endDate: Date | null = null;
+
+    const { container } = render(
+      <DatePicker
+        selectsRange={true}
+        startDate={startDate}
+        endDate={endDate}
+        // The key test: NO explicit type annotation on `dates` parameter
+        // TypeScript should infer `dates` as `[Date | null, Date | null]`
+        onChange={(dates) => {
+          // If type inference works, destructuring should work without error
+          const [start, end] = dates;
+          startDate = start;
+          endDate = end;
+        }}
+      />,
+    );
+
+    const input = safeQuerySelector<HTMLInputElement>(container, "input");
+    fireEvent.change(input, { target: { value: "01/01/2024" } });
+
+    expect(startDate).not.toBeNull();
+  });
+
+  it("should infer Date[] | null for multiple picker without explicit type annotation", () => {
+    let selectedDates: Date[] | null = null;
+
+    const { container } = render(
+      <DatePicker
+        selectsMultiple={true}
+        selectedDates={selectedDates ?? []}
+        // The key test: NO explicit type annotation on `dates` parameter
+        // TypeScript should infer `dates` as `Date[] | null`
+        onChange={(dates) => {
+          // If type inference works, this assignment should compile without error
+          selectedDates = dates;
+        }}
+      />,
+    );
+
+    const input = safeQuerySelector<HTMLInputElement>(container, "input");
+    fireEvent.change(input, { target: { value: "01/01/2024" } });
+
+    // Multiple picker doesn't respond to text input the same way, just verify render
+    expect(container.querySelector("input")).toBeTruthy();
+  });
+});

--- a/src/test/year_picker_test.test.tsx
+++ b/src/test/year_picker_test.test.tsx
@@ -642,7 +642,7 @@ describe("YearPicker", () => {
           selected={newDate("2020-01-01")}
           adjustDateOnChange
           showYearPicker
-          onChange={(d: Date | null) => {
+          onChange={(d) => {
             date = d;
           }}
         />,
@@ -674,7 +674,7 @@ describe("YearPicker", () => {
           selected={newDate("2020-01-01")}
           adjustDateOnChange
           showYearPicker
-          onChange={(d: Date | null) => {
+          onChange={(d) => {
             date = d;
           }}
         />,


### PR DESCRIPTION
## Summary
- Restores proper TypeScript type inference for `onChange` callback parameter
- Reverts discriminated union changes that broke type narrowing
- Adds type inference tests to prevent regression

## Problem
After upgrading to 9.1.0, TypeScript could not infer the type of the `onChange` parameter:

```tsx
<DatePicker
  onChange={(x) => {
    // x was inferred as 'any' instead of 'Date | null'
  }}
/>
```

This caused the error: "Parameter 'x' implicitly has an 'any' type. (7006)"

## Root Cause
Commit 3a82fd16 changed `selectsRange: true` and `selectsMultiple: true` to optional (`selectsRange?: true` and `selectsMultiple?: true`) in the discriminated union type. This prevented TypeScript from narrowing the union when neither prop is specified, causing all three `onChange` signatures to be valid simultaneously.

## Solution
Restore the required discriminators:
- `selectsRange: true` (not optional)
- `selectsMultiple: true` (not optional)

This allows TypeScript to properly narrow the type when neither prop is passed.

## Impact on #6131
The original fix (#6131) was for wrapper components spreading props. Those users can work around this with a type assertion:

```tsx
// Wrapper component workaround
<DatePicker {...(props as DatePickerProps)} />
```

This is acceptable because:
1. The 99% use case (basic DatePicker) now has proper type inference
2. Wrapper component authors are a smaller, more sophisticated audience who can use type assertions
3. Users of `selectsRange` and `selectsMultiple` already pass these props explicitly (required for runtime behavior)

## Test plan
- [x] Added `type_inference_test.test.tsx` to verify TypeScript can infer types without explicit annotations
- [x] Reverted test workarounds that added explicit type annotations
- [ ] CI should pass type-check and tests

Fixes #6202

🤖 Generated with [Claude Code](https://claude.com/claude-code)