### PR TITLE
fix: allow keyboard navigation into month-picker boundary months

### DIFF
--- a/src/date_utils.ts
+++ b/src/date_utils.ts
@@ -1140,7 +1140,10 @@ export function isMonthYearDisabled(
   > = {},
 ): boolean {
   return (
-    isOutOfBounds(date, { minDate, maxDate }) ||
+    isOutOfBounds(date, {
+      minDate: minDate ? startOfMonth(minDate) : undefined,
+      maxDate: maxDate ? endOfMonth(maxDate) : undefined,
+    }) ||
     (excludeDates &&
       excludeDates.some((excludedDate) =>
         isSameMonth(

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -43,6 +43,7 @@ import {
   DEFAULT_YEAR_ITEM_NUMBER,
   isSameDay,
   isMonthDisabled,
+  isMonthYearDisabled,
   isYearDisabled,
   safeMultipleDatesFormat,
   getHolidaysMap,
@@ -1054,15 +1055,19 @@ export class DatePicker extends Component<DatePickerProps, DatePickerState> {
     }
   };
 
-  // When checking preSelection via min/maxDate, times need to be manipulated via getStartOfDay/getEndOfDay
+  // Validate pre-selection at the active picker's granularity: month or day.
   setPreSelection = (date?: Date | null): void => {
     if (this.props.readOnly) return;
     const hasMinDate = isDate(this.props.minDate);
     const hasMaxDate = isDate(this.props.maxDate);
     let isValidDateSelection = true;
     if (date) {
-      const dateStartOfDay = getStartOfDay(date);
-      if (hasMinDate && hasMaxDate) {
+      if (this.props.showMonthYearPicker) {
+        isValidDateSelection = !isMonthYearDisabled(date, {
+          minDate: this.props.minDate,
+          maxDate: this.props.maxDate,
+        });
+      } else if (hasMinDate && hasMaxDate) {
         // isDayInRange uses getStartOfDay internally, so not necessary to manipulate times here
         isValidDateSelection = isDayInRange(
           date,
@@ -1070,11 +1075,13 @@ export class DatePicker extends Component<DatePickerProps, DatePickerState> {
           this.props.maxDate,
         );
       } else if (hasMinDate) {
+        const dateStartOfDay = getStartOfDay(date);
         const minDateStartOfDay = getStartOfDay(this.props.minDate);
         isValidDateSelection =
           isAfter(date, minDateStartOfDay) ||
           isEqual(dateStartOfDay, minDateStartOfDay);
       } else if (hasMaxDate) {
+        const dateStartOfDay = getStartOfDay(date);
         const maxDateEndOfDay = getEndOfDay(this.props.maxDate);
         isValidDateSelection =
           isBefore(date, maxDateEndOfDay) ||

--- a/src/month.tsx
+++ b/src/month.tsx
@@ -11,6 +11,7 @@ import {
   getMonth,
   getMonthInLocale,
   getMonthShortInLocale,
+  getEndOfMonth,
   getQuarter,
   getQuarterShortInLocale,
   getStartOfMonth,
@@ -652,7 +653,7 @@ export default class Month extends Component<MonthProps> {
           break;
         }
         // if minDate exists and the new month is before the minimum month, it will try to find the next available month after
-        if (minDate && newCalculatedDate < minDate) {
+        if (minDate && newCalculatedDate < getStartOfMonth(minDate)) {
           eventKeyCopy = KeyType.ArrowRight;
           const obj = calculateNewDateAndMonth(
             eventKeyCopy,
@@ -664,7 +665,7 @@ export default class Month extends Component<MonthProps> {
         }
 
         // if maxDate exists and the new month is after the maximum month, it will try to find the next available month before
-        if (maxDate && newCalculatedDate > maxDate) {
+        if (maxDate && newCalculatedDate > getEndOfMonth(maxDate)) {
           eventKeyCopy = KeyType.ArrowLeft;
           const obj = calculateNewDateAndMonth(
             eventKeyCopy,

--- a/src/test/date_utils_test.test.ts
+++ b/src/test/date_utils_test.test.ts
@@ -1591,6 +1591,20 @@ describe("date_utils", () => {
       expect(isMonthYearDisabled(date, props)).toBe(true);
     });
 
+    it("should return false if date is before a mid-month min date in the same month", () => {
+      const date = new Date(2023, 2, 1);
+      expect(
+        isMonthYearDisabled(date, { minDate: new Date(2023, 2, 15) }),
+      ).toBe(false);
+    });
+
+    it("should return false if date is after a mid-month max date in the same month", () => {
+      const date = new Date(2023, 2, 31);
+      expect(
+        isMonthYearDisabled(date, { maxDate: new Date(2023, 2, 15) }),
+      ).toBe(false);
+    });
+
     it("should return false if month is not disabled", () => {
       const date = new Date(new Date(2023, 3, 1));
       expect(isMonthYearDisabled(date, props)).toBe(false);

--- a/src/test/month_test.test.tsx
+++ b/src/test/month_test.test.tsx
@@ -1881,6 +1881,52 @@ describe("Month", () => {
         );
       });
 
+      it("should pre-select March when arrowLeft navigates to a month with a mid-month min date", () => {
+        let preSelected: Date | null | undefined = null;
+        const setPreSelection = (param?: Date | null) => {
+          preSelected = param;
+        };
+        const monthComponent = renderMonth({
+          selected: newDate("2015-04-01"),
+          day: newDate("2015-04-01"),
+          setPreSelection,
+          preSelection: newDate("2015-04-01"),
+          minDate: newDate("2015-03-15"),
+        });
+
+        fireEvent.keyDown(
+          monthComponent.querySelector(".react-datepicker__month-3") as Element,
+          getKey(KeyType.ArrowLeft),
+        );
+
+        expect((preSelected! as Date).toString()).toBe(
+          newDate("2015-03-01").toString(),
+        );
+      });
+
+      it("should pre-select June when arrowRight navigates to a month with a mid-month max date", () => {
+        let preSelected: Date | null | undefined = null;
+        const setPreSelection = (param?: Date | null) => {
+          preSelected = param;
+        };
+        const monthComponent = renderMonth({
+          selected: newDate("2015-05-31"),
+          day: newDate("2015-05-31"),
+          setPreSelection,
+          preSelection: newDate("2015-05-31"),
+          maxDate: newDate("2015-06-15"),
+        });
+
+        fireEvent.keyDown(
+          monthComponent.querySelector(".react-datepicker__month-4") as Element,
+          getKey(KeyType.ArrowRight),
+        );
+
+        expect((preSelected! as Date).toString()).toBe(
+          newDate("2015-06-30").toString(),
+        );
+      });
+
       it("should trigger setPreSelection and set May as pre-selected on arrowUp", () => {
         let preSelected: Date | null | undefined = null;
         const setPreSelection = (param?: Date | null) => {

--- a/src/test/month_test.test.tsx
+++ b/src/test/month_test.test.tsx
@@ -1927,6 +1927,80 @@ describe("Month", () => {
         );
       });
 
+      it("should keep keyboard pre-selection aligned after navigating through a min-date boundary month", () => {
+        let instance: DatePicker | null = null;
+        const { container } = render(
+          <DatePicker
+            ref={(node) => {
+              instance = node;
+            }}
+            inline
+            showMonthYearPicker
+            selected={newDate("2015-02-15")}
+            minDate={newDate("2015-01-31")}
+          />,
+        );
+        const january = container.querySelector(
+          ".react-datepicker__month-0",
+        ) as HTMLElement;
+        const february = container.querySelector(
+          ".react-datepicker__month-1",
+        ) as HTMLElement;
+        const march = container.querySelector(
+          ".react-datepicker__month-2",
+        ) as HTMLElement;
+
+        february.focus();
+        fireEvent.keyDown(february, getKey(KeyType.ArrowLeft));
+        fireEvent.keyDown(january, getKey(KeyType.ArrowRight));
+        fireEvent.keyDown(february, getKey(KeyType.ArrowRight));
+
+        expect(document.activeElement).toBe(march);
+        expect(instance!.state.preSelection).toEqual(newDate("2015-03-15"));
+        expect(
+          container.querySelector(
+            ".react-datepicker__month-text--keyboard-selected",
+          ),
+        ).toBe(march);
+      });
+
+      it("should keep keyboard pre-selection aligned after navigating through a max-date boundary month", () => {
+        let instance: DatePicker | null = null;
+        const { container } = render(
+          <DatePicker
+            ref={(node) => {
+              instance = node;
+            }}
+            inline
+            showMonthYearPicker
+            selected={newDate("2015-11-15")}
+            maxDate={newDate("2015-12-01")}
+          />,
+        );
+        const october = container.querySelector(
+          ".react-datepicker__month-9",
+        ) as HTMLElement;
+        const november = container.querySelector(
+          ".react-datepicker__month-10",
+        ) as HTMLElement;
+        const december = container.querySelector(
+          ".react-datepicker__month-11",
+        ) as HTMLElement;
+
+        november.focus();
+        fireEvent.keyDown(november, getKey(KeyType.ArrowRight));
+        fireEvent.keyDown(december, getKey(KeyType.ArrowLeft));
+        fireEvent.keyDown(november, getKey(KeyType.ArrowLeft));
+
+        expect(document.activeElement).toBe(october);
+        expect(instance!.state.preSelection).toEqual(newDate("2015-10-15"));
+        expect(
+          container.querySelector(
+            ".react-datepicker__month-text--keyboard-selected",
+          ),
+        ).toBe(october);
+      });
+
       it("should trigger setPreSelection and set May as pre-selected on arrowUp", () => {
         let preSelected: Date | null | undefined = null;
         const setPreSelection = (param?: Date | null) => {


### PR DESCRIPTION
## Description
**Linked issue**: None

**Problem**
When showMonthYearPicker is used, a boundary month can be rendered as enabled and selectable but still be unreachable using arrow-key navigation when minDate or maxDate falls within that month.

For example:

- With minDate={January 31}, January is enabled because it contains a selectable date, but it cannot be reached by pressing ArrowLeft while February is selected.

- With maxDate={December 1}, December is enabled because it contains a selectable date, but it cannot be reached by pressing ArrowRight while November is selected.

This happened because month rendering and selection treated availability at month granularity, while keyboard navigation compared a day-preserving candidate against the raw date boundary. For example, navigating left from February 15 calculated January 15, which was rejected as being before minDate={January 31}. Likewise, navigating right from November 15 calculated December 15, which was rejected as being after maxDate={December 1}.

After making the boundary month reachable, another part of the same inconsistency became observable: DatePicker.setPreSelection still validated the candidate at day granularity. DOM focus could move to the boundary month while the new preSelection was rejected. Subsequent arrow-key presses then used the stale preSelection to calculate the next date, causing the keyboard highlight and focus ring to point to different months.

**Changes**
- Normalize minDate to the start of its month and maxDate to the end of its month when checking whether a month is disabled.

- Use the same month-level boundaries when calculating month-picker keyboard navigation.

- Validate preSelection at month granularity when showMonthYearPicker is enabled.

- Preserve the existing day-level preSelection validation for other picker modes.

- Add regression tests covering:
  - Mid-month minimum and maximum boundaries.
  - Keyboard navigation into both boundary months.
  - Consecutive navigation after entering a boundary month.
  - Alignment between DOM focus, preSelection, and the keyboard-selected month.



## Screenshots
The recording below compares the same keyboard interaction before and after the fix.

<img width="460" height="302" alt="before" src="https://github.com/user-attachments/assets/325239ee-ac82-4bb7-999c-a24c32a6e247" />

- Before: the enabled boundary month cannot be reached using an arrow key.

<img width="460" height="302" alt="after" src="https://github.com/user-attachments/assets/f6688c94-90de-4b28-90e3-b4dd6e5085a6" />

- After: the boundary month is reachable, and DOM focus remains aligned with the keyboard-selected month during consecutive navigation.

## To reviewers
The intended invariant is that an enabled and selectable month must also be reachable by keyboard, and the focused month must remain aligned with preSelection.

The setPreSelection change is limited to showMonthYearPicker. Day, week, quarter, and year picker validation remains unchanged. Only minDate and maxDate participate in the new month-level pre-selection check, so existing include/exclude and filtering behavior is preserved.

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
