### PR TITLE
fix: correct getDayOfWeekCode to return day of week instead of day of month

### DIFF
--- a/src/date_utils.ts
+++ b/src/date_utils.ts
@@ -59,6 +59,7 @@ import {
   subYears,
   toDate,
 } from "date-fns";
+import { enUS } from "date-fns/locale";
 
 import type { Locale as DateFnsLocale, Day } from "date-fns";
 
@@ -590,7 +591,7 @@ export function getWeek(date: Date): number {
  * @returns - The day of the week code.
  */
 export function getDayOfWeekCode(day: Date, locale?: Locale): string {
-  return formatDate(day, "ddd", locale);
+  return formatDate(day, "eee", enUS).toLowerCase();
 }
 
 // *** Start of ***


### PR DESCRIPTION
## Summary

Fixes #6217 - getDayOfWeekCode in date_utils has incorrect behavior

## Problem

The current implementation of `getDayOfWeekCode()` returns the day of the month instead of the day of week code. This happens because the format string `ddd` is used with date-fns, which represents the day of month with ordinal (1st, 2nd, 3rd, etc.) rather than the day of week abbreviation.

**Current code:**
```typescript
export function getDayOfWeekCode(day: Date, locale?: Locale): string {
  return formatDate(day, "ddd", locale);
}
```

For example, calling this on the 15th of any month would return "15" instead of the expected day code like "mon" or "tue".

## Solution

Changed the format string to `eee` which correctly returns the abbreviated day of week name, using the `enUS` locale to ensure consistency, and converting to lowercase to match the expected output format.

**Fixed code:**
```typescript
export function getDayOfWeekCode(day: Date, locale?: Locale): string {
  return formatDate(day, "eee", enUS).toLowerCase();
}
```

This now correctly returns lowercase day-of-week codes: `sun`, `mon`, `tue`, `wed`, `thu`, `fri`, `sat`

## Reference

- date-fns format documentation: https://date-fns.org/docs/format
  - `ddd` = ordinal day of month (1st, 2nd, 3rd, etc.)
  - `eee` = abbreviated day of week (Sun, Mon, Tue, etc.)

## Testing

- The fix ensures getDayOfWeekCode returns the correct day-of-week codes
- Uses enUS locale for consistent output across different locales
- Converts to lowercase to match expected format

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>