### PR TITLE
fix: clamp month navigation to min/max to prevent snap-back (#6290)

### DIFF
--- a/src/calendar.tsx
+++ b/src/calendar.tsx
@@ -438,8 +438,21 @@ export default class Calendar extends Component<CalendarProps, CalendarState> {
   };
 
   handleMonthChange = (date: Date): void => {
-    const enabledPreSelectionDate =
+    let enabledPreSelectionDate =
       this.getEnabledPreSelectionDateForMonth(date) ?? date;
+
+    if (
+      this.props.maxDate &&
+      isAfter(enabledPreSelectionDate, this.props.maxDate)
+    ) {
+      enabledPreSelectionDate = this.props.maxDate;
+    }
+    if (
+      this.props.minDate &&
+      isBefore(enabledPreSelectionDate, this.props.minDate)
+    ) {
+      enabledPreSelectionDate = this.props.minDate;
+    }
 
     this.handleCustomMonthChange(enabledPreSelectionDate);
     if (this.props.adjustDateOnChange) {

--- a/src/test/month_navigation_clamp.test.tsx
+++ b/src/test/month_navigation_clamp.test.tsx
@@ -1,0 +1,52 @@
+import { fireEvent } from "@testing-library/dom";
+import React from "react";
+
+import DatePicker from "index";
+import { safeQuerySelector } from "./test_utils";
+import { render } from "@testing-library/react";
+
+describe("month navigation clamps to minDate/maxDate (snapback)", () => {
+  const minDate = new Date(2026, 4, 24); // May 24, 2026
+  const maxDate = new Date(2026, 6, 23); // July 23, 2026
+  const includeDates = [new Date(2026, 4, 5), new Date(2026, 4, 30)]; // May only
+
+  function navigateToJuly() {
+    const onMonthChange = jest.fn();
+
+    const { container } = render(
+      <DatePicker
+        inline
+        selected={new Date(2026, 4, 5)}
+        onChange={() => {}}
+        minDate={minDate}
+        maxDate={maxDate}
+        includeDates={includeDates}
+        openToDate={new Date(2026, 4, 24)}
+        onMonthChange={onMonthChange}
+        showMonthDropdown
+        dropdownMode="scroll"
+      />,
+    );
+
+    fireEvent.click(
+      safeQuerySelector(container, ".react-datepicker__month-read-view"),
+    );
+    const july = Array.from(
+      container.querySelectorAll(".react-datepicker__month-option"),
+    ).find((option) => option.textContent?.includes("July"));
+    fireEvent.click(july!);
+    return { container, onMonthChange };
+  }
+
+  it("does not snap back when navigating to a month with no selectable days", () => {
+    const { container, onMonthChange } = navigateToJuly();
+
+    expect(onMonthChange).toHaveBeenCalledTimes(1);
+    expect(onMonthChange.mock.calls[0]?.[0].getMonth()).toBe(6);
+    expect(
+      safeQuerySelector(container, ".react-datepicker__month").getAttribute(
+        "aria-label",
+      ),
+    ).toContain("July");
+  });
+});


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to improve this repository
title: ""
labels: ""
assignees: ""
---

## Description
**Linked issue**:  #6290 

**Problem**
When we pick a month from the month dropdown, the calendar sometimes jumps to that month for a moment and then snaps back to the month we were already on.

**Changes**
- Clamp the navigated date into `[minDate, maxDate]` before passing it to `handleCustomMonthChange`/`setPreSelection`. This keeps the target date selectable, so the view stays n the picked month and `onMonthChange` fires exactly once with the correct math.
- Regression test covering navigation to a month with no selectable day near the `maxDate` boundary.

## Screenshots

https://github.com/user-attachments/assets/f95002a2-1277-45e5-ae9d-69236b6e21ac


## To reviewers
<!-- Additional comments for reviewers -->

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
