### PR TITLE
Fix #6298: 🐛 Allow Enter key selection when selected is null

### DIFF
--- a/src/test/year_picker_test.test.tsx
+++ b/src/test/year_picker_test.test.tsx
@@ -910,6 +910,34 @@ describe("YearPicker", () => {
       expect(selectedDay ? getYear(selectedDay) : selectedDay).toBe(2021);
     });
 
+    it("should select 2021 when Enter key is pressed (in Inline Mode)", () => {
+      const onDayClickMock = jest.fn();
+      const { container } = render(
+        <DatePicker
+          selected={null}
+          onChange={() => {}}
+          onSelect={onDayClickMock}
+          showYearPicker
+        />,
+      );
+      openDateInput(container);
+
+      const currentYear = container.querySelector(
+        ".react-datepicker__year-text--today",
+      ) as HTMLElement;
+      fireEvent.keyDown(currentYear, getKey(KeyType.Enter));
+
+      expect(onDayClickMock).toHaveBeenCalledTimes(1);
+      const expectedSelectedDate = getStartOfYear(newDate());
+
+      expect(onDayClickMock).toHaveBeenCalledWith(
+        expectedSelectedDate,
+        expect.objectContaining({
+          key: KeyType.Enter,
+        }),
+      );
+    });
+
     it("should call onKeyDown handler on any key press", () => {
       const onKeyDownSpy = jest.fn();
 
@@ -1020,30 +1048,6 @@ describe("YearPicker", () => {
   });
 
   describe("edge cases for coverage", () => {
-    it("should handle keyboard navigation with null selected date (Enter key)", () => {
-      const onDayClickMock = jest.fn();
-      const { container } = render(
-        <DatePicker
-          selected={null}
-          onChange={() => {}}
-          onSelect={onDayClickMock}
-          showYearPicker
-        />,
-      );
-
-      openDateInput(container);
-
-      const currentYear = container.querySelector(
-        ".react-datepicker__year-text--today",
-      ) as HTMLElement;
-
-      fireEvent.keyDown(currentYear, getKey(KeyType.Enter));
-
-      // When selected is null and Enter is pressed, onDayClick should not be called
-      // because of the early return at line 297
-      expect(onDayClickMock).not.toHaveBeenCalled();
-    });
-
     it("should handle keyboard navigation with null preSelection (Arrow keys)", () => {
       const { container } = render(
         <DatePicker

--- a/src/year.tsx
+++ b/src/year.tsx
@@ -292,9 +292,6 @@ export default class Year extends Component<YearProps> {
     if (!this.props.disabledKeyboardNavigation) {
       switch (key) {
         case KeyType.Enter:
-          if (this.props.selected == null) {
-            break;
-          }
           this.onYearClick(event, y);
           this.props.setPreSelection?.(this.props.selected);
           break;


### PR DESCRIPTION
**Description**

Linked issue: #6298 

---

**Problem**

In YearPicker (`showYearPicker`), pressing Enter does not select a year when `selected` is `null` or `undefined`.

This is caused by an early return in `onYearKeyDown` (`src/year.tsx`):

```ts
if (this.props.selected == null) {
  break;
}
```

This prevents keyboard-based selection entirely when no initial value is set.

The behavior is inconsistent with:

* Mouse selection (works correctly)
* Default DatePicker and MonthPicker (keyboard works even with null selection)

---

**Changes**

* Removed the `selected == null` guard from Enter key handling
* Enabled selection based on the currently focused/preselected year
* Updated test cases to reflect expected behavior
* Removed/adjusted test enforcing no selection when `selected` is null

---

**Behavior Changes**

* ✅ Enter key now selects a year even when `selected` is initially null
* ✅ Keyboard and mouse interactions are now consistent
* ✅ Behavior aligned with other picker modes
* ⚠️ Existing tests expecting no selection on null `selected` are updated

---

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
