### PR TITLE
fix: honor calendarStartDay when navigating with the End key

### DIFF
--- a/src/date_utils.ts
+++ b/src/date_utils.ts
@@ -681,10 +681,22 @@ export function getEndOfDay(date: Date): Date {
  * Gets the end of the week for a given date.
  *
  * @param date - The date.
+ * @param locale - The locale.
+ * @param calendarStartDay - The day the calendar starts on.
  * @returns - The end of the week.
  */
-export function getEndOfWeek(date: Date): Date {
-  return endOfWeek(date);
+export function getEndOfWeek(
+  date: Date,
+  locale?: Locale,
+  calendarStartDay?: Day,
+): Date {
+  const localeObj = locale
+    ? getLocaleObject(locale)
+    : getLocaleObject(getDefaultLocale());
+  return endOfWeek(date, {
+    locale: localeObj,
+    weekStartsOn: calendarStartDay,
+  });
 }
 
 /**

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1566,7 +1566,7 @@ export class DatePicker extends Component<DatePickerProps, DatePickerState> {
           newCalculatedDate = getStartOfWeek(date, locale, calendarStartDay);
           break;
         case KeyType.End:
-          newCalculatedDate = getEndOfWeek(date);
+          newCalculatedDate = getEndOfWeek(date, locale, calendarStartDay);
           break;
       }
       return newCalculatedDate;

--- a/src/test/date_utils_test.test.ts
+++ b/src/test/date_utils_test.test.ts
@@ -6,6 +6,7 @@ import {
   setMinutes,
 } from "date-fns";
 import { ptBR } from "date-fns/locale/pt-BR";
+import { enGB } from "date-fns/locale/en-GB";
 
 import {
   newDate,
@@ -39,6 +40,8 @@ import {
   isQuarterInRange,
   isYearInRange,
   getStartOfYear,
+  getStartOfWeek,
+  getEndOfWeek,
   getYearsPeriod,
   setDefaultLocale,
   yearsDisabledAfter,
@@ -1379,6 +1382,39 @@ describe("date_utils", () => {
     it("should return the first 2022 year week", () => {
       const first2022Day = new Date("2022-01-01");
       expect(getWeek(first2022Day)).toEqual(52);
+    });
+  });
+
+  describe("getEndOfWeek", () => {
+    // 2024-06-12 is a Wednesday
+    const wednesday = new Date("2024-06-12T12:00:00");
+
+    it("defaults to a Sunday-Saturday week", () => {
+      // end of a Sunday-start week containing Wed 2024-06-12 is Sat 2024-06-15
+      expect(getEndOfWeek(wednesday).getDate()).toBe(15);
+    });
+
+    it("respects calendarStartDay for a Monday-Sunday week (#6326)", () => {
+      // end of a Monday-start week containing Wed 2024-06-12 is Sun 2024-06-16
+      expect(getEndOfWeek(wednesday, undefined, 1).getDate()).toBe(16);
+    });
+
+    it("stays symmetric with getStartOfWeek for the same calendarStartDay", () => {
+      const start = getStartOfWeek(wednesday, undefined, 1);
+      const end = getEndOfWeek(wednesday, undefined, 1);
+      expect(start.getDate()).toBe(10); // Mon 2024-06-10
+      expect(end.getDate()).toBe(16); // Sun 2024-06-16
+    });
+
+    it("uses the week start defined by a passed locale object", () => {
+      // enGB weeks start on Monday, so the week containing Wed 2024-06-12
+      // ends on Sun 2024-06-16
+      expect(getEndOfWeek(wednesday, enGB).getDate()).toBe(16);
+    });
+
+    it("uses the week start defined by a registered locale name", () => {
+      registerLocale("en-GB", enGB);
+      expect(getEndOfWeek(wednesday, "en-GB").getDate()).toBe(16);
     });
   });
 

--- a/src/test/datepicker_test.test.tsx
+++ b/src/test/datepicker_test.test.tsx
@@ -1494,6 +1494,22 @@ describe("DatePicker", () => {
     );
   });
 
+  it("should handle onDayKeyDown End honoring calendarStartDay (#6326)", () => {
+    const data = getOnInputKeyDownStuff({
+      selected: newDate("2024-06-12"), // Wednesday
+      calendarStartDay: 1, // Monday-Sunday week
+    });
+    fireEvent.keyDown(data.dateInput, getKey(KeyType.ArrowDown));
+    const selectedDayNode = getSelectedDayNode(data.container);
+    expect(selectedDayNode).toBeTruthy();
+    fireEvent.keyDown(selectedDayNode!, getKey(KeyType.End));
+    expect(data.instance.state.preSelection).toBeTruthy();
+    // last day of a Monday-Sunday week containing Wed 2024-06-12 is Sun 2024-06-16
+    expect(formatDate(data.instance.state.preSelection!, data.testFormat)).toBe(
+      "2024-06-16",
+    );
+  });
+
   it("should handle onDayKeyDown when the minDate is null", () => {
     const data = getOnInputKeyDownStuff({ minDate: null });
     fireEvent.keyDown(data.dateInput, getKey(KeyType.ArrowDown));


### PR DESCRIPTION
## Summary

Fixes #6326.

## Problem

The calendar lets you jump to the first day of the week with the `Home` key and to the last day of the week with the `End` key. When weeks are configured to start on a day other than Sunday (for example `calendarStartDay={1}` for a Monday–Sunday week), `Home` respected that setting but `End` did not.

The cause: the `Home` handler passed `locale` and `calendarStartDay` to `getStartOfWeek`, but the `End` handler called `getEndOfWeek(date)` with no configuration, so `date-fns` fell back to its own default of a Sunday–Saturday week.

Example — with `calendarStartDay={1}`, focus on Wednesday, June 12, 2024:

| Key | Before | After |
| --- | --- | --- |
| `Home` | Mon, Jun 10 ✅ | Mon, Jun 10 ✅ |
| `End` | Sat, Jun 15 ❌ | Sun, Jun 16 ✅ |

The keyboard handler before the fix:

```tsx
case KeyType.Home:
  newCalculatedDate = getStartOfWeek(date, locale, calendarStartDay);
  break;
case KeyType.End:
  newCalculatedDate = getEndOfWeek(date); // locale + calendarStartDay dropped
  break;
```

## Changes

- `src/date_utils.ts`: `getEndOfWeek` now accepts optional `locale` and `calendarStartDay` arguments, mirroring `getStartOfWeek`, and forwards them to `date-fns` `endOfWeek` via `{ locale, weekStartsOn }`.
- `src/index.tsx`: the `End` case in the keyboard handler now calls `getEndOfWeek(date, locale, calendarStartDay)`, so `Home` and `End` compute symmetric week boundaries.
- `src/test/date_utils_test.test.ts`: new `getEndOfWeek` tests — default Sunday–Saturday week, Monday–Sunday week via `calendarStartDay`, and symmetry with `getStartOfWeek`.
- `src/test/datepicker_test.test.tsx`: new test asserting `End` moves focus to Sunday, June 16, 2024 with `calendarStartDay={1}`.

The new parameters are optional, so existing single-argument callers and tests are unaffected. `yarn test:ci` (43 suites, 1489 tests), `yarn type-check`, and `yarn eslint` all pass.

<img width="1118" height="788" alt="react date picker" src="https://github.com/user-attachments/assets/63193f3a-ff97-4658-a384-74dcf0641186" />

## Contribution checklist

- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
