### PR TITLE
refactor(date-utils) ♻️ Rename misleading getDayOfWeekCode to getDayOfMonthCode

### DIFF
--- a/src/date_utils.ts
+++ b/src/date_utils.ts
@@ -583,14 +583,14 @@ export function getWeek(date: Date): number {
 }
 
 /**
- * Gets the day of the week code for a given day.
+ * Gets the day-of-the-month code for a given date.
+ * Returns a zero-padded 3-digit string from "001" to "031".
  *
  * @param day - The day.
- * @param locale - The locale.
- * @returns - The day of the week code.
+ * @returns - A string representing the day of the month (e.g. "001", "002", "003", etc).
  */
-export function getDayOfWeekCode(day: Date, locale?: Locale): string {
-  return formatDate(day, "ddd", locale);
+export function getDayOfMonthCode(day: Date): string {
+  return formatDate(day, "ddd");
 }
 
 // *** Start of ***

--- a/src/day.tsx
+++ b/src/day.tsx
@@ -13,7 +13,7 @@ import {
   isEqual,
   isBefore,
   isAfter,
-  getDayOfWeekCode,
+  getDayOfMonthCode,
   getStartOfWeek,
   formatDate,
   type DateFilterOptionsWithDisabled,
@@ -445,7 +445,7 @@ export default class Day extends Component<DayProps> {
     return clsx(
       "react-datepicker__day",
       dayClassName,
-      "react-datepicker__day--" + getDayOfWeekCode(this.props.day),
+      "react-datepicker__day--" + getDayOfMonthCode(this.props.day),
       {
         "react-datepicker__day--disabled": this.isDisabled(),
         "react-datepicker__day--excluded": this.isExcluded(),

--- a/src/test/day_test.test.tsx
+++ b/src/test/day_test.test.tsx
@@ -3,7 +3,7 @@ import { es } from "date-fns/locale";
 import React from "react";
 
 import {
-  getDayOfWeekCode,
+  getDayOfMonthCode,
   newDate,
   getDate,
   addDays,
@@ -38,10 +38,10 @@ describe("Day", () => {
       expect(container.textContent).toBe(getDate(day) + "");
     });
 
-    it("should apply the day of week class", () => {
+    it("should apply the day of month class", () => {
       let day = newDate();
       for (let i = 0; i < 7; i++) {
-        const className = "react-datepicker__day--" + getDayOfWeekCode(day);
+        const className = `react-datepicker__day--${getDayOfMonthCode(day)}`;
         const container = renderDay(day);
         expect(
           container


### PR DESCRIPTION
## Description
**Linked issue**: #6217

**Problem**
This PR renames a date utility function and update its documentation to correctly reflect it's day-of-month behaviour when using the ddd format.  The previous name `getDayOfWeekCode`  implies it would return week codes like 'sun', 'mon', etc.  However, it actually returns the day of the month as a zero-padded 3-digit string (e.g. "001", "002", "003", etc).

**Changes**
- Renamed `getDayOfWeekCode` to `getDayOfMonthCode`
- Removed the unused `locale` argument
- Updated the documentation to correctly reflect the new function's behaviour
- Updated the code to use the new function
- Updated the tests to reflect the new function's behaviour
- No functional changes

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
