### PR TITLE
fix: keep sr-only weekday header text visually hidden with inline styles

### DIFF
--- a/src/calendar.tsx
+++ b/src/calendar.tsx
@@ -56,6 +56,18 @@ import YearDropdown from "./year_dropdown";
 import type { ClickOutsideHandler } from "./click_outside_wrapper";
 import type { Day } from "date-fns";
 
+const visuallyHiddenStyle: React.CSSProperties = {
+  position: "absolute",
+  width: "1px",
+  height: "1px",
+  padding: 0,
+  margin: "-1px",
+  overflow: "hidden",
+  clipPath: "inset(50%)",
+  whiteSpace: "nowrap",
+  border: 0,
+};
+
 interface YearDropdownProps extends React.ComponentPropsWithoutRef<
   typeof YearDropdown
 > {}
@@ -517,7 +529,12 @@ export default class Calendar extends Component<CalendarProps, CalendarState> {
           className={`react-datepicker__day-name ${disabled ? "react-datepicker__day-name--disabled" : ""}`}
           role="columnheader"
         >
-          <span className="react-datepicker__sr-only">Week number</span>
+          <span
+            className="react-datepicker__sr-only"
+            style={visuallyHiddenStyle}
+          >
+            Week number
+          </span>
           <span aria-hidden="true">{this.props.weekLabel || "#"}</span>
         </div>,
       );
@@ -568,7 +585,12 @@ export default class Calendar extends Component<CalendarProps, CalendarState> {
               disabled ? "react-datepicker__day-name--disabled" : "",
             )}
           >
-            <span className="react-datepicker__sr-only">{fullDayName}</span>
+            <span
+              className="react-datepicker__sr-only"
+              style={visuallyHiddenStyle}
+            >
+              {fullDayName}
+            </span>
             <span aria-hidden="true">{weekDayName}</span>
           </div>
         );

--- a/src/test/calendar_test.test.tsx
+++ b/src/test/calendar_test.test.tsx
@@ -2446,6 +2446,35 @@ describe("Calendar", () => {
     });
   });
 
+  it("should keep sr-only day name and week number spans visually hidden via inline styles", () => {
+    const { container } = render(
+      <Calendar
+        dateFormat={DATE_FORMAT}
+        onSelect={() => {}}
+        onClickOutside={() => {}}
+        dropdownMode="scroll"
+        showWeekNumbers
+      />,
+    );
+
+    const srOnlySpans = container.querySelectorAll(
+      ".react-datepicker__day-name > span.react-datepicker__sr-only",
+    );
+    expect(srOnlySpans).toHaveLength(8);
+
+    srOnlySpans.forEach((span) => {
+      const { style } = span as HTMLElement;
+      expect(style.position).toBe("absolute");
+      expect(style.width).toBe("1px");
+      expect(style.height).toBe("1px");
+      expect(style.padding).toBe("0px");
+      expect(style.margin).toBe("-1px");
+      expect(style.overflow).toBe("hidden");
+      expect(style.clipPath).toBe("inset(50%)");
+      expect(style.whiteSpace).toBe("nowrap");
+    });
+  });
+
   it("should have a next-button with the provided aria-label for year", () => {
     const ariaLabel = "A label in my native language for next year";
     const { container } = render(


### PR DESCRIPTION
## Description
**Linked issue**: #6302

**Problem**
Since v8.5.0 the calendar weekday header renders a screen-reader-only span with the full day name (`Sunday`, `Monday`, ...) next to the visible short name. The span is hidden by the `.react-datepicker__sr-only` rule (named `.sr-only` in v8.5.0–v8.6.0) shipped in the package stylesheet.

When the stylesheet loaded by the consumer app does not match the installed JS version — a vendored copy of the v7 CSS, a CDN link pinned to an older version, or a stale build cache — that rule is missing, and the full day names render visibly, overlapping the short names exactly as shown in the issue screenshots. Every published version of the package ships matching JS + CSS (verified 7.7.0 through 9.1.0 across `react-datepicker.css`, `react-datepicker.min.css`, and the CSS-modules variants), which is why the issue is not reproducible with a correct setup.

**Changes**
This makes the component degrade gracefully instead of producing a broken header when the loaded stylesheet is out of sync: the visually-hidden styles are now also applied inline on the two sr-only spans, mirroring the `.react-datepicker__sr-only` rule. The class name and the SCSS rule are unchanged.

| File | Change |
|------|--------|
| `src/calendar.tsx` | Added a `visuallyHiddenStyle` constant (mirror of the `.react-datepicker__sr-only` ruleset) and applied it inline to the week-number and day-name sr-only spans |
| `src/test/calendar_test.test.tsx` | Regression test asserting the sr-only spans stay visually hidden via inline styles, independent of the stylesheet |

## Screenshots
See the issue for before/after screenshots of the broken header (v7 stylesheet + v8/v9 JS).

## To reviewers
Two intentional tradeoffs worth a conscious decision:
- The visually-hidden ruleset now exists in two places (`datepicker.scss` and `calendar.tsx`); they must be kept in sync if the clipping technique ever changes.
- Inline styles win over class-selector overrides, so a consumer who deliberately restyles `.react-datepicker__sr-only` would now need `!important`. Given the class exists purely to hide accessible text, this seems like the right default.

The added test pins that the inline styles stay applied at the JSX level; jsdom cannot reproduce the visual overlap itself.

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
