### PR TITLE
fix: set explicit width on custom time input example

### DIFF
--- a/docs-site/src/examples/ts/customTimeInput.tsx
+++ b/docs-site/src/examples/ts/customTimeInput.tsx
@@ -19,7 +19,7 @@ const CustomTimeInput = () => {
       onClick={(e: React.MouseEvent<HTMLInputElement>) =>
         (e.target as HTMLInputElement).focus()
       }
-      style={{ border: "solid 1px pink" }}
+      style={{ border: "solid 1px pink", width: "70px" }}
     />
   );
 


### PR DESCRIPTION
## Description

**Problem**
The "Custom Time Input" docs example (`docs-site/src/examples/ts/customTimeInput.tsx`) leaves the custom `<input>` without an explicit width. It falls back to the browser's default text-input width, leaving a large empty gap next to the short `HH:MM` value.

**Changes**
Added an explicit `width: 70px` to the input's inline style so it's sized appropriately for the time value instead of relying on the browser default.

## Screenshots
**Before**
<img width="412" height="352" alt="image" src="https://github.com/user-attachments/assets/c5ee0ab6-af7d-4149-9f82-3a9faa4018a5" />

**After**
<img width="327" height="355" alt="image" src="https://github.com/user-attachments/assets/4d562174-c1c1-4ed8-b1f5-3ffa8ed3e472" />

## To reviewers
Small, isolated docs-site example fix — no changes to library source or public API.

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.