### PR TITLE
fix: correct timezone handling for date selection and display

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -534,6 +534,7 @@ export class DatePicker extends Component<DatePickerProps, DatePickerState> {
       selectsRange,
       formatMultipleDates,
       value,
+      timeZone,
     } = this.props;
     const dateFormat =
       this.props.dateFormat ?? DatePicker.defaultProps.dateFormat;
@@ -549,21 +550,24 @@ export class DatePicker extends Component<DatePickerProps, DatePickerState> {
         dateFormat,
         locale,
         rangeSeparator,
+        timeZone,
       });
     } else if (selectsMultiple) {
       if (formatMultipleDates) {
         const formatDateFn = (date: Date) =>
-          safeDateFormat(date, { dateFormat, locale });
+          safeDateFormat(date, { dateFormat, locale, timeZone });
         return formatMultipleDates(selectedDates ?? [], formatDateFn);
       }
       return safeMultipleDatesFormat(selectedDates ?? [], {
         dateFormat,
         locale,
+        timeZone,
       });
     }
     return safeDateFormat(selected, {
       dateFormat,
       locale,
+      timeZone,
     });
   };
 
@@ -1730,6 +1734,23 @@ export class DatePicker extends Component<DatePickerProps, DatePickerState> {
     if (!this.props.inline && !this.isCalendarOpen()) {
       return null;
     }
+
+    const { timeZone, selected, startDate, endDate, selectedDates } =
+      this.props;
+
+    // Convert dates to zoned time for calendar display when timeZone is specified
+    // This ensures the calendar highlights the correct day in the target timezone
+    const zonedSelected =
+      selected && timeZone ? toZonedTime(selected, timeZone) : selected;
+    const zonedStartDate =
+      startDate && timeZone ? toZonedTime(startDate, timeZone) : startDate;
+    const zonedEndDate =
+      endDate && timeZone ? toZonedTime(endDate, timeZone) : endDate;
+    const zonedSelectedDates =
+      selectedDates && timeZone
+        ? selectedDates.map((date) => toZonedTime(date, timeZone))
+        : selectedDates;
+
     return (
       <Calendar
         showMonthYearDropdown={undefined}
@@ -1738,6 +1759,11 @@ export class DatePicker extends Component<DatePickerProps, DatePickerState> {
         }}
         {...this.props}
         {...this.state}
+        // Override date props with zoned time versions for correct display
+        selected={zonedSelected}
+        startDate={zonedStartDate}
+        endDate={zonedEndDate}
+        selectedDates={zonedSelectedDates}
         setOpen={this.setOpen}
         dateFormat={
           this.props.dateFormatCalendar ??


### PR DESCRIPTION
## Summary

- Fixed input display not using timezone-aware formatting when `timeZone` prop is provided
- Fixed calendar not receiving zoned dates for `selected`, `startDate`, `endDate`, and `selectedDates` props, which caused day selection highlighting to fail when timezone differs significantly from browser timezone
- Added `timeZone` parameter support to `safeDateFormat`, `safeDateRangeFormat`, and `safeMultipleDatesFormat` functions

## Problem

When the `timeZone` prop was set to a timezone significantly different from the browser's timezone (e.g., `Pacific/Kiritimati` UTC+14 with browser in UTC), clicking a date in the calendar would result in the wrong date being selected and displayed.

For example:
1. Set `timeZone="Pacific/Kiritimati"` and browser to UTC
2. Pick Dec 26th in the calendar
3. The calendar showed Dec 25th instead

## Solution

1. Updated `safeDateFormat()` in `date_utils.ts` to use `formatInTimeZone()` when a `timeZone` parameter is provided
2. Updated `getInputValue()` in `index.tsx` to pass the `timeZone` prop to date formatting functions
3. Updated `renderCalendar()` in `index.tsx` to convert `selected`, `startDate`, `endDate`, and `selectedDates` to zoned time before passing to Calendar

## Test plan

- [x] Added new tests that reproduce the issue with extreme timezone differences
- [x] All 1484 existing tests pass
- [x] Type check passes
- [x] Lint passes

Fixes #6193

🤖 Generated with [Claude Code](https://claude.com/claude-code)