### PR TITLE
♻️ Align Time Picker header styling with Date Picker header

### DIFF
--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -176,7 +176,8 @@
   font-size: $datepicker__font-size * 1.18;
 }
 
-h2.react-datepicker__current-month {
+h2.react-datepicker__current-month,
+h2.react-datepicker-time__header {
   padding: 0;
   margin: 0;
 }

--- a/src/test/show_time_test.test.tsx
+++ b/src/test/show_time_test.test.tsx
@@ -20,6 +20,14 @@ describe("DatePicker", () => {
     expect(timeComponent).not.toBeNull();
   });
 
+  it("should have default time caption", () => {
+    const { container } = render(<DatePicker showTimeSelect open />);
+    const timeComponent = container.querySelector(
+      "h2.react-datepicker-time__header",
+    );
+    expect(timeComponent).not.toBeNull();
+  });
+
   it("should have custom time caption", () => {
     const { container } = render(<TimeComponent timeCaption="Custom time" />);
 

--- a/src/time.tsx
+++ b/src/time.tsx
@@ -300,9 +300,9 @@ export default class Time extends Component<TimeProps, TimeState> {
           this.header = header;
         }}
       >
-        <div className="react-datepicker-time__header">
+        <h2 className="react-datepicker-time__header">
           {this.props.timeCaption}
-        </div>
+        </h2>
       </div>
     );
   };


### PR DESCRIPTION
## Description

**Problem**
As highlighted in the below image, there is a small mismatch between the DatePicker's header and TimePicker's header.

<img width="558" height="393" alt="image" src="https://github.com/user-attachments/assets/38bc9a6f-224d-4f2a-859a-3a42628d4d0d" />


**Code**
```
const Default = () => {
  const [selectedDate, setSelectedDate] = useState<Date | null>(new Date());

  const handleChange = (date: Date | null) => {
    setSelectedDate(date);
  };

  return (
    <DatePicker
      selected={selectedDate}
      onChange={handleChange}
      showTimeSelect
    />
  );
};
```


**Changes**
- Update the Time Select header to be same as the DatePicker's Header
- Refactored the time header from a `div` to an `h2` element for better semantic structure.
- Added a test to ensure the default time caption is rendered correctly.

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
