### PR TITLE
Fix #6294: 🐛 Fix inline range datepicker resetting selection on handleSelect

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -894,7 +894,11 @@ export class DatePicker extends Component<DatePickerProps, DatePickerState> {
     if (this.props.showDateSelect) {
       this.setState({ isRenderAriaLiveMessage: true });
     }
-    if (!this.props.shouldCloseOnSelect || this.props.showTimeSelect) {
+    if (
+      !this.props.shouldCloseOnSelect ||
+      this.props.inline ||
+      this.props.showTimeSelect
+    ) {
       this.setPreSelection(date);
     } else if (isDateSelectionComplete) {
       this.setOpen(false);

--- a/src/test/datepicker_test.test.tsx
+++ b/src/test/datepicker_test.test.tsx
@@ -3738,6 +3738,48 @@ describe("DatePicker", () => {
         formatDate(selected, "yyyy-MM-dd"),
       );
     });
+
+    it("should not reset the preSelectedDate to startDate after selecting the endDate", async () => {
+      const selectedDate = newDate("2026-06-01");
+      const selectedDay = selectedDate.getDate();
+      let startDate, endDate;
+      const onChange = (dates: [Date | null, Date | null]) => {
+        startDate = dates[0] ?? null;
+        endDate = dates[1] ?? null;
+      };
+
+      const { container } = render(
+        <DatePicker
+          selected={selectedDate}
+          onChange={onChange}
+          startDate={startDate}
+          endDate={endDate}
+          selectsRange
+          inline
+        />,
+      );
+
+      const startDayClassName = `.react-datepicker__day--0${selectedDay < 10 ? "0" + selectedDay : selectedDay}`;
+      const selectedDayEl = safeQuerySelector(
+        container,
+        `${startDayClassName}.react-datepicker__day--selected`,
+      );
+      await userEvent.click(selectedDayEl);
+
+      const expectedEndDate = selectedDay + 2;
+      await userEvent.keyboard(
+        `${Array(expectedEndDate - selectedDay).fill(`{${KeyType.ArrowRight}}`)}{${KeyType.Enter}}`,
+      );
+
+      const endDayEl = safeQuerySelector(
+        container,
+        ".react-datepicker__day--keyboard-selected",
+      );
+
+      const expectedEndDayClassName = `react-datepicker__day--0${expectedEndDate < 10 ? "0" + expectedEndDate : expectedEndDate}`;
+
+      expect(endDayEl.classList.contains(expectedEndDayClassName)).toBe(true);
+    });
   });
 
   describe("is-selecting-range", () => {


### PR DESCRIPTION
## Description
**Linked issue**: #6294 & #6304

**Problem**
The handleSelect handler unconditionally calls `setOpen(false)`. While this behavior is correct for non-inline datepickers (which should close after selection), it causes unintended side effects in inline mode.

Inline datepickers do not close, but invoking `setOpen(false)` still triggers a focus reset. This results in the component switching back to selecting `startDate`, effectively losing the current range selection and creating a broken user experience.

**Changes**
- Added a conditional check to skip calling `setOpen(false)` when the datepicker is in inline mode
- Preserved existing behavior for non-inline datepickers
- Prevented unnecessary focus resets that were causing selection state loss

**Behavior Changes**
- **Inline mode**: Range selection is preserved correctly after selecting dates
- **Non-inline mode**: No change; picker continues to close after selection

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
