### PR TITLE
fix: don't crash parseDate when dateFormat contains timezone tokens

### DIFF
--- a/src/date_utils.ts
+++ b/src/date_utils.ts
@@ -306,11 +306,20 @@ export function parseDate(
   const formats = Array.isArray(dateFormat) ? dateFormat : [dateFormat];
 
   for (const format of formats) {
-    const parsedDate = parse(value, format, refDate, {
-      locale: localeObject,
-      useAdditionalWeekYearTokens: true,
-      useAdditionalDayOfYearTokens: true,
-    });
+    // date-fns `parse` throws a RangeError for format tokens it cannot
+    // consume (e.g. the `z`/`zzz` timezone tokens, which are format-only).
+    // Guard against that so an unparseable token in `dateFormat` does not
+    // crash callers such as handleChange and discard the user's input.
+    let parsedDate: Date;
+    try {
+      parsedDate = parse(value, format, refDate, {
+        locale: localeObject,
+        useAdditionalWeekYearTokens: true,
+        useAdditionalDayOfYearTokens: true,
+      });
+    } catch {
+      continue;
+    }
     if (
       isValid(parsedDate) &&
       (!strictParsing || value === formatDate(parsedDate, format, locale))

--- a/src/test/date_utils_test.test.ts
+++ b/src/test/date_utils_test.test.ts
@@ -1121,6 +1121,24 @@ describe("date_utils", () => {
       expect(actual).toEqual(expected);
     });
 
+    it("should not throw when dateFormat contains an unparseable timezone token (#6303)", () => {
+      // date-fns `parse` cannot consume the `z`/`zzz` timezone tokens and
+      // throws a RangeError ("Format string contains an unescaped latin
+      // alphabet character `z`"). parseDate must swallow that so typing an
+      // input does not crash handleChange and the user's value is not lost.
+      const value = "July 6, 2026 3:30 PM (GMT+0)";
+      const dateFormat = "MMMM d, yyyy h:mm aa (zzz)";
+
+      let actual: Date | null = null;
+      expect(() => {
+        actual = parseDate(value, dateFormat, undefined, false);
+      }).not.toThrow();
+
+      // The date/time portion still resolves via the native Date fallback.
+      expect(actual).not.toBeNull();
+      expect(actual).toEqual(new Date(2026, 6, 6, 15, 30, 0, 0));
+    });
+
     describe("native Date fallback when strictParsing is false (#6164)", () => {
       it("should parse date in different format using native Date fallback", () => {
         // User types MM/dd/yyyy but dateFormat is yyyy-MM-dd


### PR DESCRIPTION
## Description
**Linked issue**: #6303

**Problem**
When `dateFormat` contains a timezone token (e.g. `"MMMM d, yyyy h:mm aa (zzz)"`), typing anything into the datepicker input crashes the page. date-fns `parse()` throws a `RangeError` ("Format string contains an unescaped latin alphabet character `z`") because `z`/`zzz` are format-only tokens that `parse` cannot consume. The error propagates out of `parseDate` into `handleChange`, so the component throws and the user's typed input is lost.

**Changes**
- `src/date_utils.ts`: wrapped the date-fns `parse()` call inside `parseDate`'s format loop in a `try/catch`. When `parse` throws on an unparseable token, the loop `continue`s, so parsing falls through to the existing native `Date` fallback (when `strictParsing` is false) instead of crashing. Behavior for all parseable formats is unchanged.
- `src/test/date_utils_test.test.ts`: added a regression test that parses `"July 6, 2026 3:30 PM (GMT+0)"` against `"MMMM d, yyyy h:mm aa (zzz)"`, asserting `parseDate` does not throw and the date/time still resolves via the native `Date` fallback.

## Screenshots
N/A (no visual changes)

## To reviewers
`zzz` renders fine through `formatDate` (date-fns `format` supports it), so users legitimately configure it in `dateFormat`; only the parsing path threw. The try/catch also covers any other format-only token `parse` rejects.

Test run: `yarn jest src/test/date_utils_test.test.ts` — 236 passed. Prettier and ESLint pass on the touched files.

Fixes #6303

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
