### PR TITLE
fix: add runtime instanceof Node guard in click outside handler

### DIFF
--- a/src/click_outside_wrapper.tsx
+++ b/src/click_outside_wrapper.tsx
@@ -29,7 +29,11 @@ const useDetectClickOutside = (
             .composedPath()
             .find((eventTarget) => eventTarget instanceof Node)) ||
         event.target;
-      if (ref.current && !ref.current.contains(target as Node)) {
+      if (
+        ref.current &&
+        target instanceof Node &&
+        !ref.current.contains(target)
+      ) {
         if (
           !(
             ignoreClass &&


### PR DESCRIPTION
---
name: Pull Request
about: add runtime instanceof Node guard in click outside handler
title: ""
labels: ""
assignees: ""
---

## Description
**Linked issue**: #(issue number) 

**Problem**
When the `composedPath()` lookup doesn't find a `Node`, `target` falls back to
`event.target` which is typed as `EventTarget | null`. The existing code used a
TypeScript `as Node` cast, but this is erased at compile time — so
`Node.contains()` in `dist/index.js` receives an unguarded `EventTarget`.

**Changes**
This adds an explicit `target instanceof Node` runtime check before calling
`.contains()`, which also removes the need for the type cast.


## Screenshots
<!-- If applicable, add screenshots to help explain your improvements -->

## To reviewers
Verified the compiled `dist/index.js` output includes the `instanceof Node` guard

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [ ] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
