### PR TITLE
fix: close calendar when outside mousedown propagation stops

### DIFF
--- a/src/click_outside_wrapper.tsx
+++ b/src/click_outside_wrapper.tsx
@@ -44,9 +44,9 @@ const useDetectClickOutside = (
     [ignoreClass],
   );
   useEffect(() => {
-    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("mousedown", handleClickOutside, true);
     return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("mousedown", handleClickOutside, true);
     };
   }, [handleClickOutside]);
   return ref;

--- a/src/test/click_outside_wrapper.test.tsx
+++ b/src/test/click_outside_wrapper.test.tsx
@@ -42,6 +42,26 @@ describe("ClickOutsideWrapper", () => {
     expect(onClickOutsideMock).toHaveBeenCalledTimes(1);
   });
 
+  it("calls onClickOutside when an outside element stops mousedown propagation", () => {
+    const { getByTestId } = render(
+      <div>
+        <ClickOutsideWrapper onClickOutside={onClickOutsideMock}>
+          <div>Inside</div>
+        </ClickOutsideWrapper>
+        <button
+          data-testid="outside"
+          onMouseDown={(event) => event.stopPropagation()}
+        >
+          Outside
+        </button>
+      </div>,
+    );
+
+    fireEvent.mouseDown(getByTestId("outside"));
+
+    expect(onClickOutsideMock).toHaveBeenCalledTimes(1);
+  });
+
   it("does not call onClickOutside when clicking inside the wrapper", () => {
     const { container } = render(
       <ClickOutsideWrapper onClickOutside={onClickOutsideMock}>
@@ -190,6 +210,7 @@ describe("ClickOutsideWrapper", () => {
     expect(removeEventListenerSpy).toHaveBeenCalledWith(
       "mousedown",
       expect.any(Function),
+      true,
     );
 
     removeEventListenerSpy.mockRestore();

--- a/src/test/datepicker_test.test.tsx
+++ b/src/test/datepicker_test.test.tsx
@@ -2865,6 +2865,24 @@ describe("DatePicker", () => {
     expect(onClickOutsideSpy).toHaveBeenCalledTimes(1);
   });
 
+  it("should close when an outside element stops mousedown propagation", () => {
+    const { container, getByRole } = render(
+      <div>
+        <button onMouseDown={(event) => event.stopPropagation()}>
+          Outside
+        </button>
+        <DatePicker />
+      </div>,
+    );
+
+    fireEvent.focus(safeQuerySelector(container, "input"));
+    expect(container.querySelector(".react-datepicker")).not.toBeNull();
+
+    fireEvent.mouseDown(getByRole("button", { name: "Outside" }));
+
+    expect(container.querySelector(".react-datepicker")).toBeNull();
+  });
+
   it("should not close date picker when onClickOutside calls preventDefault", () => {
     const onClickOutside = (event: MouseEvent) => {
       event.preventDefault();


### PR DESCRIPTION
## Description

**Linked issue**: #6292

**Problem**

The calendar's document-level `mousedown` listener ran during the bubbling phase. Third-party controls such as `react-select` can stop `mousedown` propagation, preventing the outside-click handler from running and leaving the calendar open.

**Changes**

- Register and remove the outside-click listener in the capture phase so outside presses are observed before a target stops propagation.
- Preserve the existing target containment, `ignoreClass`, and listener cleanup behavior.
- Add unit coverage for the click-outside wrapper and an integration regression test confirming that the DatePicker calendar closes.

## Screenshots

Not applicable; this changes event handling without visual changes.

## To reviewers

The regression is covered with an outside button whose React `onMouseDown` handler calls `stopPropagation()`. The test fails with the previous bubbling listener and passes with capture enabled.

Validation completed locally:

- `yarn prettier:check`
- `yarn type-check`
- `yarn lint`
- `yarn test:ci --runInBand --watchman=false --silent` (43 suites, 1,487 tests)
- `yarn build`

## Contribution checklist

- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.

Closes #6292
