### PR TITLE
fix: narrow react/react-dom peerDependencies to drop false React 16 claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,9 @@ We're always trying to stay compatible with the latest version of React. We can'
 
 Latest compatible versions:
 
-- React 16 or newer: React-datepicker v2.9.4 and newer
+- React 17 or newer: React-datepicker versions after v9.1.0 (React 16 is no longer supported — our
+  positioning dependency, `@floating-ui/react`, dropped React 16 support in its `0.27.0` release)
+- React 16 or newer: React-datepicker v2.9.4 up to v9.1.0
 - React 15.5: React-datepicker v2.9.3
 - React 15.4.1: needs React-datepicker v0.40.0, newer won't work (due to react-onclickoutside dependencies)
 - React 0.14 or newer: All above React-datepicker v0.13.0

--- a/docs-site/yarn.lock
+++ b/docs-site/yarn.lock
@@ -4697,8 +4697,8 @@ __metadata:
     date-fns: "npm:^4.1.0"
   peerDependencies:
     date-fns-tz: ^3.0.0
-    react: ^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc
-    react-dom: ^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc
+    react: ^17 || ^18 || ^19 || ^19.0.0-rc
+    react-dom: ^17 || ^18 || ^19 || ^19.0.0-rc
   peerDependenciesMeta:
     date-fns-tz:
       optional: true

--- a/package.json
+++ b/package.json
@@ -98,8 +98,8 @@
   },
   "peerDependencies": {
     "date-fns-tz": "^3.0.0",
-    "react": "^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc",
-    "react-dom": "^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+    "react": "^17 || ^18 || ^19 || ^19.0.0-rc",
+    "react-dom": "^17 || ^18 || ^19 || ^19.0.0-rc"
   },
   "peerDependenciesMeta": {
     "date-fns-tz": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8867,8 +8867,8 @@ __metadata:
     typescript-eslint: "npm:^8.22.0"
   peerDependencies:
     date-fns-tz: ^3.0.0
-    react: ^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc
-    react-dom: ^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc
+    react: ^17 || ^18 || ^19 || ^19.0.0-rc
+    react-dom: ^17 || ^18 || ^19 || ^19.0.0-rc
   peerDependenciesMeta:
     date-fns-tz:
       optional: true


### PR DESCRIPTION
## Description

Linked issue: #6321

### Problem

`package.json` `peerDependencies` still claim React 16 support
(`^16.9.0 || ^17 || ^18 || ^19`), but our positioning dependency, `@floating-ui/react`,
dropped React 16 support as of its `0.27.0` release — the installed
`@floating-ui/react` already declares `peerDependencies: { react: ">=17.0.0" }`. Every
React 16 install of `react-datepicker` has been getting an `npm warn` peer-dependency
error since `@floating-ui/react` was bumped past `0.27.0` in #5268, for a React version
we don't actually support end-to-end.

### Why floating-ui dropped React 16

Traced to [floating-ui/floating-ui#3103](https://github.com/floating-ui/floating-ui/pull/3103)
(purely a `peerDependencies`/changeset bump — no source changed), which closes
[floating-ui/floating-ui#3092](https://github.com/floating-ui/floating-ui/issues/3092)
(WONTFIX): on React 16, nested `FloatingPortal`s need two clicks to dismiss instead of
one. React 16 attaches synthetic event listeners to `document`; React 17+ attaches them
to the root container instead, and floating-ui's `useDismiss` + `FloatingPortal`
outside-click logic relies on the React 17+ attachment point.

### Does this bug reach react-datepicker?

No. `src/with_floating.tsx` only imports `useFloating`/`autoUpdate`/`flip`/`offset`/
`arrow` from `@floating-ui/react` — pure positioning. It never imports `useDismiss` or
`FloatingPortal`; outside-click handling here is our own `ClickOutsideWrapper`. So the
one documented React-16 regression upstream can't fire through this codebase's usage.

## Fix

Metadata-only — no runtime code changes, since the code path that could have broken was
never used:
- `package.json` — narrow `react`/`react-dom` `peerDependencies` to `^17 || ^18 || ^19 || ^19.0.0-rc`, matching `@floating-ui/react`'s own floor.
- `yarn.lock` — regenerated so the workspace metadata matches.
- `README.md` — the "Compatibility" table repeated the same stale "React 16 or newer" claim for current versions; added a line clarifying versions after v9.1.0 require React 17+.

## Note for reviewers

Narrowing a `peerDependencies` *range* is itself semver-breaking for anyone still on
React 16, even though application code is untouched — npm/pnpm peer resolution can go
from a soft warning to a hard install failure for those installs. Worth calling that out
explicitly in release notes rather than shipping it as an invisible patch (i.e. this
probably wants to land as at least a semver-minor with a changelog note, if not paired
with a major bump).

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
- [x] `yarn type-check`, `yarn eslint`, and `yarn test` (1485/1485 tests, 43/43 suites) all pass unchanged.
