### PR TITLE
fix: allow keyboard year selection without selected date

### DIFF
--- a/src/test/year_picker_test.test.tsx
+++ b/src/test/year_picker_test.test.tsx
@@ -910,6 +910,29 @@ describe("YearPicker", () => {
       expect(selectedDay ? getYear(selectedDay) : selectedDay).toBe(2021);
     });
 
+    it("should select a year when Enter is pressed without a selected date", () => {
+      const onDayClickMock = jest.fn();
+      const date = newDate("2024-01-01");
+      const { container } = render(
+        <Year
+          date={date}
+          preSelection={date}
+          onDayClick={onDayClickMock}
+          onYearMouseEnter={() => {}}
+          onYearMouseLeave={() => {}}
+        />,
+      );
+
+      const target = safeQuerySelector(
+        container,
+        ".react-datepicker__year-2024",
+      );
+      fireEvent.keyDown(target, getKey(KeyType.Enter));
+
+      expect(onDayClickMock).toHaveBeenCalledTimes(1);
+      expect(getYear(onDayClickMock.mock.calls[0][0])).toBe(2024);
+    });
+
     it("should call onKeyDown handler on any key press", () => {
       const onKeyDownSpy = jest.fn();
 
@@ -1039,9 +1062,7 @@ describe("YearPicker", () => {
 
       fireEvent.keyDown(currentYear, getKey(KeyType.Enter));
 
-      // When selected is null and Enter is pressed, onDayClick should not be called
-      // because of the early return at line 297
-      expect(onDayClickMock).not.toHaveBeenCalled();
+      expect(onDayClickMock).toHaveBeenCalledTimes(1);
     });
 
     it("should handle keyboard navigation with null preSelection (Arrow keys)", () => {

--- a/src/year.tsx
+++ b/src/year.tsx
@@ -292,11 +292,10 @@ export default class Year extends Component<YearProps> {
     if (!this.props.disabledKeyboardNavigation) {
       switch (key) {
         case KeyType.Enter:
-          if (this.props.selected == null) {
-            break;
-          }
           this.onYearClick(event, y);
-          this.props.setPreSelection?.(this.props.selected);
+          if (this.props.selected != null) {
+            this.props.setPreSelection?.(this.props.selected);
+          }
           break;
         case KeyType.ArrowRight:
           if (this.props.preSelection == null) {


### PR DESCRIPTION
## Description

Fixes #6298

### Problem

When `showYearPicker` is enabled without an initial `selected` date, the year cells could be clicked with the mouse but pressing Enter on a focused year did nothing. The keyboard handler returned early whenever `selected` was nullish, so keyboard-only users could not select a year.

### Changes

- Route Enter through the same year-selection handler used by mouse clicks.
- Keep the existing pre-selection update for controlled pickers that already have a selected date.
- Add regression coverage for selecting a year with Enter when no date is selected, including the DatePicker integration path.

### Verification

- `yarn test src/test/year_picker_test.test.tsx --runInBand --watchman=false`
- `yarn type-check`
- `yarn eslint src/year.tsx src/test/year_picker_test.test.tsx`
- `yarn prettier --check src/year.tsx src/test/year_picker_test.test.tsx`

## Contribution checklist

- [x] I have followed the contributing guidelines.
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
