### PR TITLE
fix: complete safeToDate adoption in Calendar.renderInputTime

### DIFF
--- a/src/calendar.tsx
+++ b/src/calendar.tsx
@@ -37,6 +37,7 @@ import {
   getEffectiveMaxDate,
   addZero,
   isValid,
+  safeToDate,
   getYearsPeriod,
   DEFAULT_YEAR_ITEM_NUMBER,
   getMonthInLocale,
@@ -1189,14 +1190,14 @@ export default class Calendar extends Component<CalendarProps, CalendarState> {
     if (this.props.selectsRange) {
       const { startDate, endDate } = this.props;
 
-      const startTime = startDate ? new Date(startDate) : undefined;
+      const startTime = safeToDate(startDate) ?? undefined;
       const startTimeValid =
         startTime && isValid(startTime) && Boolean(startDate);
       const startTimeString = startTimeValid
         ? `${addZero(startTime.getHours())}:${addZero(startTime.getMinutes())}`
         : "";
 
-      const endTime = endDate ? new Date(endDate) : undefined;
+      const endTime = safeToDate(endDate) ?? undefined;
       const endTimeValid = endTime && isValid(endTime) && Boolean(endDate);
       const endTimeString = endTimeValid
         ? `${addZero(endTime.getHours())}:${addZero(endTime.getMinutes())}`
@@ -1229,9 +1230,7 @@ export default class Calendar extends Component<CalendarProps, CalendarState> {
     }
 
     // Single date mode (original behavior)
-    const time = this.props.selected
-      ? new Date(this.props.selected)
-      : undefined;
+    const time = safeToDate(this.props.selected) ?? undefined;
     const timeValid = time && isValid(time) && Boolean(this.props.selected);
     const timeString = timeValid
       ? `${addZero(time.getHours())}:${addZero(time.getMinutes())}`


### PR DESCRIPTION
## Summary

Completes the `safeToDate()` sibling-sweep started in 149d5470 ("fix: prevent crash when date props are passed as strings") by adopting the helper in the three remaining raw-`new Date()` callsites in `Calendar.renderInputTime`.

## Context

`safeToDate(date: Date | null | undefined): Date | null` was introduced to guard against runtime crashes from consumers that pass non-Date values (strings, numbers, plain objects) to props typed as `Date`. After 149d5470 the codebase has 7 callsites that adopted the helper:

- `src/index.tsx:809`, `:811`, `:1258`, `:1320`
- `src/time.tsx:144`, `:224`, `:225`

Three sibling callsites in `src/calendar.tsx` were missed:

- `:1193` — `startDate` in `selectsRange` mode
- `:1200` — `endDate` in `selectsRange` mode
- `:1233` — `selected` in single-date mode

This PR closes that gap.

## Behavior change

| Consumer usage | Before | After |
|---|---|---|
| `<DatePicker selected={new Date()} />` (typed Date) | renders | renders (unchanged) |
| `<DatePicker selected={undefined} />` | does not render | does not render (unchanged) |
| `<DatePicker selected={"2025-01-01" as any} />` (TS violation) | renders time input with parsed Date | does not render (consistent with the rest of the codebase) |
| `<DatePicker selected={"garbage" as any} />` | does not render (existing `isValid` guard catches Invalid Date) | does not render (unchanged) |

The behavior change only affects consumers who already bypass the TypeScript type contract by passing non-Date values. The new behavior aligns `Calendar.renderInputTime` with the documented `safeToDate` policy from 149d5470.

## Diff

```
 src/calendar.tsx | 9 ++++-----
 1 file changed, 4 insertions(+), 5 deletions(-)
```

- Imports `safeToDate` from `./date_utils` alongside the existing `isValid` import.
- Replaces three `propValue ? new Date(propValue) : undefined` constructions with `safeToDate(propValue) ?? undefined`.
- The downstream `startTime && isValid(startTime) && Boolean(propValue)` checks are kept as-is (defensive, harmless redundancy with the new guard).

## Test plan

- [x] `yarn type-check` — clean
- [x] `yarn eslint` — clean
- [x] `yarn jest src/test/timepicker_test.test.tsx src/test/show_time_test.test.tsx` — passing (existing `renderInputTime` coverage in these suites exercises both branches)
- [x] `yarn jest --ci` full suite — same 8 pre-existing failures as on `main` (`week_picker_test`, `datepicker_test`); zero regressions introduced by this change. Verified by running the same tests against `main` with this branch stashed.
