### PR TITLE
fix: showMonthYearDropdown not keyboard/tab accessible

### DIFF
--- a/src/month_year_dropdown.tsx
+++ b/src/month_year_dropdown.tsx
@@ -91,8 +91,9 @@ export default class MonthYearDropdown extends Component<
     );
 
     return (
-      <div
+      <button
         key="read"
+        type="button"
         style={{ visibility: visible ? "visible" : "hidden" }}
         className="react-datepicker__month-year-read-view"
         onClick={this.toggleDropdown}
@@ -101,7 +102,7 @@ export default class MonthYearDropdown extends Component<
         <span className="react-datepicker__month-year-read-view--selected-month-year">
           {yearMonth}
         </span>
-      </div>
+      </button>
     );
   };
 

--- a/src/month_year_dropdown_options.tsx
+++ b/src/month_year_dropdown_options.tsx
@@ -72,9 +72,38 @@ export default class MonthYearDropdownOptions extends Component<
     };
   }
 
+  monthYearOptionButtonsRef: Record<number, HTMLDivElement | null> = {};
+
+  handleOptionKeyDown = (
+    i: number,
+    monthYearPoint: number,
+    e: React.KeyboardEvent,
+  ): void => {
+    switch (e.key) {
+      case "Enter":
+        e.preventDefault();
+        this.onChange(monthYearPoint);
+        break;
+      case "Escape":
+        e.preventDefault();
+        this.props.onCancel();
+        break;
+      case "ArrowUp":
+      case "ArrowDown": {
+        e.preventDefault();
+        const newIndex = i + (e.key === "ArrowUp" ? -1 : 1);
+        this.monthYearOptionButtonsRef[newIndex]?.focus();
+        break;
+      }
+    }
+  };
+
   renderOptions = (): React.ReactElement[] => {
+    // Clear refs to prevent memory leaks on re-render
+    this.monthYearOptionButtonsRef = {};
+
     return this.state.monthYearsList.map<React.ReactElement>(
-      (monthYear: Date): React.ReactElement => {
+      (monthYear: Date, i: number): React.ReactElement => {
         const monthYearPoint = getTime(monthYear);
         const isSameMonthYear =
           isSameYear(this.props.date, monthYear) &&
@@ -82,6 +111,14 @@ export default class MonthYearDropdownOptions extends Component<
 
         return (
           <div
+            ref={(el) => {
+              this.monthYearOptionButtonsRef[i] = el;
+              if (isSameMonthYear) {
+                el?.focus();
+              }
+            }}
+            role="button"
+            tabIndex={0}
             className={
               isSameMonthYear
                 ? "react-datepicker__month-year-option--selected_month-year"
@@ -89,6 +126,7 @@ export default class MonthYearDropdownOptions extends Component<
             }
             key={monthYearPoint}
             onClick={this.onChange.bind(this, monthYearPoint)}
+            onKeyDown={this.handleOptionKeyDown.bind(this, i, monthYearPoint)}
             aria-selected={isSameMonthYear ? "true" : undefined}
           >
             {isSameMonthYear ? (

--- a/src/test/month_year_dropdown_test.test.tsx
+++ b/src/test/month_year_dropdown_test.test.tsx
@@ -209,6 +209,128 @@ describe("MonthYearDropdown", () => {
       expect(handleChangeResult?.toString()).toBe(expected_date.toString());
     });
 
+    it("focuses the selected month year option when the dropdown opens", () => {
+      const monthYearReadView = safeQuerySelector(
+        monthYearDropdown,
+        ".react-datepicker__month-year-read-view",
+      );
+      fireEvent.click(monthYearReadView);
+
+      const selectedOption = safeQuerySelector(
+        monthYearDropdown,
+        ".react-datepicker__month-year-option--selected_month-year",
+      );
+      expect(document.activeElement).toEqual(selectedOption);
+    });
+
+    it("calls the supplied onChange function when a month year is selected using arrows and enter key", () => {
+      const monthYearReadView = safeQuerySelector(
+        monthYearDropdown,
+        ".react-datepicker__month-year-read-view",
+      );
+      fireEvent.click(monthYearReadView);
+
+      const monthYearOptions = safeQuerySelectorAll(
+        monthYearDropdown,
+        '.react-datepicker__month-year-dropdown [role="button"]',
+        12,
+      );
+
+      const selectedOption = monthYearOptions[6]!;
+      fireEvent.keyDown(selectedOption, { key: "ArrowDown" });
+
+      const nextOption = monthYearOptions[7];
+      expect(document.activeElement).toEqual(nextOption);
+
+      fireEvent.keyDown(document.activeElement!, { key: "Enter" });
+      expect(handleChangeResult?.toString()).toBe(
+        newDate("2018-02").toString(),
+      );
+    });
+
+    it("handles ArrowUp key navigation correctly", () => {
+      const monthYearReadView = safeQuerySelector(
+        monthYearDropdown,
+        ".react-datepicker__month-year-read-view",
+      );
+      fireEvent.click(monthYearReadView);
+
+      const monthYearOptions = safeQuerySelectorAll(
+        monthYearDropdown,
+        '.react-datepicker__month-year-dropdown [role="button"]',
+        12,
+      );
+
+      const selectedOption = monthYearOptions[6]!;
+      fireEvent.keyDown(selectedOption, { key: "ArrowUp" });
+
+      const prevOption = monthYearOptions[5];
+      expect(document.activeElement).toEqual(prevOption);
+    });
+
+    it("handles Escape key to cancel dropdown", () => {
+      const monthYearReadView = safeQuerySelector(
+        monthYearDropdown,
+        ".react-datepicker__month-year-read-view",
+      );
+      fireEvent.click(monthYearReadView);
+
+      const monthYearOptions = safeQuerySelectorAll(
+        monthYearDropdown,
+        '.react-datepicker__month-year-dropdown [role="button"]',
+        12,
+      );
+
+      const selectedOption = monthYearOptions[6]!;
+      fireEvent.keyDown(selectedOption, { key: "Escape" });
+
+      expect(
+        monthYearDropdown?.querySelectorAll(
+          ".react-datepicker__month-year-dropdown",
+        ),
+      ).toHaveLength(0);
+    });
+
+    it("does not move focus past the last option when pressing ArrowDown", () => {
+      const monthYearReadView = safeQuerySelector(
+        monthYearDropdown,
+        ".react-datepicker__month-year-read-view",
+      );
+      fireEvent.click(monthYearReadView);
+
+      const monthYearOptions = safeQuerySelectorAll(
+        monthYearDropdown,
+        '.react-datepicker__month-year-dropdown [role="button"]',
+        12,
+      );
+
+      const lastOption = monthYearOptions[11]!;
+      lastOption.focus();
+      fireEvent.keyDown(lastOption, { key: "ArrowDown" });
+
+      expect(document.activeElement).toEqual(lastOption);
+    });
+
+    it("does not move focus before the first option when pressing ArrowUp", () => {
+      const monthYearReadView = safeQuerySelector(
+        monthYearDropdown,
+        ".react-datepicker__month-year-read-view",
+      );
+      fireEvent.click(monthYearReadView);
+
+      const monthYearOptions = safeQuerySelectorAll(
+        monthYearDropdown,
+        '.react-datepicker__month-year-dropdown [role="button"]',
+        12,
+      );
+
+      const firstOption = monthYearOptions[0]!;
+      firstOption.focus();
+      fireEvent.keyDown(firstOption, { key: "ArrowUp" });
+
+      expect(document.activeElement).toEqual(firstOption);
+    });
+
     it("should use dateFormat to display date in dropdown", () => {
       registerLocale("fi", fi);
       let dropdownDateFormat = getMonthYearDropdown({

--- a/src/test/month_year_dropdown_test.test.tsx
+++ b/src/test/month_year_dropdown_test.test.tsx
@@ -82,6 +82,14 @@ describe("MonthYearDropdown", () => {
       );
     });
 
+    it("renders the read view as a button so it is reachable via Tab, matching MonthDropdown/YearDropdown", () => {
+      const monthYearReadView = safeQuerySelector(
+        monthYearDropdown,
+        ".react-datepicker__month-year-read-view",
+      );
+      expect(monthYearReadView.tagName).toBe("BUTTON");
+    });
+
     it("opens a list when read view is clicked", () => {
       const monthYearReadView = safeQuerySelector(
         monthYearDropdown,


### PR DESCRIPTION
## Description
Linked issue: #6311

### Problem
When `showMonthYearDropdown` is enabled:
- The read-view toggle (`MonthYearDropdown.renderReadView`) rendered as a plain `<div onClick>` instead of a `<button type="button">` like `MonthDropdown`/`YearDropdown`, so it was skipped by `Tab` and didn't respond to `Enter`/`Space`.
- Once opened, the options list (`MonthYearDropdownOptions`) rendered each option as a plain `<div>` with no `role`, `tabIndex`, `onKeyDown`, or focus management, unlike `MonthDropdownOptions`/`YearDropdownOptions`, so the list itself couldn't be navigated by keyboard even after the toggle became reachable.

### Changes
- `src/month_year_dropdown.tsx`: changed the read-view toggle from `<div>` to `<button type="button">`.
- `src/month_year_dropdown_options.tsx`: added `role="button"`, `tabIndex`, and `onKeyDown` handling (`Enter` selects, `Escape` cancels, `ArrowUp`/`ArrowDown` moves focus between options without wrapping) plus auto-focus of the selected option when the list opens — matching the existing `MonthDropdownOptions`/`YearDropdownOptions` pattern.
- `src/test/month_year_dropdown_test.test.tsx`: added regression tests covering the button read view and the new keyboard navigation/focus behavior.

## Contribution checklist
- [x] I have followed the contributing guidelines.
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.