### PR TITLE
Fix #6297: 🐛 Fix inline Year datepicker Keyboard Navigation Accessibility

### DIFF
--- a/src/test/year_picker_test.test.tsx
+++ b/src/test/year_picker_test.test.tsx
@@ -634,6 +634,20 @@ describe("YearPicker", () => {
       expect(selectedYear?.textContent).toBe(`${currentYear}`);
     });
 
+    it("should set the key-selected class (pre-select) automatically to the current year when there is no selected date passed - in the Inline Mode", () => {
+      const { container } = render(
+        <DatePicker showYearPicker dateFormat="yyyy" inline />,
+      );
+
+      const selectedYear = container.querySelector(
+        ".react-datepicker__year-text--keyboard-selected",
+      );
+      expect(selectedYear).toBeDefined();
+
+      const currentYear = new Date().getFullYear();
+      expect(selectedYear?.textContent).toBe(`${currentYear}`);
+    });
+
     it("should set the date to the selected year of the previous period when previous button clicked", () => {
       let date: Date | null;
       const expectedDate = getStartOfYear(setYear(newDate(), 2008));

--- a/src/year.tsx
+++ b/src/year.tsx
@@ -250,12 +250,7 @@ export default class Year extends Component<YearProps> {
       getStartOfYear(this.props.preSelection),
     );
 
-    return (
-      !this.props.inline &&
-      !isSelectedDay &&
-      isKeyboardSelectedDay &&
-      !isDisabled
-    );
+    return !isSelectedDay && isKeyboardSelectedDay && !isDisabled;
   };
 
   isSelectedYear = (year: number) => {


### PR DESCRIPTION
**Description**

Linked issue: #6297

---

**Problem**

In `showYearPicker` mode, keyboard navigation does not visually highlight the active (focused) year when the DatePicker is rendered with `inline`.

This behavior is inconsistent with:

* Default DatePicker (day view)
* MonthPicker (`showMonthYearPicker`)

Root cause:

* `isKeyboardSelected` in `src/year.tsx` includes a `!this.props.inline` condition
* This prevents the `react-datepicker__day--keyboard-selected` class from being applied in inline mode

---

**Changes**

* Removed the unnecessary `!this.props.inline` check from `isKeyboardSelected`
* Ensures keyboard-selected state is applied regardless of inline rendering

<img width="814" height="507" alt="image" src="https://github.com/user-attachments/assets/a7718052-b30c-4256-b5c1-da53c932bdbc" />


---

**Behavior Changes**

* ✅ YearPicker now highlights the focused year during keyboard navigation in inline mode
* ✅ Behavior is now consistent across all picker modes
* ⚠️ No impact on non-inline behavior
* ⚠️ No changes to selection logic, only visual keyboard state handling

---

**Contribution checklist**
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.